### PR TITLE
fix(sdk-py): correct __exit__ return type for mypy

### DIFF
--- a/mosaico-sdk-py/src/mosaicolabs/comm/mosaico_client.py
+++ b/mosaico-sdk-py/src/mosaicolabs/comm/mosaico_client.py
@@ -170,12 +170,11 @@ class MosaicoClient:
         exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException],
         exc_tb: Optional[Any],
-    ) -> bool:
+    ) -> None:
         """
         Context manager exit point. Ensures resources are closed.
 
-        Returns:
-            bool: False, to propagate any exceptions raised within the `with` block.
+        Exceptions raised within the `with` block are propagated.
         """
         try:
             self.close()
@@ -183,7 +182,6 @@ class MosaicoClient:
             log.exception(
                 f"Error releasing resources allocated from MosaicoClient.\nInner err: {e}"
             )
-        return False
 
     def __del__(self):
         """Destructor. Failsafe if close() is not explicitly called."""

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/sequence_handler.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/sequence_handler.py
@@ -126,7 +126,7 @@ class SequenceHandler:
         exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException],
         exc_tb: Optional[Any],
-    ) -> bool:
+    ) -> None:
         """Context manager exit for SequenceHandler."""
         try:
             self.close()
@@ -134,7 +134,6 @@ class SequenceHandler:
             log.exception(
                 f"Error releasing resources allocated from SequenceHandler '{self._sequence.name}'.\nInner err: {e}"
             )
-        return False
 
     # -------------------- Public methods --------------------
     @property

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/sequence_writer.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/sequence_writer.py
@@ -109,7 +109,7 @@ class SequenceWriter:
         exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException],
         exc_tb: Optional[Any],
-    ) -> bool:
+    ) -> None:
         """
         Finalizes the sequence.
 
@@ -157,8 +157,6 @@ class SequenceWriter:
 
             if exc_type is None and out_exc is not None:
                 raise out_exc  # Re-raise the cleanup error if it's the only one
-
-        return False
 
     def __del__(self):
         """Destructor check to warn if the writer was left pending."""

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/topic_handler.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/topic_handler.py
@@ -139,7 +139,7 @@ class TopicHandler:
         exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException],
         exc_tb: Optional[Any],
-    ) -> bool:
+    ) -> None:
         """Context manager exit for TopicHandler."""
         try:
             self.close()
@@ -147,7 +147,6 @@ class TopicHandler:
             log.exception(
                 f"Error releasing resources allocated from TopicHandler '{self._topic.name}'.\nInner err: {e}"
             )
-        return False
 
     @property
     def user_metadata(self):

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/topic_writer.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/topic_writer.py
@@ -131,15 +131,13 @@ class TopicWriter:
         exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException],
         exc_tb: Optional[Any],
-    ) -> bool:
+    ) -> None:
         """
         Context manager exit.
 
         Guarantees cleanup of the Flight stream. If an exception occurred within
         the block, it triggers the configured `OnErrorPolicy` (e.g., reporting the error).
-
-        Returns:
-            bool: False, ensuring exceptions are propagated.
+        Exceptions from the with-block are always propagated.
         """
         error_occurred = exc_type is not None
 
@@ -162,9 +160,6 @@ class TopicWriter:
                 log.exception(
                     f"Error handling topic '{self._name}' after exception: {e}"
                 )
-
-        # Do not suppress any exception from the with-block
-        return False
 
     def __del__(self):
         """Destructor check to ensure `finalize()` was called."""


### PR DESCRIPTION
mypy catches the bool as an error, propagation behaviour unchanged, low priority for merge
- Fix mypy `exit-return` error: change `__exit__` return type from `bool` to `None`