### PR TITLE
Add restricted-query support using QueryResponse (tests & docs)

### DIFF
--- a/mosaico-sdk-py/src/mosaicolabs/comm/do_action.py
+++ b/mosaico-sdk-py/src/mosaicolabs/comm/do_action.py
@@ -18,7 +18,7 @@ import datetime
 import logging as log
 import pyarrow.flight as fl
 from ..enum import FlightAction
-from ..models.query import QueryResponseItem
+from ..models.query import QueryResponseItem, QueryResponse
 
 # Generic TypeVar allowing _do_action to return the specific subclass requested
 T_DoActionResponse = TypeVar("T_DoActionResponse", bound="_DoActionResponse")
@@ -211,14 +211,16 @@ class _DoActionQueryResponse(_DoActionResponse):
     """Response containing the result of a query to data platform"""
 
     actions: ClassVar[list[FlightAction]] = [FlightAction.QUERY]
-    items: list[QueryResponseItem]
+    query_response: QueryResponse
 
-    def __init__(self, items: list) -> None:
-        self.items = items
+    def __init__(self, qresp: QueryResponse) -> None:
+        self.query_response = qresp
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "_DoActionQueryResponse":
         if data.get("items") is None:
             raise KeyError("Unable to find 'items' key in data dict.")
-        items = [QueryResponseItem(**item) for item in data["items"]]
-        return _DoActionQueryResponse(items=items)
+        qresp = QueryResponse(
+            items=[QueryResponseItem(**item) for item in data["items"]]
+        )
+        return _DoActionQueryResponse(qresp=qresp)

--- a/mosaico-sdk-py/src/mosaicolabs/comm/mosaico_client.py
+++ b/mosaico-sdk-py/src/mosaicolabs/comm/mosaico_client.py
@@ -8,11 +8,11 @@ creating resource handlers (sequences, topics) and executing queries.
 """
 
 import os
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, Optional, Type
 import logging as log
 import pyarrow.flight as fl
 
-from mosaicolabs.models.query import Query, QueryResponseItem
+from mosaicolabs.models.query import Query, QueryResponse
 from mosaicolabs.models.query.protocols import QueryableProtocol
 
 from ..helpers import pack_topic_resource_name
@@ -338,8 +338,10 @@ class MosaicoClient:
             log.error(f"Server error while asking for Sequence deletion, {e}")
 
     def query(
-        self, *queries: QueryableProtocol, query: Optional[Query] = None
-    ) -> Optional[List[QueryResponseItem]]:
+        self,
+        *queries: QueryableProtocol,
+        query: Optional[Query] = None,
+    ) -> Optional[QueryResponse]:
         """
         Executes one or more queries against the Mosaico database.
         The provided queries are joined in AND condition.
@@ -390,7 +392,7 @@ class MosaicoClient:
             log.error(f"Action '{FlightAction.QUERY}' returned no response.")
             return None
 
-        return act_resp.items
+        return act_resp.query_response
 
     def close(self):
         """

--- a/mosaico-sdk-py/src/mosaicolabs/models/query/__init__.py
+++ b/mosaico-sdk-py/src/mosaicolabs/models/query/__init__.py
@@ -7,4 +7,5 @@ from .builders import (
 
 from .response import (
     QueryResponseItem as QueryResponseItem,
+    QueryResponse as QueryResponse,
 )

--- a/mosaico-sdk-py/src/mosaicolabs/models/query/builders.py
+++ b/mosaico-sdk-py/src/mosaicolabs/models/query/builders.py
@@ -281,7 +281,7 @@ class QueryTopic:
         .with_expression(Topic.Q.user_metadata["firmware.version"].eq("v0.1.2"))
 
         Args:
-            expr: A _QueryTopicExpression, e.g., Topic.Q.name.eq("...").
+            expr: A _QueryTopicExpression, Topic.Q.user_metadata["key"].eq("...").
 
         Returns:
             The QueryTopic instance for method chaining.
@@ -460,7 +460,7 @@ class QuerySequence:
         Adds a new expression to the query (fluent interface).
 
         Args:
-            expr: A _QuerySequenceExpression, e.g., Sequence.Q.name.eq("...").
+            expr: A _QuerySequenceExpression, e.g., Sequence.Q.user_metadata["key"].eq("...").
 
         Returns:
             The QuerySequence instance for method chaining.

--- a/mosaico-sdk-py/src/testing/integration/config.py
+++ b/mosaico-sdk-py/src/testing/integration/config.py
@@ -1,7 +1,4 @@
-import logging as log
 from mosaicolabs.models.sensors import IMU, GPS, Image
-
-log.basicConfig(level=log.DEBUG, format="%(levelname)s - %(message)s")
 
 
 # ----- Sequence setup ----
@@ -9,7 +6,7 @@ log.basicConfig(level=log.DEBUG, format="%(levelname)s - %(message)s")
 UPLOADED_SEQUENCE_NAME = "test-sequence-datastream"
 UPLOADED_SEQUENCE_METADATA = {
     "status": "processed",
-    "visibility": "private",
+    "visibility": "team-01",
     # --- Acquisition metadata ---
     "location": {
         "city": "Milan",
@@ -180,7 +177,7 @@ UPLOADED_MAGNETOMETER_METADATA = {
 QUERY_SEQUENCES_MOCKUP = {
     "test-query-sequence-1": {
         "topics": [
-            {"name": "/topic11", "metadata": {}, "ontology_type": IMU},
+            {"name": "/topic11", "metadata": {}, "ontology_type": Image},
             {"name": "/topic12", "metadata": {}, "ontology_type": GPS},
         ],
         "metadata": {

--- a/mosaico-sdk-py/src/testing/integration/test_failures.py
+++ b/mosaico-sdk-py/src/testing/integration/test_failures.py
@@ -96,4 +96,5 @@ def test_topic_push_not_serializable(_client: MosaicoClient):
         tw = sw.topic_create("test-topic-registered", {}, NotSerializable)  # type: ignore (disable pylance complaining)
         assert tw is None
 
+    # free resources
     _client.close()

--- a/mosaico-sdk-py/src/testing/integration/test_query_catalog.py
+++ b/mosaico-sdk-py/src/testing/integration/test_query_catalog.py
@@ -36,8 +36,8 @@ def test_query_ontology(
     ]
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
-    assert all([t for t in query_resp[0].topics if t in expected_topic_names])
-    assert all([t for t in expected_topic_names if t in query_resp[0].topics])
+    assert all([t in expected_topic_names for t in query_resp[0].topics])
+    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # Query by multiple condition: time and value
     tstamp = Time.from_float(1700000000.26)
@@ -59,8 +59,8 @@ def test_query_ontology(
     ]
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
-    assert all([t for t in query_resp[0].topics if t in expected_topic_names])
-    assert all([t for t in expected_topic_names if t in query_resp[0].topics])
+    assert all([t in expected_topic_names for t in query_resp[0].topics])
+    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # Query by multiple condition: time and value (GPS)
     tstamp = Time.from_float(1700000000.26)
@@ -81,6 +81,9 @@ def test_query_ontology(
 
     _validate_returned_topic_name(query_resp[0].topics[0])
     assert query_resp[0].topics[0] == expected_topic_name
+
+    # free resources
+    _client.close()
 
 
 def test_query_ontology_between(
@@ -106,8 +109,8 @@ def test_query_ontology_between(
     ]
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
-    assert all([t for t in query_resp[0].topics if t in expected_topic_names])
-    assert all([t for t in expected_topic_names if t in query_resp[0].topics])
+    assert all([t in expected_topic_names for t in query_resp[0].topics])
+    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # Query by mixed conditions
     query_resp = _client.query(
@@ -128,8 +131,11 @@ def test_query_ontology_between(
     ]
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
-    assert all([t for t in query_resp[0].topics if t in expected_topic_names])
-    assert all([t for t in expected_topic_names if t in query_resp[0].topics])
+    assert all([t in expected_topic_names for t in query_resp[0].topics])
+    assert all([t in query_resp[0].topics for t in expected_topic_names])
+
+    # free resources
+    _client.close()
 
 
 def test_mixed_query_ontology(
@@ -177,6 +183,9 @@ def test_mixed_query_ontology(
     _validate_returned_topic_name(query_resp[0].topics[0])
     assert query_resp[0].topics[0] == expected_topic_name
 
+    # free resources
+    _client.close()
+
 
 def test_mixed_query_no_return(
     _client: MosaicoClient,
@@ -195,6 +204,9 @@ def test_mixed_query_no_return(
     # One (1) sequence corresponds to this query
     assert len(query_resp) == 0
 
+    # free resources
+    _client.close()
+
 
 def test_fail_query_multi_tag_ontology(
     _client: MosaicoClient,
@@ -206,3 +218,6 @@ def test_fail_query_multi_tag_ontology(
             .with_expression(IMU.Q.header.stamp.sec.eq(0))
             .with_expression(Image.Q.format.eq("png"))
         )
+
+    # free resources
+    _client.close()

--- a/mosaico-sdk-py/src/testing/integration/test_query_mockup.py
+++ b/mosaico-sdk-py/src/testing/integration/test_query_mockup.py
@@ -30,8 +30,8 @@ def test_query_mockup_sequence_by_name(
     expected_topic_names = [topic for topic in expected_topic_names]
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
-    assert all([t for t in query_resp[0].topics if t in expected_topic_names])
-    assert all([t for t in expected_topic_names if t in query_resp[0].topics])
+    assert all([t in expected_topic_names for t in query_resp[0].topics])
+    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # Query by partial name
     n_char = int(len(sequence_name) / 2)  # half the length
@@ -51,8 +51,8 @@ def test_query_mockup_sequence_by_name(
         expected_topic_names = [topic for topic in expected_topic_names]
         # all the expected topics, and only them
         [_validate_returned_topic_name(topic) for topic in item.topics]
-        assert all([t for t in item.topics if t in expected_topic_names])
-        assert all([t for t in expected_topic_names if t in item.topics])
+        assert all([t in expected_topic_names for t in item.topics])
+        assert all([t in item.topics for t in expected_topic_names])
 
     # Query by partial name: startswith
     n_char = int(len(sequence_name) / 2)  # half the length
@@ -74,8 +74,8 @@ def test_query_mockup_sequence_by_name(
         expected_topic_names = [topic for topic in expected_topic_names]
         # all the expected topics, and only them
         [_validate_returned_topic_name(topic) for topic in item.topics]
-        assert all([t for t in item.topics if t in expected_topic_names])
-        assert all([t for t in expected_topic_names if t in item.topics])
+        assert all([t in expected_topic_names for t in item.topics])
+        assert all([t in item.topics for t in expected_topic_names])
 
     # Query by partial name: endswith
     n_char = int(len(sequence_name) / 2)  # half the length
@@ -97,8 +97,11 @@ def test_query_mockup_sequence_by_name(
         expected_topic_names = [topic for topic in expected_topic_names]
         # all the expected topics, and only them
         [_validate_returned_topic_name(topic) for topic in item.topics]
-        assert all([t for t in item.topics if t in expected_topic_names])
-        assert all([t for t in expected_topic_names if t in item.topics])
+        assert all([t in expected_topic_names for t in item.topics])
+        assert all([t in item.topics for t in expected_topic_names])
+
+    # free resources
+    _client.close()
 
 
 def test_query_mockup_sequence_metadata(
@@ -128,8 +131,8 @@ def test_query_mockup_sequence_metadata(
     expected_topic_names = [topic for topic in expected_topic_names]
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
-    assert all([t for t in query_resp[0].topics if t in expected_topic_names])
-    assert all([t for t in expected_topic_names if t in query_resp[0].topics])
+    assert all([t in expected_topic_names for t in query_resp[0].topics])
+    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # Test 2: with None return
     query_resp = _client.query(
@@ -140,3 +143,110 @@ def test_query_mockup_sequence_metadata(
 
     assert query_resp is not None
     assert len(query_resp) == 0
+
+    # free resources
+    _client.close()
+
+
+def test_query_sequence_from_response(
+    _client: MosaicoClient,
+    _inject_sequences_mockup,  # Ensure the data are available on the data platform
+):
+    visibility_val = "private"
+    query_resp = _client.query(
+        QuerySequence().with_expression(
+            Sequence.Q.user_metadata["visibility"].eq(visibility_val)
+        )
+    )
+    # We do expect a successful query
+    assert query_resp is not None
+    # The other criteria have been tested above...
+    expected_sequence_names = [
+        key
+        for key, val in QUERY_SEQUENCES_MOCKUP.items()
+        if val.get("metadata", {}).get("visibility") == visibility_val
+    ]
+    assert len(query_resp) == len(expected_sequence_names)
+    assert all(
+        [it.sequence for it in query_resp if it.sequence in expected_sequence_names]
+    )
+    assert all(
+        [s for s in expected_sequence_names if s in [it.sequence for it in query_resp]]
+    )
+    # This translates to:
+    # 'query among the sequences in the returned response'
+    qsequence = query_resp.to_query_sequence()
+    # simply reprovide the same query to the client
+    query_resp = _client.query(qsequence)
+    # One (1) sequence corresponds to this query
+    assert query_resp is not None
+    assert len(query_resp) == len(expected_sequence_names)
+    assert all(
+        [it.sequence for it in query_resp if it.sequence in expected_sequence_names]
+    )
+    assert all(
+        [s for s in expected_sequence_names if s in [it.sequence for it in query_resp]]
+    )
+    # The other criteria have been tested above...
+
+    # free resources
+    _client.close()
+
+
+def test_query_topic_from_response(
+    _client: MosaicoClient,
+    _inject_sequences_mockup,  # Ensure the data are available on the data platform
+):
+    visibility_val = "private"
+    query_resp = _client.query(
+        QuerySequence().with_expression(
+            Sequence.Q.user_metadata["visibility"].eq(visibility_val)
+        )
+    )
+    # We do expect a successful query
+    assert query_resp is not None
+    # The other criteria have been tested above...
+    expected_sequence_names = [
+        key
+        for key, val in QUERY_SEQUENCES_MOCKUP.items()
+        if val.get("metadata", {}).get("visibility") == visibility_val
+    ]
+    assert len(query_resp) == len(expected_sequence_names)
+    assert all(
+        [it.sequence for it in query_resp if it.sequence in expected_sequence_names]
+    )
+    assert all(
+        [s for s in expected_sequence_names if s in [it.sequence for it in query_resp]]
+    )
+    # This translates to:
+    # 'query among the topics in the returned response'
+    qtopic = query_resp.to_query_topic()
+    # simply reprovide the same query to the client
+    query_resp = _client.query(qtopic)
+    # One (1) sequence corresponds to this query
+    assert query_resp is not None
+    assert len(query_resp) == len(expected_sequence_names)
+    assert all(
+        [it.sequence for it in query_resp if it.sequence in expected_sequence_names]
+    )
+    assert all(
+        [s for s in expected_sequence_names if s in [it.sequence for it in query_resp]]
+    )
+    # The other criteria have been tested above...
+
+    # Try restricting further the query...
+    # get the first available ontology tag
+    ontology_tag = "image"
+    query_resp = _client.query(qtopic.with_ontology_tag(ontology_tag))
+    # One (1) sequence corresponds to this query
+    assert query_resp is not None
+
+    expected_sequence_name = "test-query-sequence-1"
+    expected_topic_name = "/topic11"
+    assert len(query_resp) == 1
+    assert query_resp[0].sequence == expected_sequence_name
+    assert len(query_resp[0].topics) == 1
+    assert query_resp[0].topics[0] == expected_topic_name
+
+    # free resources
+    _client.close()

--- a/mosaico-sdk-py/src/testing/unit/query/test_query_metadata.py
+++ b/mosaico-sdk-py/src/testing/unit/query/test_query_metadata.py
@@ -26,6 +26,8 @@ class TestQueryTopicMetadataAPI:
         Topic.Q.user_metadata["something"]
 
         with pytest.raises(AttributeError):
+            Topic.Q.name  # name is not queryable
+        with pytest.raises(AttributeError):
             Topic.Q.user_metadata.something  # user_metadata is not dot-accessible
 
     def test_field_queryable_inheritance(self):
@@ -97,6 +99,8 @@ class TestQuerySequenceMetadataAPI:
         Sequence.Q.user_metadata
         Sequence.Q.user_metadata["something"]
 
+        with pytest.raises(AttributeError):
+            Sequence.Q.name  # name is not queryable
         with pytest.raises(AttributeError):
             Sequence.Q.user_metadata.something  # user_metadata is not dot-accessible
 


### PR DESCRIPTION
Add "restricted query" support so a query can be sent using a previous query response while restricting expressions to sequences/topics present in that response.

- **What changed:**
  - **New type:** `QueryResponse` container for `QueryResponseItem`.
  - **API return type:** `_DoActionQueryResponse` now returns `QueryResponse` instead of `List[QueryResponseItem]` (backwards-compatible: `QueryResponse` implements `__len__` and `__iter__`).
  - **Tests:** added unit and integration tests validating the restricted-query logic and fixed several trivial test assertions.
  - **Base-type tests:** added unit tests for base data types query construction (`TestQueryBaseTypesAPI` in `test_query_data.py`).
  - **Docs:** updated documentation to reflect the new behavior.

- **Impact:** No breaking API changes for callers (behavior is preserved via `QueryResponse` iteration); increases test coverage and documents the restricted-query flow.