### PR TITLE
Fix ros-injector CLI command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what the bug is.
 
 ```bash
 # Example:
-poetry run mosaicolabs.ros_injector ./my_bag.mcap --name "Test_Seq" ...
+poetry run mosaico.ros_injector ./my_bag.mcap --name "Test_Seq" ...
 ```
 
 ### Include logs

--- a/mosaico-sdk-py/README.md
+++ b/mosaico-sdk-py/README.md
@@ -87,15 +87,15 @@ The SDK comes with a quick-start built-in CLI tool to inject ROS bags directly i
 
 ```bash
 # Run the injector
-mosaicolabs.ros_injector ./my_bag_file.mcap \
+mosaico.ros_injector ./my_bag_file.mcap \
     --name "Sequence_001" \
     --metadata '{"location": "lab", "operator": "alice"}'
 ```
 
-The full list of options by running `mosaicolabs.ros_injector -h`:
+The full list of options by running `mosaico.ros_injector -h`:
 
 ```bash
-usage: mosaicolabs.ros_injector [-h] --name NAME [--host HOST] [--port PORT] [--topics TOPICS [TOPICS ...]] [--metadata METADATA]
+usage: mosaico.ros_injector [-h] --name NAME [--host HOST] [--port PORT] [--topics TOPICS [TOPICS ...]] [--metadata METADATA]
                                 [--ros-distro {empty,latest,ros1_noetic,ros2_dashing,ros2_eloquent,ros2_foxy,ros2_galactic,ros2_humble,ros2_iron,ros2_jazzy,ros2_kilted}]
                                 bag_path
 

--- a/mosaico-sdk-py/doc-md/ros_bridge.md
+++ b/mosaico-sdk-py/doc-md/ros_bridge.md
@@ -110,10 +110,10 @@ mosaico-ros-injector ./data.db3 \
   --ros-distro ros2_humble
 ```
 
-The full list of options can be retrieved by running `mosaicolabs.ros_injector -h`:
+The full list of options can be retrieved by running `mosaico.ros_injector -h`:
 
 ```bash
-usage: mosaicolabs.ros_injector [-h] --name NAME [--host HOST] [--port PORT] [--topics TOPICS [TOPICS ...]] [--metadata METADATA]
+usage: mosaico.ros_injector [-h] --name NAME [--host HOST] [--port PORT] [--topics TOPICS [TOPICS ...]] [--metadata METADATA]
                                 [--ros-distro {empty,latest,ros1_noetic,ros2_dashing,ros2_eloquent,ros2_foxy,ros2_galactic,ros2_humble,ros2_iron,ros2_jazzy,ros2_kilted}]
                                 bag_path
 

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
@@ -13,7 +13,7 @@ It handles the complex orchestration of:
 4.  **Configuration:** Managing custom message definitions via `ROSTypeRegistry`.
 
 Typical usage as a script:
-    $ mosaicolabs.ros_injector ./data.mcap --name "Test_Run_01" --topics /camera/image_raw
+    $ mosaico.ros_injector ./data.mcap --name "Test_Run_01"
 
 Typical usage as a library:
     config = ROSInjectionConfig(file_path=Path("data.mcap"), ...)


### PR DESCRIPTION
This commit fixes the ros-injector CLI command, after updates in the pyproject.toml installation file.
No other changes are included in this PR.