### PR TITLE
Enhance sequence and topic name validation with comprehensive character restrictions

### DIFF
--- a/mosaico-sdk-py/src/mosaicolabs/handlers/helpers.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/helpers.py
@@ -9,6 +9,10 @@ from pathlib import Path
 from typing import Optional
 from ..helpers import unpack_topic_full_path
 
+# Set the unsupported name chars for sequence and topic names
+_UNSUPPORTED_TOPIC_NAME_CHARS = ["!", '"', "'", "*", "£", "$", "%", "&"]
+_UNSUPPORTED_SEQUENCE_NAME_CHARS = _UNSUPPORTED_TOPIC_NAME_CHARS + ["/"]
+
 
 def _make_exception(msg: str, exc_msg: Optional[Exception] = None) -> Exception:
     """
@@ -46,8 +50,43 @@ def _parse_ep_ticket(blocation: bytes) -> Optional[tuple[str, str]]:
 
 
 def _validate_sequence_name(name: str):
+    if not name:
+        raise ValueError("Empty sequence name")
     nbase = Path(name)
     if nbase.is_absolute():
         nbase = nbase.relative_to("/")
-    if "/" in str(nbase):
-        raise ValueError(f"Invalid characters '/' in sequence name '{name}'")
+    # Assert sequence name format
+    nbase = str(nbase)
+    # Sequence name contained only a '/'
+    if not nbase:
+        raise ValueError("Empty sequence name after '/' removal")
+    # Check the first char is alphanumeric
+    if not nbase[0].isalnum():
+        raise ValueError("Sequence name does not begin with a letter or a number.")
+    # Check the name does not contain unsupported chars
+
+    if any(ch in nbase for ch in _UNSUPPORTED_SEQUENCE_NAME_CHARS):
+        raise ValueError(
+            f"Sequence name contains invalid characters: {_UNSUPPORTED_SEQUENCE_NAME_CHARS}"
+        )
+
+
+def _validate_topic_name(name: str):
+    if not name:
+        raise ValueError("Empty topic name")
+    nbase = Path(name)
+    if nbase.is_absolute():
+        nbase = nbase.relative_to("/")
+    # Assert topic name format
+    nbase = str(nbase)
+    # Topic name contained only a '/'
+    if not nbase:
+        raise ValueError("Empty topic name after '/' removal")
+    # Check the first char is alphanumeric
+    if not nbase[0].isalnum():
+        raise ValueError("Topic name does not begin with a letter or a number.")
+    # Check the name does not contain unsupported chars
+    if any(ch in nbase for ch in _UNSUPPORTED_TOPIC_NAME_CHARS if ch != "/"):
+        raise ValueError(
+            f"Topic name contains invalid characters: {_UNSUPPORTED_TOPIC_NAME_CHARS}"
+        )

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/sequence_writer.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/sequence_writer.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Type, Optional
 import pyarrow.flight as fl
 
 from .config import WriterConfig
-from .helpers import _make_exception, _validate_sequence_name
+from .helpers import _make_exception, _validate_sequence_name, _validate_topic_name
 from .topic_writer import TopicWriter
 from ..comm.do_action import _do_action, _DoActionResponseKey
 from ..comm.connection import _ConnectionPool
@@ -209,6 +209,8 @@ class SequenceWriter:
         if topic_name in self._topic_writers:
             logger.error(f"Topic '{topic_name}' already exists in this sequence.")
             return None
+
+        _validate_topic_name(topic_name)
 
         logger.debug(f"Requesting new topic '{topic_name}' for sequence '{self._name}'")
 


### PR DESCRIPTION
This PR implements robust validation for sequence and topic names during creation to prevent invalid naming patterns and improve data consistency.

### Changes:
- **Added character restrictions**: Introduced `_UNSUPPORTED_TOPIC_NAME_CHARS` and `_UNSUPPORTED_SEQUENCE_NAME_CHARS` lists to define illegal characters for naming (!, ", ', *, £, $, %, &, and / for sequences only)
- **Refactored sequence validation**: Updated `_validate_sequence_name()` helper to enforce:
  - Non-empty names
  - Alphanumeric start character
  - No unsupported special characters
  - Proper handling of absolute paths
  
- **Added topic validation**: Implemented new `_validate_topic_name()` helper function with similar validation rules, integrated into `SequenceWriter.topic_create()` method
- **Comprehensive test coverage**: Enhanced `test_failures.py` with parametrized tests covering all unsupported characters for both sequence and topic naming

### Related Issue
Closes issue #93

This PR is compliance with the `CONTRIBUTING.md` and `IP.md` policies
> [!WARNING]
> We value everyone’s time and effort.  
> To avoid work on unrequested or duplicate features, **pull requests must meet the requirements below**.

Please confirm all of the following before submitting this PR:

- I have read and understood the `CONTRIBUTING.md` file
- I have opened a discussion related to this feature or bug
- This work was previously discussed and agreed upon by maintainers
