### PR TITLE
Add topic filtering to sequence streamer and enforce stricter handler errors.

### DIFF
--- a/mosaico-sdk-py/doc-md/handlers.md
+++ b/mosaico-sdk-py/doc-md/handlers.md
@@ -163,16 +163,19 @@ This is the handler to an existing sequence. It allows you to inspect what topic
 
 **Streamer Factories**
 
-  * **`get_data_streamer(force_new_instance: bool = False) -> SequenceDataStreamer`**
+  * **`get_data_streamer(topics: List[str] = [], force_new_instance: bool = False) -> SequenceDataStreamer`**
     Creates and returns a `SequenceDataStreamer` initialized to read the **entire** sequence. By default, it caches the streamer instance.
-
+      * **`topics`**: Retrieves the sequence stream from the passed topics only (ignore the other topics, if any). Returns the data-stream from all the topics by default.
       * **`force_new_instance`**: If `True`, closes any existing streamer and creates a fresh one (useful for restarting iteration).
+      
+    Raises `ValueError` if some of the input topic names are not valid.
 
-  * **`get_topic_handler(topic_name: str, force_new_instance: bool = False) -> Optional[TopicHandler]`**
-    Returns a `TopicHandler` for a specific child topic.
-
+  * **`get_topic_handler(topic_name: str, force_new_instance: bool = False) -> TopicHandler`**
+    Returns a `TopicHandler` for a specific child topic:
       * **`topic_name`**: The name of the topic to retrieve.
       * **`force_new_instance`**: If `True`, recreates the handler connection.
+
+    Raises a `ValueError` if the topic name does not exist in the sequence.
 
   * **`close() -> None`**
     Closes all cached topic handlers and active data streamers associated with this handler.
@@ -306,10 +309,11 @@ The `TopicHandler` provides access to metadata, schema definitions, and acts as 
   * Returns the full `Topic` data model. This includes system-level details such as the ontology model class and data volume size.
 
 **Streamer Factories**
-* **`get_data_streamer(force_new_instance: bool = False) -> Optional[TopicDataStreamer]`**
+* **`get_data_streamer(force_new_instance: bool = False) -> TopicDataStreamer`**
   * Initializes and returns a `TopicDataStreamer`.
   * If a streamer is already active for this handler, it returns the existing instance unless `force_new_instance` is set to `True`.
   * Returns `None` if the topic contains no data or cannot be reached.
+  * Raises `ValueError` if a data streamer cannot be spawned.
 
 
 #### Class: `TopicDataStreamer`

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/topic_handler.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/topic_handler.py
@@ -163,9 +163,7 @@ class TopicHandler:
         """Returns the topic name."""
         return self._topic.name
 
-    def get_data_streamer(
-        self, force_new_instance=False
-    ) -> Optional[TopicDataStreamer]:
+    def get_data_streamer(self, force_new_instance=False) -> TopicDataStreamer:
         """
         Creates or retrieves a `TopicDataStreamer` to read data.
 
@@ -173,13 +171,15 @@ class TopicHandler:
             force_new_instance (bool): If True, creates a fresh reader even if one exists.
 
         Returns:
-            Optional[TopicDataStreamer]: The reader object.
+            TopicDataStreamer: The reader object.
+
+        Raises:
+            ValueError: if TopicHandler internal is not valid
         """
         if self._fl_ticket is None:
-            log.error(
+            raise ValueError(
                 f"Unable to get a TopicDataStreamer for topic {self._topic.name}: invalid TopicHandler!"
             )
-            return None
 
         if force_new_instance and self._data_streamer_instance is not None:
             self._data_streamer_instance.close()

--- a/mosaico-sdk-py/src/testing/integration/helpers.py
+++ b/mosaico-sdk-py/src/testing/integration/helpers.py
@@ -112,6 +112,13 @@ def make_magn_msg(msg_time: int, meas_time: Time):
     )
 
 
+topic_list = [
+    UPLOADED_IMU_FRONT_TOPIC,
+    UPLOADED_IMU_CAMERA_TOPIC,
+    UPLOADED_GPS_TOPIC,
+    UPLOADED_MAGNETOMETER_TOPIC,
+]
+
 topic_to_maker_factory = [
     (UPLOADED_IMU_FRONT_TOPIC, make_imu_front_msg),
     (UPLOADED_IMU_CAMERA_TOPIC, make_imu_cam_msg),

--- a/mosaico-sdk-py/src/testing/integration/test_failures.py
+++ b/mosaico-sdk-py/src/testing/integration/test_failures.py
@@ -9,6 +9,7 @@ import pyarrow as pa
 from mosaicolabs.handlers import TopicWriter
 from mosaicolabs.comm import MosaicoClient
 from mosaicolabs.enum import SequenceStatus, SerializationFormat
+from testing.integration.config import UPLOADED_SEQUENCE_NAME
 
 
 def test_invalid_host():
@@ -98,3 +99,35 @@ def test_topic_push_not_serializable(_client: MosaicoClient):
 
     # free resources
     _client.close()
+
+
+def test_non_existing_topic_handler(
+    _client: MosaicoClient,
+    _inject_sequence_data_stream,
+):
+    """Test the exception raising of non-existing topic handler from sequence"""
+    seqhandler = _client.sequence_handler(UPLOADED_SEQUENCE_NAME)
+    # Sequence must exist
+    assert seqhandler is not None
+
+    with pytest.raises(
+        ValueError, match="Topic 'non-existing-topic-name' not available in sequence"
+    ):
+        seqhandler.get_topic_handler("non-existing-topic-name")
+
+
+def test_sequence_streamer_non_existing_topics(
+    _client: MosaicoClient,
+    _inject_sequence_data_stream,
+):
+    """Test the exception raising of non-existing topics when spawning data-stream from sequence"""
+    seqhandler = _client.sequence_handler(UPLOADED_SEQUENCE_NAME)
+    # Sequence must exist
+    assert seqhandler is not None
+
+    with pytest.raises(ValueError, match="Invalid input topic names"):
+        seqhandler.get_data_streamer(
+            topics=[
+                "non-existing-topic-name",
+            ]
+        )

--- a/mosaico-sdk-py/src/testing/integration/test_query_catalog.py
+++ b/mosaico-sdk-py/src/testing/integration/test_query_catalog.py
@@ -1,9 +1,8 @@
-import pytest
 from mosaicolabs.comm import MosaicoClient
 from mosaicolabs.models import Time
 from mosaicolabs.models.platform import Topic
 from mosaicolabs.models.query import QueryOntologyCatalog, QueryTopic, QuerySequence
-from mosaicolabs.models.sensors import IMU, Image, GPS
+from mosaicolabs.models.sensors import IMU, GPS
 from testing.integration.config import (
     UPLOADED_GPS_TOPIC,
     UPLOADED_IMU_CAMERA_TOPIC,
@@ -27,17 +26,16 @@ def test_query_ontology(
     assert query_resp is not None
     # One (1) sequence corresponds to this query
     assert len(query_resp) == 1
-    # Two (2) topics correspond to this query
-    assert len(query_resp[0].topics) == 2
     # The target topics are 'UPLOADED_IMU_FRONT_TOPIC' and 'UPLOADED_IMU_CAMERA_TOPIC'
     expected_topic_names = [
         UPLOADED_IMU_FRONT_TOPIC,
         UPLOADED_IMU_CAMERA_TOPIC,
     ]
+    assert len(query_resp[0].topics) == len(expected_topic_names)
+
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
     assert all([t in expected_topic_names for t in query_resp[0].topics])
-    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # Query by multiple condition: time and value
     tstamp = Time.from_float(1700000000.26)
@@ -50,17 +48,15 @@ def test_query_ontology(
     assert query_resp is not None
     # One (1) sequence corresponds to this query
     assert len(query_resp) == 1
-    # Two (2) topics correspond to this query
-    assert len(query_resp[0].topics) == 2
     # The target topics are 'UPLOADED_IMU_FRONT_TOPIC' and 'UPLOADED_IMU_CAMERA_TOPIC'
     expected_topic_names = [
         UPLOADED_IMU_FRONT_TOPIC,
         UPLOADED_IMU_CAMERA_TOPIC,
     ]
+    assert len(query_resp[0].topics) == len(expected_topic_names)
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
     assert all([t in expected_topic_names for t in query_resp[0].topics])
-    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # Query by multiple condition: time and value (GPS)
     tstamp = Time.from_float(1700000000.26)
@@ -100,17 +96,15 @@ def test_query_ontology_between(
     assert query_resp is not None
     # One (1) sequence corresponds to this query
     assert len(query_resp) == 1
-    # Two (2) topics correspond to this query
-    assert len(query_resp[0].topics) == 2
     # The target topics are 'UPLOADED_IMU_FRONT_TOPIC' and 'UPLOADED_IMU_CAMERA_TOPIC'
     expected_topic_names = [
         UPLOADED_IMU_FRONT_TOPIC,
         UPLOADED_IMU_CAMERA_TOPIC,
     ]
+    assert len(query_resp[0].topics) == len(expected_topic_names)
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
     assert all([t in expected_topic_names for t in query_resp[0].topics])
-    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # Query by mixed conditions
     query_resp = _client.query(
@@ -123,16 +117,14 @@ def test_query_ontology_between(
     assert query_resp is not None
     # One (1) sequence corresponds to this query
     assert len(query_resp) == 1
-    # Two (2) topics correspond to this query
-    assert len(query_resp[0].topics) == 1
     # The target topics are 'UPLOADED_IMU_FRONT_TOPIC' and 'UPLOADED_IMU_CAMERA_TOPIC'
     expected_topic_names = [
         UPLOADED_IMU_CAMERA_TOPIC,
     ]
+    assert len(query_resp[0].topics) == len(expected_topic_names)
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
     assert all([t in expected_topic_names for t in query_resp[0].topics])
-    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # free resources
     _client.close()

--- a/mosaico-sdk-py/src/testing/integration/test_query_mockup.py
+++ b/mosaico-sdk-py/src/testing/integration/test_query_mockup.py
@@ -27,11 +27,9 @@ def test_query_mockup_sequence_by_name(
     topics = [t["name"] for t in QUERY_SEQUENCES_MOCKUP[sequence_name]["topics"]]
     expected_topic_names = topics
     assert len(query_resp[0].topics) == len(expected_topic_names)
-    expected_topic_names = [topic for topic in expected_topic_names]
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
     assert all([t in expected_topic_names for t in query_resp[0].topics])
-    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # Query by partial name
     n_char = int(len(sequence_name) / 2)  # half the length
@@ -48,11 +46,9 @@ def test_query_mockup_sequence_by_name(
         topics = [t["name"] for t in QUERY_SEQUENCES_MOCKUP[seqname]["topics"]]
         expected_topic_names = topics
         assert len(item.topics) == len(expected_topic_names)
-        expected_topic_names = [topic for topic in expected_topic_names]
         # all the expected topics, and only them
         [_validate_returned_topic_name(topic) for topic in item.topics]
         assert all([t in expected_topic_names for t in item.topics])
-        assert all([t in item.topics for t in expected_topic_names])
 
     # Query by partial name: startswith
     n_char = int(len(sequence_name) / 2)  # half the length
@@ -71,11 +67,9 @@ def test_query_mockup_sequence_by_name(
         topics = [t["name"] for t in QUERY_SEQUENCES_MOCKUP[seqname]["topics"]]
         expected_topic_names = topics
         assert len(item.topics) == len(expected_topic_names)
-        expected_topic_names = [topic for topic in expected_topic_names]
         # all the expected topics, and only them
         [_validate_returned_topic_name(topic) for topic in item.topics]
         assert all([t in expected_topic_names for t in item.topics])
-        assert all([t in item.topics for t in expected_topic_names])
 
     # Query by partial name: endswith
     n_char = int(len(sequence_name) / 2)  # half the length
@@ -94,11 +88,9 @@ def test_query_mockup_sequence_by_name(
         topics = [t["name"] for t in QUERY_SEQUENCES_MOCKUP[seqname]["topics"]]
         expected_topic_names = topics
         assert len(item.topics) == len(expected_topic_names)
-        expected_topic_names = [topic for topic in expected_topic_names]
         # all the expected topics, and only them
         [_validate_returned_topic_name(topic) for topic in item.topics]
         assert all([t in expected_topic_names for t in item.topics])
-        assert all([t in item.topics for t in expected_topic_names])
 
     # free resources
     _client.close()
@@ -128,11 +120,9 @@ def test_query_mockup_sequence_metadata(
     ]
     expected_topic_names = topics
     assert len(query_resp[0].topics) == len(expected_topic_names)
-    expected_topic_names = [topic for topic in expected_topic_names]
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
     assert all([t in expected_topic_names for t in query_resp[0].topics])
-    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # Test 2: with None return
     query_resp = _client.query(

--- a/mosaico-sdk-py/src/testing/integration/test_query_topic.py
+++ b/mosaico-sdk-py/src/testing/integration/test_query_topic.py
@@ -60,12 +60,10 @@ def test_query_topic_by_creation_timestamp(
     # We expect to obtain all the topics
     expected_topic_names = list(topic_to_metadata_dict.keys())
     assert len(query_resp[0].topics) == len(expected_topic_names)
-    expected_topic_names = [topic for topic in expected_topic_names]
 
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
     assert all([t in expected_topic_names for t in query_resp[0].topics])
-    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # free resources
     _client.close()
@@ -97,11 +95,9 @@ def test_query_topic_by_sensor_tag(
     ]
     # N topics may correspond to this query
     assert len(query_resp[0].topics) == len(expected_topic_names)
-    expected_topic_names = [topic for topic in expected_topic_names]
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
     assert all([t in expected_topic_names for t in query_resp[0].topics])
-    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # free resources
     _client.close()
@@ -136,11 +132,9 @@ def test_query_topic_multi_criteria(
     ]
     # N topics may correspond to this query
     assert len(query_resp[0].topics) == len(expected_topic_names)
-    expected_topic_names = [topic for topic in expected_topic_names]
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
     assert all([t in expected_topic_names for t in query_resp[0].topics])
-    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # Test with multiple criteria: trigger between
     # Query by ontology_tag
@@ -175,11 +169,9 @@ def test_query_topic_multi_criteria(
     ]
     # N topics may correspond to this query
     assert len(query_resp[0].topics) == len(expected_topic_names)
-    expected_topic_names = [topic for topic in expected_topic_names]
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
     assert all([t in expected_topic_names for t in query_resp[0].topics])
-    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # free resources
     _client.close()
@@ -251,17 +243,15 @@ def test_query_topic_metadata(
     assert query_resp is not None
     # One (1) sequence corresponds to this query
     assert len(query_resp) == 1
-    # Two (2) topics correspond to this query
-    assert len(query_resp[0].topics) == 2
     # The target topics are 'UPLOADED_IMU_FRONT_TOPIC' and 'UPLOADED_IMU_CAMERA_TOPIC'
     expected_topic_names = [
         UPLOADED_IMU_FRONT_TOPIC,
         UPLOADED_IMU_CAMERA_TOPIC,
     ]
+    assert len(expected_topic_names) == len(query_resp[0].topics)
     # all the expected topics, and only them
     [_validate_returned_topic_name(topic) for topic in query_resp[0].topics]
     assert all([t in expected_topic_names for t in query_resp[0].topics])
-    assert all([t in query_resp[0].topics for t in expected_topic_names])
 
     # Test with nested field
     query_resp = _client.query(


### PR DESCRIPTION
**Summary**
- Added topic-level filtering to sequence reads: `SequenceHandler.get_data_streamer(topics=...)` forwards requested topic list to `SequenceDataStreamer.connect`, which now filters endpoints by parsed tickets and only opens readers for matching topics.
- Strengthened error handling and return types: `SequenceHandler` and `TopicHandler` now raise `ValueError` on invalid or missing topics/tickets; several methods changed from optional returns to concrete types and have clearer docstrings and type hints.
- Implemented input validation: `get_data_streamer` validates requested topic names against the sequence's available topics and raises descriptive errors.
- Tests and test helpers updated: exported `topic_list` in integration helpers and adapted/added integration tests (test_stream.py, test_failures.py) to cover non-existing-topic errors and sequence-level topic filtering behavior.
- Minor cleanups: adjusted imports and typing annotations, improved logging/error messages to make failures explicit and easier to diagnose.

The PR closes issue #48 