### PR TITLE
Improved testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,13 @@ The SDK handles serialization, ROS bridging, and client communication. We use **
 - Use strict Python type hints. This is critical for our Ontology and `Serializable` models.
 - When modifying `SequenceDataStreamer` or `TopicDataStreamer`, preserve the **batching strategy**. Do not load full sequences into RAM.
 - Use `rosbags` for parsing. If adding custom message support, use the `ROSTypeRegistry`.
-  
+
+### Tests
+
+Make many tests.
+
+Tests can be executed using the `scripts/test_suite.sh` script. Be aware that integration tests are configured to run on a non-default port (`6276`) in order to avoid writes on a live instance of the backend.
+
 #### Prerequisites**
 
   * **Python:** version 3.13 or newer.

--- a/docker/quick_start/compose.yml
+++ b/docker/quick_start/compose.yml
@@ -1,36 +1,47 @@
 name: "mosaico-quick-start"
 services:
-  db:
+  qs-pg:
     image: postgres:16
-    container_name: db-mosaico 
+    container_name: pg
+    hostname: db
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
       POSTGRES_DB: mosaico
+    networks:
+      - mosaico-qs
     ports:
       - "5432:5432"
     volumes:
-      - mosaico_db_data:/var/lib/postgresql/data
+      - mosaico-qs-pg-data:/var/lib/postgresql/data
     healthcheck: # Ensure the DB is ready for the compilation step
       test: ["CMD-SHELL", "pg_isready -U  postgres"]
       interval: 5s
       timeout: 5s
       retries: 5
 
-  mosaicod:
+  qs-mosaicod:
     build:
       context: ../../mosaicod
       dockerfile: ../docker/quick_start/Dockerfile.mosaicod
+    image: mosaicolabs/mosaicod
+    container_name: mosaicod
+    networks:
+      - mosaico-qs
     environment:
       MOSAICO_REPOSITORY_DB_URL: postgresql://postgres:password@db:5432/mosaico
       RUST_LOG: mosaico=trace
     command: |
       run --host --local-store /store
     depends_on:
-      db:
+      qs-pg:
         condition: service_healthy
     ports:
       - "6726:6726"
 
 volumes:
-  mosaico_db_data:
+  mosaico-qs-pg-data:
+
+networks:
+  mosaico-qs:
+    name: mosaico-qs

--- a/docker/testing/compose.yml
+++ b/docker/testing/compose.yml
@@ -1,8 +1,7 @@
 name: "mosaico-testing"
 services:
-  database:
+  mosaico-pg-testing:
     image: postgres:16
-    container_name: db-testing
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
@@ -10,9 +9,16 @@ services:
     ports:
       - "6543:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - mosaico-testing-pg-data:/var/lib/postgresql/data
+    networks:
+      - mosaico-testing
 
 
 volumes:
-  postgres_data:
+  mosaico-testing-pg-data:
+
+networks:
+  mosaico-testing:
+    name: mosaico-testing
+
 

--- a/mosaico-sdk-py/src/testing/integration/config.py
+++ b/mosaico-sdk-py/src/testing/integration/config.py
@@ -2,6 +2,7 @@ import logging as log
 from mosaicolabs.models.sensors import IMU, GPS, Image
 
 TESTS_HOST = "127.0.0.1"
+TESTS_PORT = 6276
 log.basicConfig(level=log.DEBUG, format="%(levelname)s - %(message)s")
 
 

--- a/mosaico-sdk-py/src/testing/integration/conftest.py
+++ b/mosaico-sdk-py/src/testing/integration/conftest.py
@@ -12,6 +12,7 @@ from testing.integration.helpers import (
 )
 from .config import (
     TESTS_HOST,
+    TESTS_PORT,
     UPLOADED_SEQUENCE_METADATA,
     UPLOADED_SEQUENCE_NAME,
     QUERY_SEQUENCES_MOCKUP,
@@ -21,7 +22,7 @@ from .config import (
 @pytest.fixture(scope="function")
 def _client():
     """Open a client connection FOR EACH function using this fixture"""
-    return MosaicoClient.connect(host=TESTS_HOST, port=6726)
+    return MosaicoClient.connect(host=TESTS_HOST, port=TESTS_PORT)
 
 
 @pytest.fixture(
@@ -29,7 +30,7 @@ def _client():
 )  # the first who calls this function, wins and avoid this is called multiple times
 def _make_sequence_data_stream():
     """Generate synthetic data, create a sequence and pushes messages"""
-    _client = MosaicoClient.connect(host=TESTS_HOST, port=6726)
+    _client = MosaicoClient.connect(host=TESTS_HOST, port=TESTS_PORT)
     out_stream: List[DataStreamItem] = []
 
     start_time_sec = 1700000000
@@ -74,7 +75,7 @@ def _make_sequence_data_stream():
 @pytest.fixture(scope="session")
 def _inject_sequence_data_stream(_make_sequence_data_stream):
     """Generate synthetic data, create a sequence and pushes messages"""
-    _client = MosaicoClient.connect(host=TESTS_HOST, port=6726)
+    _client = MosaicoClient.connect(host=TESTS_HOST, port=TESTS_PORT)
 
     with _client.sequence_create(
         sequence_name=UPLOADED_SEQUENCE_NAME,
@@ -102,7 +103,7 @@ def _inject_sequence_data_stream(_make_sequence_data_stream):
 @pytest.fixture(scope="session")
 def _query_sequences_mockup():
     """Generate synthetic data, create a sequence and pushes messages"""
-    _client = MosaicoClient.connect(host=TESTS_HOST, port=6726)
+    _client = MosaicoClient.connect(host=TESTS_HOST, port=TESTS_PORT)
     for sname, sdata in QUERY_SEQUENCES_MOCKUP.items():
         # TODO: delete before production: make development easier when debugging tests
         log.warning(

--- a/mosaicod/src/main.rs
+++ b/mosaicod/src/main.rs
@@ -58,7 +58,7 @@ fn load_env_variables() -> Result<Variables, Box<dyn std::error::Error>> {
     let vars = Variables { repository_db_url };
 
     debug!("{:#?}", params::configurables());
-    // debug!("{:#?}", vars);
+    debug!("{:#?}", vars);
 
     Ok(vars)
 }
@@ -99,7 +99,7 @@ fn run(startup_time: &Instant) -> Result<(), Box<dyn std::error::Error>> {
                 args.port,
                 store,
                 repo::Config {
-                    db_url: vars.repository_db_url,
+                    db_url: vars.repository_db_url.clone(),
                 },
             );
 

--- a/scripts/test_suite.sh
+++ b/scripts/test_suite.sh
@@ -38,7 +38,6 @@ export RUST_BACKTRACE
 export TERM
 
 
-
 COLS=$(tput cols || echo 80 )
 if (( "$COLS" < 70 )); then
     COLS=70
@@ -102,7 +101,6 @@ title "running test suite" "#" ${GREEN}
 title "setup" "-"
 cd ${DOCKER_PATH}
 title "docker" "." ${BLUE}
-docker compose up -d --wait 2> /dev/null
 cd ${PYTHON_SDK_PATH}
 title "poetry" "." ${BLUE}
 poetry install
@@ -120,7 +118,7 @@ title "integration tests" "-"
 cd ${MOSAICOD_PATH}
 title "mosaicod build" "." ${BLUE}
 cargo build
-./target/debug/mosaicod run --local-store "${TEST_DIRECTORY}" > ${MOSAICOD_OUTPUT} 2>&1 &
+./target/debug/mosaicod run --port 6276 --local-store "${TEST_DIRECTORY}" > "${MOSAICOD_OUTPUT}" 2>&1 &
 MOSAICOD_PID=$!
 title "mosaicod startup" "." ${BLUE}
 echo "starting mosaicod as background service (pid ${MOSAICOD_PID}), output can be found in ${BOLD}${MOSAICOD_OUTPUT}${RESET}"


### PR DESCRIPTION
Integration tests now run on port 6276 to avoid conflicts with live backend instances. 

Docker Compose files for quick start and testing have been refactored for clearer service naming, custom networks, and volume names. 

Python integration test configuration and fixtures now use the new port. 

Minor improvements and cleanups were made to the test suite script and Rust main file for better debugging and configuration handling.