### PR TITLE
Handle missing serialization format in FacadeQuery

### DIFF
--- a/mosaicod/src/repo/facades/facade_error.rs
+++ b/mosaicod/src/repo/facades/facade_error.rs
@@ -4,6 +4,8 @@ pub enum FacadeError {
     NotFound(String),
     #[error("missing metadata field `{0}`")]
     MissingMetadataField(String),
+    #[error("missing serialization format for resource {0}")]
+    MissingSerializationFormat(String),
     #[error("error reading {src}: {msg}")]
     ReadError { src: String, msg: String },
     #[error("error writing to {dst} data: {msg}")]

--- a/mosaicod/src/repo/facades/facade_query.rs
+++ b/mosaicod/src/repo/facades/facade_query.rs
@@ -116,12 +116,13 @@ impl FacadeQuery {
                             chunk.data_file().to_string_lossy()
                         );
 
+                        let serialization_format =
+                            topic.serialization_format().ok_or_else(|| {
+                                FacadeError::MissingSerializationFormat(topic.topic_name.to_owned())
+                            })?;
+
                         let qr = ts_engine
-                            .read(
-                                chunk.data_file(),
-                                topic.serialization_format().unwrap(), // TODO: handle error
-                                None,
-                            )
+                            .read(chunk.data_file(), serialization_format, None)
                             .await?;
 
                         let qr = qr.filter(ontology_tag_exprs.to_owned())?;


### PR DESCRIPTION
Added a new FacadeError variant for missing `serialization_format` and updated FacadeQuery to return this error when the format is not present.