### PR TITLE
feat(mosaicod): implement transactional outbox pattern for S3 uploads

### DIFF
--- a/mosaicod/Cargo.lock
+++ b/mosaicod/Cargo.lock
@@ -3715,6 +3715,7 @@ checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -3791,6 +3792,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest",
  "dotenvy",
@@ -3833,6 +3835,7 @@ dependencies = [
  "base64",
  "bitflags",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -3868,6 +3871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",

--- a/mosaicod/Cargo.toml
+++ b/mosaicod/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.9.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 signal-hook = "0.3.18"
-sqlx = { version = "0.8.6", features = ["postgres", "macros", "runtime-tokio", "uuid", "json"] }
+sqlx = { version = "0.8.6", features = ["postgres", "macros", "runtime-tokio", "uuid", "json", "chrono"] }
 thiserror = "2.0.16"
 tokio = { version = "1.47.1", features = ["rt-multi-thread"] }
 tonic = "0.13.1"

--- a/mosaicod/migrations/20260119100000_chunks_outbox.sql
+++ b/mosaicod/migrations/20260119100000_chunks_outbox.sql
@@ -1,0 +1,27 @@
+-- Outbox table for transactional chunk upload to S3
+-- This table temporarily stores parquet data until it's successfully written to S3
+
+CREATE TABLE chunks_outbox (
+    outbox_id SERIAL PRIMARY KEY,
+    -- Reference to the chunk being uploaded (inserted in same transaction)
+    chunk_id INTEGER NOT NULL REFERENCES chunk_t(chunk_id) ON DELETE CASCADE,
+    -- S3 path where the parquet file should be written
+    s3_path TEXT NOT NULL,
+    -- Parquet data bytes (temporary storage until S3 write succeeds)
+    -- NULL after processing to free storage
+    parquet_data BYTEA,
+    -- Timestamps for tracking
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    processed_at TIMESTAMPTZ NULL,
+    -- Error tracking for failed attempts
+    error_message TEXT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0
+);
+
+-- Index for efficient polling of pending entries
+CREATE INDEX idx_chunks_outbox_pending ON chunks_outbox (created_at)
+    WHERE processed_at IS NULL;
+
+-- Index for cleanup of processed entries
+CREATE INDEX idx_chunks_outbox_processed ON chunks_outbox (processed_at)
+    WHERE processed_at IS NOT NULL;

--- a/mosaicod/src/params.rs
+++ b/mosaicod/src/params.rs
@@ -48,6 +48,12 @@ pub struct ConfigurablesParams {
     /// When a chunk exceeds this size, it is finalized and a new chunk is started.
     /// A value of 0 means unlimited (no automatic splitting).
     pub max_chunk_size_in_bytes: usize,
+    /// Outbox worker poll interval in milliseconds
+    pub outbox_poll_interval_ms: u64,
+    /// Outbox worker batch size (entries processed per poll)
+    pub outbox_batch_size: usize,
+    /// Maximum retries for failed outbox entries
+    pub outbox_max_retries: usize,
 }
 
 static ENV: OnceLock<ConfigurablesParams> = OnceLock::new();
@@ -72,6 +78,9 @@ pub fn load_configurables_from_env() {
             "MOSAICO_MAX_CHUNK_SIZE_IN_BYTES",
             256 * 1024 * 1024, // 256 MiB default
         ),
+        outbox_poll_interval_ms: cast_env_var("MOSAICO_OUTBOX_POLL_INTERVAL_MS", 100),
+        outbox_batch_size: cast_env_var("MOSAICO_OUTBOX_BATCH_SIZE", 50),
+        outbox_max_retries: cast_env_var("MOSAICO_OUTBOX_MAX_RETRIES", 5),
     };
 
     let _ = ENV.set(ev);

--- a/mosaicod/src/repo/mod.rs
+++ b/mosaicod/src/repo/mod.rs
@@ -10,6 +10,18 @@ pub use facades::*;
 // operations remain encapsulated within the facade layer.
 pub use sql_models::{get_resource_locator_from_name, layer_bootstrap, sequence_find_all};
 
+// Chunk-related exports for do_put.rs transactional outbox pattern
+pub use sql_models::{
+    Chunk, ColumnChunkLiteral, ColumnChunkNumeric, chunk_create, column_chunk_literal_create_batch,
+    column_chunk_numeric_create_batch, column_get_or_create,
+};
+
+// Outbox-related exports for the background worker
+pub use sql_models::{
+    ChunkOutboxEntry, outbox_cleanup_processed, outbox_count_pending, outbox_create,
+    outbox_fetch_pending, outbox_mark_failed, outbox_mark_processed,
+};
+
 mod error;
 pub use error::Error;
 
@@ -20,3 +32,7 @@ pub use core::testing;
 
 mod sql_models;
 use sql_models::*;
+
+// Test-only exports for outbox edge-case tests
+#[cfg(test)]
+pub use sql_models::{SequenceRecord, TopicRecord, sequence_create, topic_create};

--- a/mosaicod/src/repo/sql_models/mod.rs
+++ b/mosaicod/src/repo/sql_models/mod.rs
@@ -9,6 +9,9 @@ pub use layers::*;
 mod notifies;
 pub use notifies::*;
 
+mod outbox;
+pub use outbox::*;
+
 mod sequence_record;
 pub use sequence_record::*;
 

--- a/mosaicod/src/repo/sql_models/outbox.rs
+++ b/mosaicod/src/repo/sql_models/outbox.rs
@@ -1,0 +1,33 @@
+use chrono::{DateTime, Utc};
+
+/// Entry in the chunks outbox table.
+///
+/// Represents a pending chunk upload to S3. The parquet data is temporarily
+/// stored here until the background worker successfully writes it to S3.
+#[derive(Debug)]
+pub struct ChunkOutboxEntry {
+    pub outbox_id: i32,
+    pub chunk_id: i32,
+    pub s3_path: String,
+    pub parquet_data: Vec<u8>,
+    pub created_at: DateTime<Utc>,
+    pub processed_at: Option<DateTime<Utc>>,
+    pub error_message: Option<String>,
+    pub retry_count: i32,
+}
+
+impl ChunkOutboxEntry {
+    /// Creates a new outbox entry for a chunk upload.
+    pub fn new(chunk_id: i32, s3_path: impl AsRef<std::path::Path>, parquet_data: Vec<u8>) -> Self {
+        Self {
+            outbox_id: crate::repo::UNREGISTERED,
+            chunk_id,
+            s3_path: s3_path.as_ref().to_string_lossy().to_string(),
+            parquet_data,
+            created_at: Utc::now(),
+            processed_at: None,
+            error_message: None,
+            retry_count: 0,
+        }
+    }
+}

--- a/mosaicod/src/repo/sql_models/pg_queries/mod.rs
+++ b/mosaicod/src/repo/sql_models/pg_queries/mod.rs
@@ -19,6 +19,9 @@ pub use layers::*;
 mod group;
 pub use group::*;
 
+mod outbox;
+pub use outbox::*;
+
 mod compilers;
 use compilers::*;
 

--- a/mosaicod/src/repo/sql_models/pg_queries/outbox.rs
+++ b/mosaicod/src/repo/sql_models/pg_queries/outbox.rs
@@ -1,0 +1,144 @@
+use crate::repo::{self, sql_models};
+use sqlx::Row;
+
+/// Inserts a new entry into the chunks outbox table.
+pub async fn outbox_create(
+    exec: &mut impl repo::AsExec,
+    entry: &sql_models::ChunkOutboxEntry,
+) -> Result<sql_models::ChunkOutboxEntry, repo::Error> {
+    let row = sqlx::query(
+        r#"INSERT INTO chunks_outbox (chunk_id, s3_path, parquet_data)
+        VALUES ($1, $2, $3)
+        RETURNING
+            outbox_id,
+            chunk_id,
+            s3_path,
+            parquet_data,
+            created_at,
+            processed_at,
+            error_message,
+            retry_count"#,
+    )
+    .bind(entry.chunk_id)
+    .bind(&entry.s3_path)
+    .bind(&entry.parquet_data)
+    .fetch_one(exec.as_exec())
+    .await?;
+
+    Ok(sql_models::ChunkOutboxEntry {
+        outbox_id: row.try_get("outbox_id")?,
+        chunk_id: row.try_get("chunk_id")?,
+        s3_path: row.try_get("s3_path")?,
+        parquet_data: row.try_get("parquet_data")?,
+        created_at: row.try_get("created_at")?,
+        processed_at: row.try_get("processed_at")?,
+        error_message: row.try_get("error_message")?,
+        retry_count: row.try_get("retry_count")?,
+    })
+}
+
+/// Fetches pending outbox entries for processing.
+/// Uses `FOR UPDATE SKIP LOCKED` to allow concurrent workers safely.
+pub async fn outbox_fetch_pending(
+    exec: &mut impl repo::AsExec,
+    batch_size: i32,
+    max_retries: i32,
+) -> Result<Vec<sql_models::ChunkOutboxEntry>, repo::Error> {
+    let rows = sqlx::query(
+        r#"SELECT
+            outbox_id,
+            chunk_id,
+            s3_path,
+            parquet_data,
+            created_at,
+            processed_at,
+            error_message,
+            retry_count
+        FROM chunks_outbox
+        WHERE processed_at IS NULL
+          AND retry_count < $2
+        ORDER BY created_at
+        LIMIT $1
+        FOR UPDATE SKIP LOCKED"#,
+    )
+    .bind(batch_size)
+    .bind(max_retries)
+    .fetch_all(exec.as_exec())
+    .await?;
+
+    let mut entries = Vec::with_capacity(rows.len());
+    for row in rows {
+        entries.push(sql_models::ChunkOutboxEntry {
+            outbox_id: row.try_get("outbox_id")?,
+            chunk_id: row.try_get("chunk_id")?,
+            s3_path: row.try_get("s3_path")?,
+            parquet_data: row.try_get("parquet_data")?,
+            created_at: row.try_get("created_at")?,
+            processed_at: row.try_get("processed_at")?,
+            error_message: row.try_get("error_message")?,
+            retry_count: row.try_get("retry_count")?,
+        });
+    }
+    Ok(entries)
+}
+
+/// Marks an outbox entry as successfully processed.
+/// Clears the parquet_data to free up storage.
+pub async fn outbox_mark_processed(
+    exec: &mut impl repo::AsExec,
+    outbox_id: i32,
+) -> Result<(), repo::Error> {
+    sqlx::query(
+        r#"UPDATE chunks_outbox
+        SET processed_at = NOW(), parquet_data = NULL
+        WHERE outbox_id = $1"#,
+    )
+    .bind(outbox_id)
+    .execute(exec.as_exec())
+    .await?;
+    Ok(())
+}
+
+/// Records a failed processing attempt with error message.
+pub async fn outbox_mark_failed(
+    exec: &mut impl repo::AsExec,
+    outbox_id: i32,
+    error_message: &str,
+) -> Result<(), repo::Error> {
+    sqlx::query(
+        r#"UPDATE chunks_outbox
+        SET retry_count = retry_count + 1, error_message = $2
+        WHERE outbox_id = $1"#,
+    )
+    .bind(outbox_id)
+    .bind(error_message)
+    .execute(exec.as_exec())
+    .await?;
+    Ok(())
+}
+
+/// Deletes old processed entries for cleanup.
+/// Returns the number of deleted entries.
+pub async fn outbox_cleanup_processed(
+    exec: &mut impl repo::AsExec,
+    older_than_hours: i32,
+) -> Result<u64, repo::Error> {
+    let result = sqlx::query(
+        r#"DELETE FROM chunks_outbox
+        WHERE processed_at IS NOT NULL
+          AND processed_at < NOW() - ($1 || ' hours')::INTERVAL"#,
+    )
+    .bind(older_than_hours.to_string())
+    .execute(exec.as_exec())
+    .await?;
+    Ok(result.rows_affected())
+}
+
+/// Returns the count of pending (unprocessed) outbox entries.
+pub async fn outbox_count_pending(exec: &mut impl repo::AsExec) -> Result<i64, repo::Error> {
+    let row =
+        sqlx::query(r#"SELECT COUNT(*) as count FROM chunks_outbox WHERE processed_at IS NULL"#)
+            .fetch_one(exec.as_exec())
+            .await?;
+    Ok(row.try_get("count")?)
+}

--- a/mosaicod/src/rw/chunked_writer.rs
+++ b/mosaicod/src/rw/chunked_writer.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 
 use arrow::array::RecordBatch;
+use bytes::Bytes;
 use log::{debug, trace};
 
 use crate::{traits, types};
@@ -10,10 +11,13 @@ use super::Error;
 use super::Format;
 use super::chunk_writer::{ChunkMetadata, ChunkWriter};
 
-/// Callback called just before file serialization
+/// Callback called when a chunk is finalized.
+/// Receives the path, parquet bytes, column stats, and metadata.
+/// The callback is responsible for persisting both metadata and data atomically.
 type OnChunkCallback = Box<
     dyn Fn(
             std::path::PathBuf,
+            Bytes,
             types::ColumnsStats,
             ChunkMetadata,
         ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send>>
@@ -37,6 +41,12 @@ pub struct ChunkedWriter<'a, W> {
     /// When the chunk-size constraint is reached, a new writer will be created.
     writer: Option<ChunkWriter>,
     format: Format,
+    /// NOTE: This field is currently unused (S3 writes are handled via outbox pattern),
+    /// but kept for API compatibility and the generic parameter constraint.
+    #[expect(
+        dead_code,
+        reason = "kept for API compatibility with generic parameter W"
+    )]
     write_target: &'a W,
     /// Target path where the data will be serialized (e.g., `my/target/path`).
     ///
@@ -92,18 +102,26 @@ impl<'a, W> ChunkedWriter<'a, W> {
         self
     }
 
-    /// Sets a callback function that will be called every time a chunk is produced just before
-    /// serialization.
+    /// Sets a callback function that will be called every time a chunk is produced.
+    ///
+    /// The callback receives:
+    /// - `path`: The target path where the data should be stored
+    /// - `bytes`: The parquet data bytes
+    /// - `stats`: Column statistics for the chunk
+    /// - `metadata`: Chunk metadata (size, row count)
+    ///
+    /// The callback is responsible for persisting both metadata to the database
+    /// and data to storage atomically (via the outbox pattern).
     pub fn on_chunk_created<F1, Fut>(mut self, clbk: F1) -> Self
     where
-        F1: Fn(std::path::PathBuf, types::ColumnsStats, ChunkMetadata) -> Fut
+        F1: Fn(std::path::PathBuf, Bytes, types::ColumnsStats, ChunkMetadata) -> Fut
             + Send
             + Sync
             + 'static,
         Fut: Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'static,
     {
-        let wrapped = move |path, stats, metadata| {
-            let fut = clbk(path, stats, metadata);
+        let wrapped = move |path, bytes, stats, metadata| {
+            let fut = clbk(path, bytes, stats, metadata);
             Box::pin(fut)
                 as Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send>>
         };
@@ -151,9 +169,7 @@ impl<'a, W> ChunkedWriter<'a, W> {
             if current_size >= max {
                 trace!(
                     "chunk size {} bytes exceeds max {} bytes, auto-finalizing chunk {}",
-                    current_size,
-                    max,
-                    self.chunk_serialized_number
+                    current_size, max, self.chunk_serialized_number
                 );
 
                 // Put the writer back for finalize() to consume it
@@ -172,14 +188,11 @@ impl<'a, W> ChunkedWriter<'a, W> {
 
     /// Finalizes any pending reading, writing operation.
     ///
-    /// It is important to call this method to ensure that an open chunk is properly finalized
-    /// and written.
-    pub async fn finalize(&mut self) -> Result<(), Error>
-    where
-        W: traits::AsyncWriteToPath,
-    {
+    /// It is important to call this method to ensure that an open chunk is properly finalized.
+    /// The callback is responsible for persisting both metadata and data via the outbox pattern.
+    pub async fn finalize(&mut self) -> Result<(), Error> {
         // Calling this function will "consume" the current writer.
-        // If another write_batch willl be called after this function call
+        // If another write_batch will be called after this function call
         // will cause the instantiation of another writer.
         if let Some(writer) = self.writer.take() {
             let path =
@@ -191,19 +204,23 @@ impl<'a, W> ChunkedWriter<'a, W> {
                 .await
                 .map_err(|e| Error::SpawnBlockingError(e.to_string()))??;
 
-            self.write_target.write_to_path(&path, buffer).await?;
+            // Convert buffer to Bytes for the callback
+            let bytes: Bytes = buffer.into();
 
             trace!(
                 "on_chunk_created_clbk present: {}",
                 self.on_chunk_created_clbk.is_some()
             );
 
+            // Call the callback with path, bytes, stats, and metadata
+            // The callback is responsible for atomically persisting metadata to DB
+            // and data to the outbox for eventual S3 upload
             return self
                 .on_chunk_created_clbk
                 .as_ref()
                 .map(async move |clbk| {
                     debug!("calling chunk serialization callback");
-                    return clbk(path, stats, metadata).await;
+                    clbk(path, bytes, stats, metadata).await
                 })
                 .unwrap()
                 .await
@@ -218,33 +235,22 @@ mod tests {
     use super::*;
     use arrow::array::{ArrayRef, BinaryArray, Int64Array};
     use arrow::datatypes::{Field, Schema};
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
-    /// Mock store that counts write operations
-    struct MockStore {
-        write_count: Arc<AtomicUsize>,
-    }
+    /// Dummy store type (no longer used for writes, but needed for generic parameter)
+    struct DummyStore;
 
-    impl MockStore {
-        fn new() -> Self {
-            Self {
-                write_count: Arc::new(AtomicUsize::new(0)),
-            }
-        }
-
-        fn get_write_count(&self) -> usize {
-            self.write_count.load(Ordering::SeqCst)
-        }
-    }
-
-    impl traits::AsyncWriteToPath for MockStore {
+    impl traits::AsyncWriteToPath for DummyStore {
+        #[expect(
+            clippy::manual_async_fn,
+            reason = "trait requires impl Future return type"
+        )]
         fn write_to_path(
             &self,
             _path: impl AsRef<std::path::Path>,
             _buf: impl Into<bytes::Bytes>,
         ) -> impl Future<Output = std::io::Result<()>> {
-            self.write_count.fetch_add(1, Ordering::SeqCst);
             async { Ok(()) }
         }
     }
@@ -275,14 +281,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_auto_split_creates_multiple_chunks() {
-        let store = MockStore::new();
+        let store = DummyStore;
+        let chunk_count = Arc::new(AtomicUsize::new(0));
+        let chunk_count_clone = chunk_count.clone();
 
         // Use a small max_chunk_size to trigger splitting
-        let mut writer = ChunkedWriter::new(&store, "test/path", Format::Default, |path, _, idx| {
-            path.join(format!("chunk_{}.parquet", idx))
-        })
-        .with_max_chunk_size(Some(1024)) // 1 KiB threshold
-        .on_chunk_created(|_, _, _| async { Ok(()) });
+        let mut writer =
+            ChunkedWriter::new(&store, "test/path", Format::Default, |path, _, idx| {
+                path.join(format!("chunk_{}.parquet", idx))
+            })
+            .with_max_chunk_size(Some(1024)) // 1 KiB threshold
+            .on_chunk_created(move |_, _bytes, _, _| {
+                chunk_count_clone.fetch_add(1, Ordering::SeqCst);
+                async { Ok(()) }
+            });
 
         // Write multiple batches with enough data to exceed threshold multiple times
         // Each batch ~500 bytes of binary data + overhead
@@ -295,24 +307,30 @@ mod tests {
         writer.finalize().await.expect("Finalize failed");
 
         // Should have created multiple chunks due to auto-split
-        let chunk_count = store.get_write_count();
+        let count = chunk_count.load(Ordering::SeqCst);
         assert!(
-            chunk_count > 1,
+            count > 1,
             "Expected multiple chunks due to auto-split, got {}",
-            chunk_count
+            count
         );
     }
 
     #[tokio::test]
     async fn test_no_split_when_under_threshold() {
-        let store = MockStore::new();
+        let store = DummyStore;
+        let chunk_count = Arc::new(AtomicUsize::new(0));
+        let chunk_count_clone = chunk_count.clone();
 
         // Use a large max_chunk_size that won't be exceeded
-        let mut writer = ChunkedWriter::new(&store, "test/path", Format::Default, |path, _, idx| {
-            path.join(format!("chunk_{}.parquet", idx))
-        })
-        .with_max_chunk_size(Some(100 * 1024 * 1024)) // 100 MiB threshold
-        .on_chunk_created(|_, _, _| async { Ok(()) });
+        let mut writer =
+            ChunkedWriter::new(&store, "test/path", Format::Default, |path, _, idx| {
+                path.join(format!("chunk_{}.parquet", idx))
+            })
+            .with_max_chunk_size(Some(100 * 1024 * 1024)) // 100 MiB threshold
+            .on_chunk_created(move |_, _bytes, _, _| {
+                chunk_count_clone.fetch_add(1, Ordering::SeqCst);
+                async { Ok(()) }
+            });
 
         // Write small batches
         for _ in 0..5 {
@@ -324,7 +342,7 @@ mod tests {
 
         // Should have created only one chunk
         assert_eq!(
-            store.get_write_count(),
+            chunk_count.load(Ordering::SeqCst),
             1,
             "Expected single chunk when under threshold"
         );
@@ -332,14 +350,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_unlimited_creates_single_chunk() {
-        let store = MockStore::new();
+        let store = DummyStore;
+        let chunk_count = Arc::new(AtomicUsize::new(0));
+        let chunk_count_clone = chunk_count.clone();
 
         // No max_chunk_size (unlimited)
-        let mut writer = ChunkedWriter::new(&store, "test/path", Format::Default, |path, _, idx| {
-            path.join(format!("chunk_{}.parquet", idx))
-        })
-        .with_max_chunk_size(None) // Unlimited
-        .on_chunk_created(|_, _, _| async { Ok(()) });
+        let mut writer =
+            ChunkedWriter::new(&store, "test/path", Format::Default, |path, _, idx| {
+                path.join(format!("chunk_{}.parquet", idx))
+            })
+            .with_max_chunk_size(None) // Unlimited
+            .on_chunk_created(move |_, _bytes, _, _| {
+                chunk_count_clone.fetch_add(1, Ordering::SeqCst);
+                async { Ok(()) }
+            });
 
         // Write many batches
         for _ in 0..20 {
@@ -351,7 +375,7 @@ mod tests {
 
         // Should have created only one chunk (no auto-split)
         assert_eq!(
-            store.get_write_count(),
+            chunk_count.load(Ordering::SeqCst),
             1,
             "Expected single chunk with unlimited size"
         );
@@ -359,16 +383,22 @@ mod tests {
 
     #[tokio::test]
     async fn test_large_data_auto_split() {
-        let store = MockStore::new();
+        let store = DummyStore;
+        let chunk_count = Arc::new(AtomicUsize::new(0));
+        let chunk_count_clone = chunk_count.clone();
 
         // 5 MiB threshold - large enough to fit multiple batches
         let max_chunk_size = 5 * 1024 * 1024;
 
-        let mut writer = ChunkedWriter::new(&store, "test/path", Format::Default, |path, _, idx| {
-            path.join(format!("chunk_{}.parquet", idx))
-        })
-        .with_max_chunk_size(Some(max_chunk_size))
-        .on_chunk_created(|_, _, _| async { Ok(()) });
+        let mut writer =
+            ChunkedWriter::new(&store, "test/path", Format::Default, |path, _, idx| {
+                path.join(format!("chunk_{}.parquet", idx))
+            })
+            .with_max_chunk_size(Some(max_chunk_size))
+            .on_chunk_created(move |_, _bytes, _, _| {
+                chunk_count_clone.fetch_add(1, Ordering::SeqCst);
+                async { Ok(()) }
+            });
 
         // Write 10 batches of ~1 MiB each (10 rows * 100KB random blob)
         // Random data doesn't compress, so total ~10 MiB
@@ -384,36 +414,42 @@ mod tests {
 
         writer.finalize().await.expect("Finalize failed");
 
-        let chunk_count = store.get_write_count();
+        let count = chunk_count.load(Ordering::SeqCst);
 
         // With ~1 MiB per batch (random data) and 5 MiB threshold:
         // Expect multiple chunks (exact count depends on Parquet overhead)
         assert!(
-            chunk_count >= 2,
+            count >= 2,
             "Expected at least 2 chunks for ~10 MiB data with 5 MiB threshold, got {}",
-            chunk_count
+            count
         );
 
         println!(
             "Large data test: wrote ~{} MiB of random data in {} chunks (threshold: {} MiB)",
             (rows_per_batch * blob_size * num_batches) / (1024 * 1024),
-            chunk_count,
+            count,
             max_chunk_size / (1024 * 1024)
         );
     }
 
     #[tokio::test]
     async fn test_single_large_batch_exceeds_threshold() {
-        let store = MockStore::new();
+        let store = DummyStore;
+        let chunk_count = Arc::new(AtomicUsize::new(0));
+        let chunk_count_clone = chunk_count.clone();
 
         // 512 KiB threshold
         let max_chunk_size = 512 * 1024;
 
-        let mut writer = ChunkedWriter::new(&store, "test/path", Format::Default, |path, _, idx| {
-            path.join(format!("chunk_{}.parquet", idx))
-        })
-        .with_max_chunk_size(Some(max_chunk_size))
-        .on_chunk_created(|_, _, _| async { Ok(()) });
+        let mut writer =
+            ChunkedWriter::new(&store, "test/path", Format::Default, |path, _, idx| {
+                path.join(format!("chunk_{}.parquet", idx))
+            })
+            .with_max_chunk_size(Some(max_chunk_size))
+            .on_chunk_created(move |_, _bytes, _, _| {
+                chunk_count_clone.fetch_add(1, Ordering::SeqCst);
+                async { Ok(()) }
+            });
 
         // Write a single batch that exceeds the threshold (~1 MiB)
         // This tests that we handle the case where a single batch > max_chunk_size
@@ -424,7 +460,7 @@ mod tests {
 
         // Should still create exactly 1 chunk (can't split a single batch)
         assert_eq!(
-            store.get_write_count(),
+            chunk_count.load(Ordering::SeqCst),
             1,
             "Single batch exceeding threshold should still create 1 chunk"
         );

--- a/mosaicod/src/server/core.rs
+++ b/mosaicod/src/server/core.rs
@@ -6,6 +6,7 @@ use tokio::sync::Notify;
 use crate::{repo, store};
 
 use super::flight;
+use super::outbox::{OutboxConfig, OutboxWorker};
 
 /// Mosaico server.
 /// Handles incoming requests and manages the repository and store.
@@ -79,6 +80,10 @@ impl Server {
         })?;
 
         let store = self.store.clone();
+        let outbox_store = self.store.clone();
+        let outbox_repo = repo.clone();
+        let outbox_shutdown = self.shutdown.clone();
+
         rt.block_on(async {
             // Create a thread in tokio runtime to handle flight requests
             let handle_flight = rt.spawn(async move {
@@ -88,9 +93,16 @@ impl Server {
                 }
             });
 
+            // Spawn the outbox worker for processing S3 uploads
+            let handle_outbox = rt.spawn(async move {
+                let config = OutboxConfig::from_env();
+                let worker = OutboxWorker::new(outbox_store, outbox_repo, outbox_shutdown, config);
+                worker.run().await;
+            });
+
             on_start();
 
-            let _ = tokio::join!(handle_flight);
+            let _ = tokio::join!(handle_flight, handle_outbox);
         });
 
         info!("stopped");

--- a/mosaicod/src/server/endpoints/do_put.rs
+++ b/mosaicod/src/server/endpoints/do_put.rs
@@ -1,3 +1,5 @@
+use bytes::Bytes;
+
 use crate::marshal;
 use crate::{repo, rw, server::errors::ServerError, store, types};
 use arrow::datatypes::SchemaRef;
@@ -92,7 +94,7 @@ async fn do_put_topic_data(
     let topic_id = r_id.id;
 
     let mut writer = handle.writer(serialization_format).on_chunk_created(
-        move |target_path, cols_stats, chunk_metadata| {
+        move |target_path, parquet_bytes, cols_stats, chunk_metadata| {
             let topic_id = topic_id;
             let repo_clone = repo.clone();
             let ontology_tag = ontology_tag.clone();
@@ -109,6 +111,7 @@ async fn do_put_topic_data(
                     topic_id,
                     &ontology_tag,
                     target_path,
+                    parquet_bytes,
                     cols_stats,
                     chunk_metadata,
                 )
@@ -153,27 +156,90 @@ async fn do_put_topic_data(
     Ok(())
 }
 
+/// Creates chunk metadata and inserts parquet data into the outbox atomically.
+///
+/// This implements the transactional outbox pattern:
+/// 1. Creates chunk metadata in the database
+/// 2. Inserts column statistics
+/// 3. Inserts parquet bytes into the outbox for background S3 upload
+///
+/// All operations are performed in a single transaction, ensuring no orphan files.
 async fn on_chunk_created(
     repo: repo::Repository,
     topic_id: i32,
     ontology_tag: &str,
     target_path: impl AsRef<std::path::Path>,
+    parquet_bytes: Bytes,
     cstats: types::ColumnsStats,
     chunk_metadata: rw::ChunkMetadata,
 ) -> Result<(), ServerError> {
-    let mut handle = repo::FacadeChunk::create(
-        topic_id,
-        &target_path,
-        chunk_metadata.size_bytes as i64,
-        chunk_metadata.row_count as i64,
-        &repo,
+    let mut tx = repo.transaction().await?;
+
+    // 1. Create chunk record
+    let chunk = repo::chunk_create(
+        &mut tx,
+        &repo::Chunk::new(
+            topic_id,
+            &target_path,
+            chunk_metadata.size_bytes as i64,
+            chunk_metadata.row_count as i64,
+        ),
     )
     .await?;
 
-    // Use batch insert for better performance (single INSERT per type instead of N)
-    handle.push_all_stats(ontology_tag, cstats).await?;
+    // 2. Insert column statistics
+    // Collect all stats and batch insert them
+    let mut numeric_batch: Vec<repo::ColumnChunkNumeric> = Vec::new();
+    let mut literal_batch: Vec<repo::ColumnChunkLiteral> = Vec::new();
 
-    handle.finalize().await?;
+    for (field, stats) in cstats.stats {
+        if stats.is_unsupported() {
+            continue;
+        }
+
+        let column = repo::column_get_or_create(&mut tx, &field, ontology_tag).await?;
+
+        match stats {
+            types::Stats::Text(stats) => {
+                let (min, max, has_null) = stats.into_owned();
+                literal_batch.push(repo::ColumnChunkLiteral::try_new(
+                    column.column_id,
+                    chunk.chunk_id,
+                    min,
+                    max,
+                    has_null,
+                )?);
+            }
+            types::Stats::Numeric(stats) => {
+                numeric_batch.push(repo::ColumnChunkNumeric::new(
+                    column.column_id,
+                    chunk.chunk_id,
+                    stats.min,
+                    stats.max,
+                    stats.has_null,
+                    stats.has_nan,
+                ));
+            }
+            types::Stats::Unsupported => {}
+        }
+    }
+
+    repo::column_chunk_numeric_create_batch(&mut tx, &numeric_batch).await?;
+    repo::column_chunk_literal_create_batch(&mut tx, &literal_batch).await?;
+
+    // 3. Insert outbox entry (atomic with chunk metadata)
+    let outbox_entry =
+        repo::ChunkOutboxEntry::new(chunk.chunk_id, &target_path, parquet_bytes.to_vec());
+    repo::outbox_create(&mut tx, &outbox_entry).await?;
+
+    // Commit all in one transaction: chunk + stats + outbox
+    tx.commit().await?;
+
+    debug!(
+        "chunk {} created with outbox entry for path: {}",
+        chunk.chunk_id,
+        target_path.as_ref().display()
+    );
 
     Ok(())
 }

--- a/mosaicod/src/server/mod.rs
+++ b/mosaicod/src/server/mod.rs
@@ -1,8 +1,10 @@
 mod core;
 mod errors;
 mod flight;
+mod outbox;
 
 mod endpoints;
 
 pub use core::Server;
 pub use errors::ServerError;
+pub use outbox::{OutboxConfig, OutboxWorker};

--- a/mosaicod/src/server/outbox.rs
+++ b/mosaicod/src/server/outbox.rs
@@ -1,0 +1,427 @@
+//! Background worker for processing the chunks outbox.
+//!
+//! This module implements the outbox pattern for reliable S3 uploads.
+//! The worker polls the outbox table for pending entries and writes
+//! the parquet data to S3, then marks entries as processed.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use log::{debug, error, info, trace, warn};
+use tokio::sync::Notify;
+
+use crate::{params, repo, store};
+
+/// Configuration for the outbox worker.
+#[derive(Debug, Clone)]
+pub struct OutboxConfig {
+    /// How often to poll for pending entries (in milliseconds)
+    pub poll_interval_ms: u64,
+    /// Maximum number of entries to process per batch
+    pub batch_size: i32,
+    /// Maximum number of retries before giving up on an entry
+    pub max_retries: i32,
+    /// How old (in hours) processed entries must be before cleanup
+    pub cleanup_after_hours: i32,
+}
+
+impl Default for OutboxConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval_ms: 100,
+            batch_size: 50,
+            max_retries: 5,
+            cleanup_after_hours: 24,
+        }
+    }
+}
+
+impl OutboxConfig {
+    /// Creates a config from environment variables with defaults.
+    pub fn from_env() -> Self {
+        let params = params::configurables();
+        Self {
+            poll_interval_ms: params.outbox_poll_interval_ms,
+            batch_size: params.outbox_batch_size as i32,
+            max_retries: params.outbox_max_retries as i32,
+            cleanup_after_hours: 24,
+        }
+    }
+}
+
+/// Background worker that processes the chunks outbox.
+pub struct OutboxWorker {
+    store: store::StoreRef,
+    repo: repo::Repository,
+    shutdown: Arc<Notify>,
+    config: OutboxConfig,
+}
+
+impl OutboxWorker {
+    /// Creates a new outbox worker.
+    pub fn new(
+        store: store::StoreRef,
+        repo: repo::Repository,
+        shutdown: Arc<Notify>,
+        config: OutboxConfig,
+    ) -> Self {
+        Self {
+            store,
+            repo,
+            shutdown,
+            config,
+        }
+    }
+
+    /// Runs the outbox worker until shutdown is signaled.
+    pub async fn run(&self) {
+        info!(
+            "outbox worker started (poll_interval={}ms, batch_size={}, max_retries={})",
+            self.config.poll_interval_ms, self.config.batch_size, self.config.max_retries
+        );
+
+        let poll_interval = Duration::from_millis(self.config.poll_interval_ms);
+        let mut cleanup_counter = 0u32;
+
+        loop {
+            tokio::select! {
+                _ = self.shutdown.notified() => {
+                    info!("outbox worker received shutdown signal");
+                    break;
+                }
+                _ = tokio::time::sleep(poll_interval) => {
+                    if let Err(e) = self.process_batch().await {
+                        error!("outbox processing error: {}", e);
+                    }
+
+                    // Periodic cleanup (every ~100 iterations)
+                    cleanup_counter += 1;
+                    if cleanup_counter >= 100 {
+                        cleanup_counter = 0;
+                        if let Err(e) = self.cleanup_processed().await {
+                            warn!("outbox cleanup error: {}", e);
+                        }
+                    }
+                }
+            }
+        }
+
+        info!("outbox worker stopped");
+    }
+
+    /// Processes a batch of pending outbox entries.
+    async fn process_batch(&self) -> Result<(), OutboxError> {
+        let mut tx = self.repo.transaction().await?;
+
+        // Fetch pending entries with row-level locking
+        let entries =
+            repo::outbox_fetch_pending(&mut tx, self.config.batch_size, self.config.max_retries)
+                .await?;
+
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        trace!("processing {} outbox entries", entries.len());
+
+        for entry in entries {
+            match self.process_entry(&entry).await {
+                Ok(()) => {
+                    // Mark as processed
+                    repo::outbox_mark_processed(&mut tx, entry.outbox_id).await?;
+                    debug!(
+                        "outbox entry {} processed: {}",
+                        entry.outbox_id, entry.s3_path
+                    );
+                }
+                Err(e) => {
+                    // Record failure
+                    let error_msg = e.to_string();
+                    repo::outbox_mark_failed(&mut tx, entry.outbox_id, &error_msg).await?;
+                    warn!(
+                        "outbox entry {} failed (retry {}): {}",
+                        entry.outbox_id,
+                        entry.retry_count + 1,
+                        error_msg
+                    );
+                }
+            }
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Processes a single outbox entry by writing to S3.
+    async fn process_entry(&self, entry: &repo::ChunkOutboxEntry) -> Result<(), OutboxError> {
+        // Write parquet data to S3 (idempotent operation)
+        self.store
+            .write_bytes(&entry.s3_path, entry.parquet_data.clone())
+            .await
+            .map_err(|e| OutboxError::StoreWrite(e.to_string()))?;
+
+        trace!(
+            "wrote {} bytes to {}",
+            entry.parquet_data.len(),
+            entry.s3_path
+        );
+        Ok(())
+    }
+
+    /// Cleans up old processed entries.
+    async fn cleanup_processed(&self) -> Result<(), OutboxError> {
+        let mut cx = self.repo.connection();
+        let deleted =
+            repo::outbox_cleanup_processed(&mut cx, self.config.cleanup_after_hours).await?;
+
+        if deleted > 0 {
+            debug!("cleaned up {} processed outbox entries", deleted);
+        }
+
+        Ok(())
+    }
+}
+
+/// Errors that can occur during outbox processing.
+#[derive(Debug, thiserror::Error)]
+pub enum OutboxError {
+    #[error("repository error: {0}")]
+    Repository(#[from] repo::Error),
+
+    #[error("store write error: {0}")]
+    StoreWrite(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::repo;
+    use sqlx::Pool;
+
+    /// Helper to create a chunk and return its ID for outbox testing.
+    /// Uses internal repo functions that are available in test context.
+    async fn create_test_chunk(repo: &repo::testing::Repository) -> i32 {
+        // chunk_create and Chunk are already publicly exported
+        // sequence_create, topic_create, SequenceRecord, TopicRecord are test-only exports
+        use crate::repo::{
+            Chunk, SequenceRecord, TopicRecord, chunk_create, sequence_create, topic_create,
+        };
+
+        let mut tx = repo.transaction().await.unwrap();
+
+        // First create a sequence
+        let seq = SequenceRecord::new("test-outbox-seq");
+        let seq = sequence_create(&mut tx, &seq).await.unwrap();
+
+        // Then create a topic
+        let topic = TopicRecord::new("test-outbox-seq/test-topic", seq.sequence_id);
+        let topic = topic_create(&mut tx, &topic).await.unwrap();
+
+        // Finally create a chunk
+        let chunk = Chunk::new(topic.topic_id, "test/path/data.parquet", 1000, 100);
+        let chunk = chunk_create(&mut tx, &chunk).await.unwrap();
+
+        tx.commit().await.unwrap();
+
+        chunk.chunk_id
+    }
+
+    #[sqlx::test]
+    async fn test_outbox_create_and_fetch(pool: Pool<repo::Database>) {
+        let repo = repo::testing::Repository::new(pool);
+        let chunk_id = create_test_chunk(&repo).await;
+
+        let mut tx = repo.transaction().await.unwrap();
+
+        // Create outbox entry
+        let entry = repo::ChunkOutboxEntry::new(chunk_id, "test/path.parquet", vec![1, 2, 3, 4]);
+        let created = repo::outbox_create(&mut tx, &entry).await.unwrap();
+
+        assert_eq!(created.chunk_id, chunk_id);
+        assert_eq!(created.s3_path, "test/path.parquet");
+        assert_eq!(created.parquet_data, vec![1, 2, 3, 4]);
+        assert_eq!(created.retry_count, 0);
+        assert!(created.processed_at.is_none());
+
+        tx.commit().await.unwrap();
+    }
+
+    #[sqlx::test]
+    async fn test_outbox_fetch_respects_max_retries(pool: Pool<repo::Database>) {
+        let repo = repo::testing::Repository::new(pool);
+        let chunk_id = create_test_chunk(&repo).await;
+
+        let mut tx = repo.transaction().await.unwrap();
+
+        // Create outbox entry
+        let entry = repo::ChunkOutboxEntry::new(chunk_id, "test/path.parquet", vec![1, 2, 3]);
+        let created = repo::outbox_create(&mut tx, &entry).await.unwrap();
+
+        // Simulate failures up to max_retries
+        let max_retries = 3;
+        for i in 0..max_retries {
+            repo::outbox_mark_failed(&mut tx, created.outbox_id, &format!("error {}", i))
+                .await
+                .unwrap();
+        }
+
+        tx.commit().await.unwrap();
+
+        // Fetch with max_retries=3 should NOT return the entry (retry_count >= max_retries)
+        let mut tx2 = repo.transaction().await.unwrap();
+        let entries = repo::outbox_fetch_pending(&mut tx2, 10, max_retries)
+            .await
+            .unwrap();
+
+        assert!(
+            entries.is_empty(),
+            "Entry with retry_count >= max_retries should not be fetched"
+        );
+    }
+
+    #[sqlx::test]
+    async fn test_outbox_fetch_returns_entries_under_max_retries(pool: Pool<repo::Database>) {
+        let repo = repo::testing::Repository::new(pool);
+        let chunk_id = create_test_chunk(&repo).await;
+
+        let mut tx = repo.transaction().await.unwrap();
+
+        // Create outbox entry
+        let entry = repo::ChunkOutboxEntry::new(chunk_id, "test/path.parquet", vec![1, 2, 3]);
+        let created = repo::outbox_create(&mut tx, &entry).await.unwrap();
+
+        // Simulate 2 failures (under max_retries=3)
+        repo::outbox_mark_failed(&mut tx, created.outbox_id, "error 1")
+            .await
+            .unwrap();
+        repo::outbox_mark_failed(&mut tx, created.outbox_id, "error 2")
+            .await
+            .unwrap();
+
+        tx.commit().await.unwrap();
+
+        // Fetch with max_retries=3 SHOULD return the entry (retry_count=2 < 3)
+        let mut tx2 = repo.transaction().await.unwrap();
+        let entries = repo::outbox_fetch_pending(&mut tx2, 10, 3).await.unwrap();
+
+        assert_eq!(
+            entries.len(),
+            1,
+            "Entry with retry_count < max_retries should be fetched"
+        );
+        assert_eq!(entries[0].retry_count, 2);
+    }
+
+    #[sqlx::test]
+    async fn test_outbox_mark_processed_clears_data(pool: Pool<repo::Database>) {
+        let repo = repo::testing::Repository::new(pool);
+        let chunk_id = create_test_chunk(&repo).await;
+
+        let mut tx = repo.transaction().await.unwrap();
+
+        // Create outbox entry with data
+        let entry = repo::ChunkOutboxEntry::new(chunk_id, "test/path.parquet", vec![1, 2, 3, 4, 5]);
+        let created = repo::outbox_create(&mut tx, &entry).await.unwrap();
+
+        // Mark as processed
+        repo::outbox_mark_processed(&mut tx, created.outbox_id)
+            .await
+            .unwrap();
+
+        tx.commit().await.unwrap();
+
+        // Verify entry is no longer fetched (processed_at is set)
+        let mut tx2 = repo.transaction().await.unwrap();
+        let entries = repo::outbox_fetch_pending(&mut tx2, 10, 5).await.unwrap();
+
+        assert!(entries.is_empty(), "Processed entry should not be fetched");
+    }
+
+    #[sqlx::test]
+    async fn test_outbox_empty_returns_early(pool: Pool<repo::Database>) {
+        let repo = repo::testing::Repository::new(pool);
+        let mut tx = repo.transaction().await.unwrap();
+
+        // Fetch from empty outbox
+        let entries = repo::outbox_fetch_pending(&mut tx, 10, 5).await.unwrap();
+
+        assert!(entries.is_empty(), "Empty outbox should return empty vec");
+    }
+
+    #[sqlx::test]
+    async fn test_outbox_batch_size_limit(pool: Pool<repo::Database>) {
+        let repo = repo::testing::Repository::new(pool);
+        let chunk_id = create_test_chunk(&repo).await;
+
+        let mut tx = repo.transaction().await.unwrap();
+
+        // Create 5 outbox entries
+        for i in 0..5 {
+            let entry =
+                repo::ChunkOutboxEntry::new(chunk_id, format!("test/path{}.parquet", i), vec![i]);
+            repo::outbox_create(&mut tx, &entry).await.unwrap();
+        }
+
+        tx.commit().await.unwrap();
+
+        // Fetch with batch_size=2 should return only 2 entries
+        let mut tx2 = repo.transaction().await.unwrap();
+        let entries = repo::outbox_fetch_pending(&mut tx2, 2, 5).await.unwrap();
+
+        assert_eq!(entries.len(), 2, "Should respect batch_size limit");
+    }
+
+    #[sqlx::test]
+    async fn test_outbox_pending_count(pool: Pool<repo::Database>) {
+        let repo = repo::testing::Repository::new(pool);
+
+        // Initially empty
+        let mut cx = repo.connection();
+        let count = repo::outbox_count_pending(&mut cx).await.unwrap();
+        assert_eq!(count, 0);
+
+        let chunk_id = create_test_chunk(&repo).await;
+
+        let mut tx = repo.transaction().await.unwrap();
+
+        // Create 3 entries
+        for i in 0..3 {
+            let entry =
+                repo::ChunkOutboxEntry::new(chunk_id, format!("test/path{}.parquet", i), vec![i]);
+            repo::outbox_create(&mut tx, &entry).await.unwrap();
+        }
+
+        let count = repo::outbox_count_pending(&mut tx).await.unwrap();
+        assert_eq!(count, 3);
+
+        tx.commit().await.unwrap();
+    }
+
+    #[sqlx::test]
+    async fn test_outbox_error_message_recorded(pool: Pool<repo::Database>) {
+        let repo = repo::testing::Repository::new(pool);
+        let chunk_id = create_test_chunk(&repo).await;
+
+        let mut tx = repo.transaction().await.unwrap();
+
+        let entry = repo::ChunkOutboxEntry::new(chunk_id, "test/path.parquet", vec![1, 2, 3]);
+        let created = repo::outbox_create(&mut tx, &entry).await.unwrap();
+
+        // Mark as failed with specific error
+        repo::outbox_mark_failed(&mut tx, created.outbox_id, "S3 connection timeout")
+            .await
+            .unwrap();
+
+        tx.commit().await.unwrap();
+
+        // Fetch and verify error message
+        let mut tx2 = repo.transaction().await.unwrap();
+        let entries = repo::outbox_fetch_pending(&mut tx2, 10, 5).await.unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].error_message.as_deref(),
+            Some("S3 connection timeout")
+        );
+        assert_eq!(entries[0].retry_count, 1);
+    }
+}


### PR DESCRIPTION
Summary                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                    
  This PR implements the Transactional Outbox pattern to eliminate S3 orphan files that could occur when the database insert fails after a successful S3 upload.                                                                                                                    
                                                                                                                                                                                                                                                                                    
  Problem                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                    
  The previous write path in chunked_writer.rs performed a non-atomic dual-write:                                                                                                                                                                                                   
  1. Write Parquet file to S3                                                                                                                                                                                                                                                       
  2. Insert metadata in PostgreSQL                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                    
  If step 2 failed after step 1 succeeded, the S3 file became an orphan with no corresponding database record.                                                                                                                                                                      
                                                                                                                                                                                                                                                                                    
  Solution                                                                                                                                                                                                                                                                          
       
 Reverse the write flow using the industry-standard https://microservices.io/patterns/data/transactional-outbox.html (used by  Netflix, Uber, DoorDash):                                                                                                                            
                                                                                                                                                                                                                                                                               
  Reverse the write flow using the industry-standard Transactional Outbox pattern:                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                    
  1. Atomic DB Write: Chunk metadata + parquet bytes are inserted into PostgreSQL in a single transaction                                                                                                                                                                           
  2. Background Worker: OutboxWorker polls the outbox table and uploads pending entries to S3                                                                                                                                                                                       
  3. Cleanup: Processed entries are periodically cleaned up             

Configuration                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                    
  The outbox worker behavior can be tuned via environment variables defined in src/params.rs. These should be set before starting mosaicod:                                                                                                                                         
                                                                                                                                                                                                                                                                                    
  - MOSAICO_OUTBOX_POLL_INTERVAL_MS (default: 100) - How often the worker checks for pending uploads, in milliseconds                                                                                                                                                               
  - MOSAICO_OUTBOX_BATCH_SIZE (default: 50) - Maximum number of entries processed per polling cycle                                                                                                                                                                                 
  - MOSAICO_OUTBOX_MAX_RETRIES (default: 5) - How many times a failed upload is retried before being abandoned      

 Test
  8 new edge-case unit tests for outbox operations                                     