### PR TITLE
[SDK] Fixed optional timestamp parameters in time-windowed data streaming queries

### DIFF
--- a/mosaico-sdk-py/src/mosaicolabs/handlers/topic_handler.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/topic_handler.py
@@ -216,16 +216,13 @@ class TopicHandler:
             topic_resrc_name = pack_topic_resource_name(
                 self._topic.sequence_name, self._topic.name
             )
-            descriptor = fl.FlightDescriptor.for_command(
-                json.dumps(
-                    {
-                        "resource_locator": topic_resrc_name,
-                        # TODO: is ok for server to receive 'null'?
-                        "timestamp_ns_start": start_timestamp_ns,
-                        "timestamp_ns_end": end_timestamp_ns,
-                    }
-                )
-            )
+            cmd_dict: dict[str, Any] = {"resource_locator": topic_resrc_name}
+            if start_timestamp_ns is not None:
+                cmd_dict.update({"timestamp_ns_start": start_timestamp_ns})
+            if end_timestamp_ns is not None:
+                cmd_dict.update({"timestamp_ns_end": end_timestamp_ns})
+
+            descriptor = fl.FlightDescriptor.for_command(json.dumps(cmd_dict))
 
             # Get FlightInfo (here we need just the Endpoints)
             try:


### PR DESCRIPTION
This PR refers to **(does not resolve)**  issue #95 by properly handling optional timestamp parameters in time-windowed queries for both sequence and topic data streaming.

## Problem
Previously, timestamp parameters (`timestamp_ns_start` and `timestamp_ns_end`) were unconditionally included in API commands, sending `null` values to the server when the user didn't specify time filters. This could cause unexpected behavior or server-side validation errors.

## Solution
- **Conditional parameter building**: Modified `SequenceDataStreamer.connect()` and `TopicHandler.get_data_streamer()` to only include timestamp parameters in the command dictionary when they are explicitly provided (not `None`)
- **Improved testing**: Enhanced test coverage with additional scenarios for partial time ranges (from/to middle of sequence) alongside existing full-range tests
- **Code quality**: Fixed test function naming, docstrings, and formatting for consistency

## Changes
- sequence_reader.py: Conditional timestamp dict building in `connect()` method
- topic_handler.py: Conditional timestamp dict building in `get_data_streamer()` method  
- test_stream_timerange.py: Updated type hints, added new test cases, improved documentation

## Testing
Tests do not pass due to server inconsistent management of partial timestamp range

The PR is compliant with `CONTRIBUTING.md` and `IP.md` policies
