### PR TITLE
Replace unsafe deletion with DataLossToken pattern

### DIFF
--- a/mosaicod/src/repo/facades/facade_sequence.rs
+++ b/mosaicod/src/repo/facades/facade_sequence.rs
@@ -227,12 +227,10 @@ impl FacadeSequence {
         for topic_loc in topics {
             let thandle = FacadeTopic::new(topic_loc.into(), self.store.clone(), self.repo.clone());
 
-            // For this special case we allow an unsafe delete since the sequence is still unlocked (previous check).
+            // For this special case we allow a data loss delete since the sequence is still unlocked (previous check).
             // This is because the system may be in a state where topics are partially uploaded:
             // some topics are fully uploaded and locked, while others are not.
-            unsafe {
-                thandle.delete_unsafe().await?;
-            }
+            thandle.delete(types::allow_data_loss()).await?;
         }
 
         // Delete sequence data

--- a/mosaicod/src/repo/sql_models/pg_queries/sequence_record.rs
+++ b/mosaicod/src/repo/sql_models/pg_queries/sequence_record.rs
@@ -106,14 +106,15 @@ pub async fn sequence_delete_unlocked(
 
 /// Deletes a sequence record from the repository by its name, **bypassing any lock state**.
 ///
-/// This function is marked `unsafe` because it permanently removes the record
+/// This function requires a [`DataLossToken`] because it permanently removes the record
 /// from the database without checking whether it is locked or referenced
 /// elsewhere. Improper use can lead to data inconsistency or loss.
-pub async unsafe fn sequence_delete(
+pub async fn sequence_delete(
     exe: &mut impl repo::AsExec,
     loc: &types::SequenceResourceLocator,
+    _: types::DataLossToken,
 ) -> Result<(), repo::Error> {
-    trace!("(unsafe) deleting `{}`", loc);
+    trace!("(data loss) deleting `{}`", loc);
     sqlx::query!("DELETE FROM sequence_t WHERE locator_name=$1", loc.name())
         .execute(exe.as_exec())
         .await?;

--- a/mosaicod/src/repo/sql_models/pg_queries/topic_record.rs
+++ b/mosaicod/src/repo/sql_models/pg_queries/topic_record.rs
@@ -85,14 +85,15 @@ pub async fn topic_delete_unlocked(
 
 /// Deletes a topic record from the repository by its name, **bypassing any lock state**.
 ///
-/// This function is marked `unsafe` because it permanently removes the record
+/// This function requires a [`DataLossToken`] since permanently removes the record
 /// from the database without checking whether it is locked or referenced
 /// elsewhere. Improper use can lead to data inconsistency or loss.
-pub async unsafe fn topic_delete(
+pub async fn topic_delete(
     exe: &mut impl repo::AsExec,
     loc: &types::TopicResourceLocator,
+    _: types::DataLossToken,
 ) -> Result<(), repo::Error> {
-    trace!("(unsafe) deleting `{}`", loc);
+    trace!("(data loss) deleting `{}`", loc);
     sqlx::query!("DELETE FROM topic_t WHERE locator_name=$1", loc.name())
         .execute(exe.as_exec())
         .await?;

--- a/mosaicod/src/server/endpoints/actions/topic.rs
+++ b/mosaicod/src/server/endpoints/actions/topic.rs
@@ -60,7 +60,7 @@ pub async fn delete(ctx: &ActionContext, name: String) -> Result<ActionResponse,
         return Err(ServerError::SequenceLocked);
     }
 
-    handle.delete().await?;
+    handle.delete_unlocked().await?;
     warn!("resource {} deleted", name);
 
     Ok(ActionResponse::Empty)

--- a/mosaicod/src/types/mod.rs
+++ b/mosaicod/src/types/mod.rs
@@ -15,6 +15,9 @@ pub use resources::*;
 mod layer;
 pub use layer::*;
 
+mod tokens;
+pub use tokens::*;
+
 mod chunk;
 pub use chunk::*;
 

--- a/mosaicod/src/types/tokens.rs
+++ b/mosaicod/src/types/tokens.rs
@@ -1,0 +1,27 @@
+/// A marker type representing a scope where data loss is explicitly acknowledged.
+///
+/// Use [`allow_data_loss`] to build this token.
+pub struct DataLossToken {
+    _private: (),
+}
+
+/// Creates a new `DataLossToken`.
+///
+/// This serves as an explicit opt-in mechanism for operations that may
+/// result in irreversible data loss.
+///
+/// # Example
+/// An example of the typical use of this construct:
+///
+/// ```
+/// use mosaicod::types::{DataLossToken, allow_data_loss};
+///
+/// fn dangerous_function(_: DataLossToken) {
+///     // destroy the universe
+/// }
+///
+/// dangerous_function(allow_data_loss());
+/// ```
+pub fn allow_data_loss() -> DataLossToken {
+    DataLossToken { _private: () }
+}


### PR DESCRIPTION
- Introduce `DataLossToken` to explicitly authorize destructive operations.
- Replace unsafe keywords in `FacadeTopic` and repository queries with token-based authorization.
- Rename `FacadeTopic::delete` to delete_unlocked to clarify safety semantics.
- Update `FacadeSequence` and API endpoints to comply with new deletion API.