### PR TITLE
Calling `get_flight_info` on dataless topic does not fail

### DIFF
--- a/mosaico-sdk-py/src/testing/integration/test_abort.py
+++ b/mosaico-sdk-py/src/testing/integration/test_abort.py
@@ -31,10 +31,9 @@ def test_sequence_report(_client: MosaicoClient):
     assert shandler is not None
     # The list of registered topics corresponds to [topic_name]
     assert shandler.topics == [topic_name]
-    # This is True because we did not push no data in the topic,
-    # so the server cannot find any serialized file
-    log.info("Expected one (1) error after this line...")
-    assert _client.topic_handler(sequence_name, topic_name) is None
+    # The topic exists although contains no data and no schema
+    assert _client.topic_handler(sequence_name, topic_name) is not None
+
     # Free resources
     _client.sequence_delete(sequence_name)
     # This must be True...

--- a/mosaicod/src/arrow.rs
+++ b/mosaicod/src/arrow.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, AsArray, RecordBatch, StructArray};
-use arrow::datatypes::{DataType, Field, FieldRef, SchemaRef};
+use arrow::datatypes::{DataType, Field, FieldRef, Schema, SchemaRef};
 use arrow::error::ArrowError;
 
 use crate::{params, traits::SquashedIterator, types};
@@ -34,6 +34,11 @@ pub fn check_schema(schema: &SchemaRef) -> Result<(), SchemaError> {
         return Err(SchemaError::MissingTimestampInSchema);
     }
     Ok(())
+}
+
+/// Return a arrow empty schema
+pub fn empty_schema_ref() -> Arc<Schema> {
+    Arc::new(Schema::empty())
 }
 
 /// Checks if the given Arrow [`DataType`] is considered numeric

--- a/mosaicod/src/repo/facades/facade_error.rs
+++ b/mosaicod/src/repo/facades/facade_error.rs
@@ -1,6 +1,6 @@
 #[derive(thiserror::Error, Debug)]
 pub enum FacadeError {
-    #[error("unable to find data: {0}")]
+    #[error("unable to find `{0}`")]
     NotFound(String),
     #[error("missing metadata field `{0}`")]
     MissingMetadataField(String),


### PR DESCRIPTION
Updated backend and integration tests in order to allow calling `get_flight_info` on dataless topic.