### PR TITLE
feat(mosaicod): add automatic chunk splitting in ChunkedWriter

### DIFF
--- a/mosaicod/env.devel
+++ b/mosaicod/env.devel
@@ -12,6 +12,11 @@ MOSAICO_MAX_DB_CONNECTIONS=10
 # Maximum concurrent chunk queries during data catalog filtering
 MOSAICO_MAX_CONCURRENT_CHUNK_QUERIES=4
 
+# Maximum chunk size in bytes before automatic splitting during upload.
+# Set to 0 to disable (not recommended for large uploads).
+# Default: 268435456 (256 MiB)
+MOSAICO_MAX_CHUNK_SIZE_IN_BYTES=268435456
+
 # Configuration variable used by sqlx to establish a connection with the database for
 # type checks
 DATABASE_URL=postgresql://postgres:password@localhost:5432/mosaico

--- a/mosaicod/src/main.rs
+++ b/mosaicod/src/main.rs
@@ -7,7 +7,7 @@ use clap::{Args, Parser, Subcommand};
 
 use dotenv::dotenv;
 
-use log::{debug, error, info, trace};
+use log::{debug, error, info, trace, warn};
 use mosaicod::{params, repo, server, store, utils::print};
 
 #[derive(Parser, Debug)]
@@ -54,6 +54,13 @@ fn load_env_variables() -> Result<Variables, Box<dyn std::error::Error>> {
     dotenv().ok();
 
     params::load_configurables_from_env();
+
+    if params::configurables().max_chunk_size_in_bytes == 0 {
+        warn!(
+            "MOSAICO_MAX_CHUNK_SIZE_IN_BYTES=0: automatic chunk splitting is disabled. \
+             Large uploads may cause high memory usage."
+        );
+    }
 
     let repository_db_url: String = params::require_env_var("MOSAICO_REPOSITORY_DB_URL")?;
     let repository_db_url: url::Url = repository_db_url.parse()?;

--- a/mosaicod/src/params.rs
+++ b/mosaicod/src/params.rs
@@ -44,6 +44,10 @@ pub struct ConfigurablesParams {
     pub max_concurrent_chunk_queries: usize,
     /// Maximum number of database connections in the pool
     pub max_db_connections: u32,
+    /// Maximum chunk size in bytes before automatic splitting during upload.
+    /// When a chunk exceeds this size, it is finalized and a new chunk is started.
+    /// A value of 0 means unlimited (no automatic splitting).
+    pub max_chunk_size_in_bytes: usize,
 }
 
 static ENV: OnceLock<ConfigurablesParams> = OnceLock::new();
@@ -64,6 +68,10 @@ pub fn load_configurables_from_env() {
         ),
         max_concurrent_chunk_queries: cast_env_var("MOSAICO_MAX_CONCURRENT_CHUNK_QUERIES", 4),
         max_db_connections: cast_env_var("MOSAICO_MAX_DB_CONNECTIONS", 10),
+        max_chunk_size_in_bytes: cast_env_var(
+            "MOSAICO_MAX_CHUNK_SIZE_IN_BYTES",
+            256 * 1024 * 1024, // 256 MiB default
+        ),
     };
 
     let _ = ENV.set(ev);


### PR DESCRIPTION
## Summary

- Add memory-bounded chunking to prevent unbounded memory growth during large data uploads
- ChunkedWriter now automatically finalizes chunks when internal buffer exceeds configurable size threshold (default 256 MiB)
- New environment variable `MOSAICO_MAX_CHUNK_SIZE_IN_BYTES` to configure threshold (0 to disable)