### PR TITLE
Fixed bug #22: Refactor CompressedImage Codecs & Introduce StatefulDecodingSession

### DIFF
--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/sensor_msgs.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/sensor_msgs.py
@@ -439,7 +439,7 @@ class ImageAdapter(ROSAdapterBase[Image]):
         """
         _validate_msgdata(cls, ros_data)
 
-        return Image.encode(
+        return Image.from_linear_pixels(
             header=_make_header(ros_data.get("header")),
             data=ros_data["data"],
             # if .get is None, the encode function will use a default format internally

--- a/mosaico-sdk-py/src/testing/unit/conversion/test_image.py
+++ b/mosaico-sdk-py/src/testing/unit/conversion/test_image.py
@@ -68,7 +68,7 @@ def test_image_round_trip_integrity(format, encoding):
 
     log.debug("encoding test img data")
     # Encode (Compress)
-    img_obj = Image.encode(
+    img_obj = Image.from_linear_pixels(
         data=original_bytes,
         stride=stride,
         height=height,
@@ -89,7 +89,7 @@ def test_image_round_trip_integrity(format, encoding):
         assert img_obj.data.startswith(b"\x89PNG"), "Data is not a valid PNG blob"
 
     # Decode (Decompress)
-    decoded_bytes = img_obj.decode()
+    decoded_bytes = img_obj.to_linear_pixels()
 
     # Assert Equality
     # The length must match exactly
@@ -127,7 +127,7 @@ def test_image_invalid_format(format, encoding):
     log.debug("encoding test img data")
     # Encode (Compress)
     with pytest.raises(ValueError, match=f"Invalid image format {format}"):
-        _ = Image.encode(
+        _ = Image.from_linear_pixels(
             data=original_bytes,
             stride=stride,
             height=height,
@@ -159,7 +159,7 @@ def test_stride_padding_preservation():
         original_data.extend(row)
 
     # Encode as PNG (This relies on the encoder using 'stride' for width, not 'width')
-    img_obj = Image.encode(
+    img_obj = Image.from_linear_pixels(
         data=original_data,
         stride=stride,
         height=height,
@@ -169,7 +169,7 @@ def test_stride_padding_preservation():
     )
 
     # Decode
-    decoded_data = img_obj.decode()
+    decoded_data = img_obj.to_linear_pixels()
 
     # Assert
     assert len(decoded_data) == total_size
@@ -187,13 +187,13 @@ def test_endianness_metadata_passthrough():
     data = [1, 2, 3, 4]
 
     # Case 1: Big Endian Source
-    img_be = Image.encode(
+    img_be = Image.from_linear_pixels(
         data=data, stride=4, height=1, width=1, encoding="32FC1", is_bigendian=True
     )
     assert img_be.is_bigendian is True
 
     # Case 2: Little Endian Source
-    img_le = Image.encode(
+    img_le = Image.from_linear_pixels(
         data=data, stride=4, height=1, width=1, encoding="32FC1", is_bigendian=False
     )
     assert img_le.is_bigendian is False
@@ -208,7 +208,7 @@ def test_invalid_input_fallback():
     # Stride=10, Height=10 -> Expected 100 bytes. We provide 5.
     bad_data = [255, 255, 255, 255, 255]
 
-    img_obj = Image.encode(
+    img_obj = Image.from_linear_pixels(
         data=bad_data,
         stride=10,
         height=10,


### PR DESCRIPTION
This PR addresses critical bugs in multi-topic video sequence reading by refactoring the `CompressedImage` codec architecture. It removes the problematic global singleton decoder (`_VideoAwareCodec`) and introduces a new session-based approach for handling stateful video formats (H.264/HEVC), preventing memory corruption when switching between streams.

**Key Changes**

* **Refactored Codec Architecture:**
* Renamed `_DefaultCodec` to `_StatelessDefaultCodec` to explicitly indicate its scope.
* Removed `_CompressedImageCodec` and `_VideoAwareCodec` classes entirely.
* Simplified `CompressedImage.to_image()`: it now defaults to using `_StatelessDefaultCodec`. If decoding fails (e.g., due to missing state context for video), it safely returns `None` instead of crashing or using a corrupted global state.

* **New Feature: `StatefulDecodingSession`:**
* Introduced a public class `StatefulDecodingSession` to manage decoding contexts explicitly.
* This class maintains a dictionary of `av.CodecContext` instances keyed by a user-provided context string (e.g., `topic_name`), ensuring that multi-topic sequences are decoded without state interference.

* **API Improvements:**
* Renamed `Image.encode()` to `Image.from_linear_pixels()` and `Image.decode()` to `Image.to_linear_pixels()` for greater clarity regarding their low-level function.
* Added explicit TODOs highlighting areas for future module refactoring.

**Motivation**
Previously, H.264 streams shared a single global decoder cache keyed only by format (e.g., "h264"). When reading multiple video topics concurrently (e.g., stereo cameras), this caused P-frames from one stream to be applied to the reference frames of another, leading to visual corruption and eventual decoding failure. This PR enforces an architecture where decoding state is managed explicitly by the user via `StatefulDecodingSession`.

**Usage Example (Stateful Video)**

```python
seq_hndl = client.sequence_handler("test-sequence")
decoder = StatefulDecodingSession() # contextually to creation of sequence data stream (e.g.)

for topic, msg in seq_hndl.get_data_streamer():
    img = msg.get_data(CompressedImage)
    
    # Old: Implicit failure on multi-topic
    # pil_img = img.to_image() 
    
    # New: Explicit, safe session management
    
    pil_img = decoder.decode(img_data=img.data, format=img.format, context=topic)

```