### PR TITLE
docs: fix typos, broken links, and inconsistent clone instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Please report any bugs or issues in the [Issues](https://github.com/mosaico-labs
 ## Do you want to contribute code?
 ### `mosaicod` (Backend)
 * **Setup:** Ensure you have a working [Rust toolchain](https://rust-lang.org/tools/install/) installed.
-* **Build Instructions:** Refer to the [`mosaicod` main guide](./README.md) for detailed instructions on building from source.
+* **Build Instructions:** Refer to the [`mosaicod` main guide](./mosaicod/README.md) for detailed instructions on building from source.
 * **Database Schema:** If you modify the database schema, you **must** run `cargo sqlx prepare` and commit the generated `.sqlx` directory.
 * **Safety:** Avoid `unsafe` blocks unless absolutely necessary for FFI or zero-copy buffer handling.
 * **Style & Linting:** Your code must be formatted via `cargo fmt` and pass `cargo clippy` without warnings. CI actions are in place to enforce these checks.
@@ -63,7 +63,7 @@ This preliminary step ensures:
 
 ## Do you want to improve the documentation?
 * Update the relevant documentation if you modify any public interfaces.
-* We encourage adding code snippets to the `examples/` directory, specifically for ROS ingestion or Streamer usage.
+* We encourage adding code snippets to the relevant documentation files, specifically for ROS ingestion or Streamer usage.
 
 ## Submission
 1. **Fork** the repository.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Mosaico is an open-source data platform specifically designed for Robotics and Physical AI.
 
-This repo contains both the Python SDK (`mosaico-sdk-py`) and the Rust backend (`mosaicod`). We have choosed to keep the code in a monorepo configuration to simplify the testing and reduce compatibility issues.
+This repo contains both the Python SDK (`mosaico-sdk-py`) and the Rust backend (`mosaicod`). We have chosen to keep the code in a monorepo configuration to simplify the testing and reduce compatibility issues.
 
 > [!WARNING]
 > **Mosaico is currently in an early development phase.**
@@ -85,6 +85,6 @@ If you use Mosaico for a publication, please cite it as:
   year = {2025},
   month = {12},
   address = {Online},
-  note = {Available from https://mosaico.dev/ and https://github.com/mosaico-labs/mosaicod}
+  note = {Available from https://mosaico.dev/ and https://github.com/mosaico-labs/mosaico}
 }
 ```

--- a/mosaico-sdk-py/README.md
+++ b/mosaico-sdk-py/README.md
@@ -51,11 +51,11 @@ poetry --version
 
 ### Clone and Install SDK
 
-Clone the repository and navigate to the project root:
+Clone the repository and navigate to the SDK directory:
 
 ```bash
-git clone https://github.com/mosaico-labs/mosaico-sdk-py.git
-cd mosaico-sdk-py
+git clone https://github.com/mosaico-labs/mosaico.git
+cd mosaico/mosaico-sdk-py
 ```
 
 Install the dependencies. This will automatically create a virtual environment and install all required libraries (PyArrow, NumPy, ROSBags, etc.):


### PR DESCRIPTION

Minor cleanup before docs improvements

- Fix grammatical error ("choosed" → "chosen") in main README
- Correct repository URL in BibTeX citation
- Update SDK clone instructions to reflect monorepo structure
- Fix mosaicod README link in CONTRIBUTING.md
- Remove reference to non-existent examples/ directory