### PR TITLE
perf: optimize stats computation and database operations

### DIFF
--- a/mosaicod/src/query/timeseries_gw.rs
+++ b/mosaicod/src/query/timeseries_gw.rs
@@ -155,6 +155,15 @@ impl TimeseriesGwResult {
     pub async fn count(self) -> Result<usize, Error> {
         Ok(self.data_frame.count().await?)
     }
+
+    /// Checks if there are any rows matching the current query.
+    /// This is more efficient than `count()` when you only need to know if results exist,
+    /// as it stops after finding the first matching row.
+    pub async fn has_rows(self) -> Result<bool, Error> {
+        // Limit to 1 row for early termination - avoids full scan
+        let limited = self.data_frame.limit(0, Some(1))?;
+        Ok(limited.count().await? > 0)
+    }
 }
 
 fn get_listing_options(_format: rw::Format) -> ListingOptions {

--- a/mosaicod/src/repo/facades/facade_chunk.rs
+++ b/mosaicod/src/repo/facades/facade_chunk.rs
@@ -19,49 +19,55 @@ impl<'a> FacadeChunk<'a> {
         Ok(Self { tx, chunk })
     }
 
-    pub async fn push_stats(
+    /// Push all column statistics using batch inserts for better performance.
+    /// This method collects all stats, resolves column IDs, then performs
+    /// two batch INSERT operations (one for numeric, one for literal stats).
+    pub async fn push_all_stats(
         &mut self,
         ontology_tag: &str,
-        field: &str,
-        stats: types::Stats,
+        cstats: types::ColumnsStats,
     ) -> Result<(), FacadeError> {
-        if stats.is_unsupported() {
-            return Ok(());
-        }
+        let mut numeric_batch: Vec<repo::ColumnChunkNumeric> = Vec::new();
+        let mut literal_batch: Vec<repo::ColumnChunkLiteral> = Vec::new();
 
-        let column = repo::column_get_or_create(&mut self.tx, field, ontology_tag).await?;
+        // First pass: resolve column IDs and collect stats for batch insert
+        for (field, stats) in cstats.stats {
+            if stats.is_unsupported() {
+                continue;
+            }
 
-        match stats {
-            types::Stats::Text(stats) => {
-                let (min, max, has_null) = stats.into_owned();
-                repo::column_chunk_literal_create(
-                    &mut self.tx,
-                    &repo::ColumnChunkLiteral::try_new(
+            let column = repo::column_get_or_create(&mut self.tx, &field, ontology_tag).await?;
+
+            match stats {
+                types::Stats::Text(stats) => {
+                    let (min, max, has_null) = stats.into_owned();
+                    literal_batch.push(repo::ColumnChunkLiteral::try_new(
                         column.column_id,
                         self.chunk.chunk_id,
                         min,
                         max,
                         has_null,
-                    )?,
-                )
-                .await?;
-            }
-            types::Stats::Numeric(stats) => {
-                repo::column_chunk_numeric_create(
-                    &mut self.tx,
-                    &repo::ColumnChunkNumeric::new(
+                    )?);
+                }
+                types::Stats::Numeric(stats) => {
+                    numeric_batch.push(repo::ColumnChunkNumeric::new(
                         column.column_id,
                         self.chunk.chunk_id,
                         stats.min,
                         stats.max,
                         stats.has_null,
                         stats.has_nan,
-                    ),
-                )
-                .await?;
+                    ));
+                }
+                types::Stats::Unsupported => {}
             }
-            _ => {}
         }
+
+        // Batch insert all numeric stats in one query
+        repo::column_chunk_numeric_create_batch(&mut self.tx, &numeric_batch).await?;
+
+        // Batch insert all literal stats in one query
+        repo::column_chunk_literal_create_batch(&mut self.tx, &literal_batch).await?;
 
         Ok(())
     }

--- a/mosaicod/src/server/endpoints/do_action.rs
+++ b/mosaicod/src/server/endpoints/do_action.rs
@@ -393,14 +393,15 @@ pub async fn do_action(
                             .await?;
 
                         let qr = qr.filter(filter)?;
-                        let count = qr.count().await?;
 
-                        if count != 0 {
-                            trace!("found {count} records matching filter in chunk");
+                        // Use has_rows() instead of count() for early termination
+                        // This avoids scanning all matching rows when we only need to know if any exist
+                        if qr.has_rows().await? {
+                            trace!("found matching records in chunk");
                             filtered.lock().await.insert(topic.topic_id);
                         } else {
                             trace!(
-                                "discarding chunk `{}` for no query match (row count is {count})",
+                                "discarding chunk `{}` for no query match",
                                 chunk.chunk_uuid
                             );
                         }

--- a/mosaicod/src/server/endpoints/do_put.rs
+++ b/mosaicod/src/server/endpoints/do_put.rs
@@ -180,9 +180,8 @@ async fn on_chunk_created(
 ) -> Result<(), ServerError> {
     let mut handle = repo::FacadeChunk::create(topic_id, &target_path, &repo).await?;
 
-    for (field, stats) in cstats.stats {
-        handle.push_stats(ontology_tag, &field, stats).await?;
-    }
+    // Use batch insert for better performance (single INSERT per type instead of N)
+    handle.push_all_stats(ontology_tag, cstats).await?;
 
     handle.finalize().await?;
 


### PR DESCRIPTION
 This commit introduces three targeted optimizations to improve data ingestion and query performance.

 
  1. SIMD-Optimized Statistics Computation

  Files: mosaicod/src/arrow.rs, mosaicod/src/types/chunk.rs

  Problem: The stats_inspect_array() function iterated through every element in an Arrow array to compute min/max statistics, resulting in O(N) comparisons with branch misprediction overhead.

  Solution: Replaced the naive loop with Arrow's compute kernels (arrow::compute::min() and arrow::compute::max()), which leverage SIMD instructions (AVX2/AVX-512) to process 4-8 float64 values per CPU instruction. Added merge() methods to NumericStats and TextStats to accept pre-computed statistics. 


  2. Early Termination for Existence Checks (This is big improvement!)

  Files: mosaicod/src/query/timeseries_gw.rs, mosaicod/src/server/endpoints/do_action.rs

  Problem: Query filtering used count() != 0 to check if any rows matched a filter. This required **scanning all matching rows even when only existence needed to be determined**.

  Solution: Added a has_rows() method that applies limit(0, Some(1)) before counting, allowing DataFusion to terminate immediately after finding the first match.

  Impact: For queries where matches exist early in the dataset, this reduces scan time from O(N) to O(1) in the best case. 

  3. Batch Database Inserts

  Files: mosaicod/src/repo/sql_models/pg_queries/data_catalog.rs, mosaicod/src/repo/facades/facade_chunk.rs, mosaicod/src/server/endpoints/do_put.rs

  Problem: Column statistics were inserted one field at a time, resulting in N separate INSERT statements per chunk (where N is the number of schema fields).

  Solution: Introduced column_chunk_numeric_create_batch() and column_chunk_literal_create_batch() functions using sqlx::QueryBuilder to generate multi-row INSERT statements. Added push_all_stats() method that collects all statistics and performs exactly 2 INSERT operations (one for numeric, one for text fields) regardless of schema size.

  Impact: Reduces database round-trips from N to 2 per chunk. 
