### PR TITLE
Fix TimestampRange logic and expand test coverage

### DIFF
--- a/mosaicod/src/marshal/flight.rs
+++ b/mosaicod/src/marshal/flight.rs
@@ -112,3 +112,87 @@ pub fn ticket_topic_from_binary(v: &[u8]) -> Result<types::flight::TicketTopic, 
 
     Ok(ticket.into())
 }
+
+#[cfg(test)]
+mod tests {
+
+    use crate::types;
+
+    /// Check that the conversion between [`super::GetFlightInfoCmd`] and
+    /// [`types::flight::GetFlightInfoCmd`] is correct from a fully bounded info message.
+    #[test]
+    fn get_flight_info_cmd_to_types_full() {
+        let src = super::GetFlightInfoCmd {
+            resource_locator: "test_sequence/topic/a".to_owned(),
+            timestamp_ns_start: Some(100000),
+            timestamp_ns_end: Some(110000),
+        };
+
+        let name = src.resource_locator.clone();
+        let start = src.timestamp_ns_start.unwrap();
+        let end = src.timestamp_ns_end.unwrap();
+
+        let dest: types::flight::GetFlightInfoCmd = src.into();
+
+        assert_eq!(dest.resource_locator, name);
+        assert_eq!(dest.timestamp_range.as_ref().unwrap().start.as_i64(), start);
+        assert_eq!(dest.timestamp_range.as_ref().unwrap().end.as_i64(), end);
+    }
+
+    /// Check that the conversion between [`super::GetFlightInfoCmd`] and
+    /// [`types::flight::GetFlightInfoCmd`] is correct from a lower bounded info message.
+    #[test]
+    fn get_flight_info_cmd_to_types_lb() {
+        let src = super::GetFlightInfoCmd {
+            resource_locator: "test_sequence/topic/a".to_owned(),
+            timestamp_ns_start: Some(100000),
+            timestamp_ns_end: None,
+        };
+
+        let name = src.resource_locator.clone();
+        let start = src.timestamp_ns_start.unwrap();
+
+        let dest: types::flight::GetFlightInfoCmd = src.into();
+
+        assert_eq!(dest.resource_locator, name);
+        assert_eq!(dest.timestamp_range.as_ref().unwrap().start.as_i64(), start);
+        assert!(dest.timestamp_range.as_ref().unwrap().end.is_unbounded());
+    }
+
+    /// Check that the conversion between [`super::GetFlightInfoCmd`] and
+    /// [`types::flight::GetFlightInfoCmd`] is correct from a upper bounded info message.
+    #[test]
+    fn get_flight_info_cmd_to_types_ub() {
+        let src = super::GetFlightInfoCmd {
+            resource_locator: "test_sequence/topic/a".to_owned(),
+            timestamp_ns_start: None,
+            timestamp_ns_end: Some(110000),
+        };
+
+        let name = src.resource_locator.clone();
+        let end = src.timestamp_ns_end.unwrap();
+
+        let dest: types::flight::GetFlightInfoCmd = src.into();
+
+        assert_eq!(dest.resource_locator, name);
+        assert!(dest.timestamp_range.as_ref().unwrap().start.is_unbounded());
+        assert_eq!(dest.timestamp_range.as_ref().unwrap().end.as_i64(), end);
+    }
+
+    /// Check that the conversion between [`super::GetFlightInfoCmd`] and
+    /// [`types::flight::GetFlightInfoCmd`] is correct from a message without timestamp.
+    #[test]
+    fn get_flight_info_cmd_to_types_no_bounds() {
+        let src = super::GetFlightInfoCmd {
+            resource_locator: "test_sequence/topic/a".to_owned(),
+            timestamp_ns_start: None,
+            timestamp_ns_end: None,
+        };
+
+        let name = src.resource_locator.clone();
+        let dest: types::flight::GetFlightInfoCmd = src.into();
+
+        assert_eq!(dest.resource_locator, name);
+        assert!(dest.timestamp_range.is_none());
+    }
+}

--- a/mosaicod/src/types/flight.rs
+++ b/mosaicod/src/types/flight.rs
@@ -2,19 +2,19 @@ use crate::types::TimestampRange;
 
 /// Message used to initiate the flight communication to upload a new datastream
 pub struct DoPutCmd {
-    pub resource_locator: String,
+    pub resource_locator: String, //(cabba) TODO: replace this with a resource locator
     pub key: String,
 }
 
 /// Request info on a mosaico resource (topic or sequence)
 pub struct GetFlightInfoCmd {
-    pub resource_locator: String,
+    pub resource_locator: String, //(cabba) TODO: replace this with a resource locator
     pub timestamp_range: Option<TimestampRange>,
 }
 
 pub struct TicketTopic {
     /// Locator for the topic
-    pub locator: String,
+    pub locator: String, //(cabba) TODO: replace this with a resource locator
     /// Optional timestamp range used to limit the data stream
     pub timestamp_range: Option<TimestampRange>,
 }

--- a/mosaicod/src/types/time.rs
+++ b/mosaicod/src/types/time.rs
@@ -115,7 +115,12 @@ impl TimestampRange {
 
     /// Returns true is both start and end are unbounded timestamps
     pub fn is_unbounded(&self) -> bool {
-        self.start.is_unbounded() || self.end.is_unbounded()
+        self.start.is_unbounded() && self.end.is_unbounded()
+    }
+
+    /// Check if the timestamp range if empty (i.e. start >= end)
+    pub fn is_empty(&self) -> bool {
+        self.start >= self.end
     }
 }
 
@@ -155,7 +160,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn timestamp() {
+    fn timestamp_bounds_check() {
         let ub_pos = Timestamp::unbounded_pos();
         let ub_neg = Timestamp::unbounded_neg();
         let ts: Timestamp = 1234567.into();
@@ -169,5 +174,52 @@ mod tests {
         assert!(!ts.is_unbounded());
         assert!(!ts.is_unbounded_pos());
         assert!(!ts.is_unbounded_neg());
+    }
+
+    #[test]
+    fn timestamp_range_bounds_check() {
+        let lb = 10000;
+        let ub = 11000;
+
+        let ts_lb_ub = TimestampRange::between(lb.into(), ub.into());
+        assert!(!ts_lb_ub.is_unbounded());
+
+        let ts_ub = TimestampRange::ending_at(lb.into());
+        assert!(!ts_ub.is_unbounded());
+
+        let ts_ub_2 = TimestampRange::between(Timestamp::unbounded_neg(), ub.into());
+        assert!(!ts_ub_2.is_unbounded());
+
+        let ts_lb = TimestampRange::starting_at(lb.into());
+        assert!(!ts_lb.is_unbounded());
+
+        let ts_lb_2 = TimestampRange::between(ub.into(), Timestamp::unbounded_pos());
+        assert!(!ts_lb_2.is_unbounded());
+
+        let ts_unbounded =
+            TimestampRange::between(Timestamp::unbounded_neg(), Timestamp::unbounded_pos());
+        assert!(ts_unbounded.is_unbounded());
+
+        let ts_unbounded = TimestampRange::starting_at(Timestamp::unbounded_pos());
+        assert!(ts_unbounded.is_unbounded());
+
+        let ts_unbounded = TimestampRange::ending_at(Timestamp::unbounded_neg());
+        assert!(ts_unbounded.is_unbounded());
+    }
+
+    #[test]
+    fn timestamp_range_empty() {
+        let ts_empty = TimestampRange::between(11000.into(), 10000.into());
+        assert!(ts_empty.is_empty());
+
+        let ts_empty = TimestampRange::between(11000.into(), Timestamp::unbounded_neg());
+        assert!(ts_empty.is_empty());
+
+        let ts_empty = TimestampRange::between(Timestamp::unbounded_pos(), 1000.into());
+        assert!(ts_empty.is_empty());
+
+        let ts_empty =
+            TimestampRange::between(Timestamp::unbounded_pos(), Timestamp::unbounded_neg());
+        assert!(ts_empty.is_empty());
     }
 }


### PR DESCRIPTION
- Fix `TimestampRange::is_unbounded` to require both start and end to be unbounded.
- Implement `TimestampRange::is_empty` utility.
- Add unit tests for timestamp bounds and flight info marshaling.
- Annotate `resource_locator` fields with TODOs in flight types.

Closes #95
