### PR TITLE
Renamed literal into texual for text-based statistics in mosaicod

### DIFF
--- a/mosaicod/.sqlx/query-52bf81ef269d8d00e4b3164e2daf9dfb9397551edcd167fec07f5eab7d32f475.json
+++ b/mosaicod/.sqlx/query-52bf81ef269d8d00e4b3164e2daf9dfb9397551edcd167fec07f5eab7d32f475.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "INSERT INTO column_chunk_literal_t(\n            column_id, chunk_id,\n            min_value, max_value,\n            has_null \n        )\n        VALUES ($1, $2, $3, $4, $5)\n        RETURNING *",
+  "query": "INSERT INTO column_chunk_textual_t(\n            column_id, chunk_id,\n            min_value, max_value,\n            has_null \n        )\n        VALUES ($1, $2, $3, $4, $5)\n        RETURNING *",
   "describe": {
     "columns": [
       {
@@ -46,5 +46,5 @@
       false
     ]
   },
-  "hash": "e89e1bd5c54a16df5fd6870c084c41d0452f11d1ae014f1712c24beb08916fd6"
+  "hash": "52bf81ef269d8d00e4b3164e2daf9dfb9397551edcd167fec07f5eab7d32f475"
 }

--- a/mosaicod/migrations/20251110134258_data_catalog.sql
+++ b/mosaicod/migrations/20251110134258_data_catalog.sql
@@ -22,7 +22,7 @@ CREATE TABLE chunk_t(
     ON DELETE CASCADE
 );
 
-CREATE TABLE column_chunk_literal_t(
+CREATE TABLE column_chunk_textual_t(
   column_id    INTEGER REFERENCES column_t(column_id) NOT NULL,
   chunk_id     INTEGER NOT NULL, -- Constraint on chunks defined below
 

--- a/mosaicod/src/arrow.rs
+++ b/mosaicod/src/arrow.rs
@@ -58,7 +58,7 @@ pub fn is_numeric(data_type: &DataType) -> bool {
 
 /// Checks if the given Arrow [`DataType`] is considered text
 #[must_use]
-pub fn is_text(data_type: &DataType) -> bool {
+pub fn is_textual(data_type: &DataType) -> bool {
     matches!(
         data_type,
         DataType::Utf8
@@ -72,15 +72,15 @@ pub fn is_text(data_type: &DataType) -> bool {
 }
 
 /// Converts an arrow [`Array`] to a text type array (Utf8)
-pub fn cast_array_to_text(array: &ArrayRef) -> Result<ArrayRef, ArrowError> {
-    if is_text(array.data_type()) {
+pub fn cast_array_to_textual(array: &ArrayRef) -> Result<ArrayRef, ArrowError> {
+    if is_textual(array.data_type()) {
         Ok(arrow_cast::cast(
             array.as_ref(),
             &arrow_schema::DataType::Utf8,
         )?)
     } else {
         Err(arrow::error::ArrowError::CastError(
-            "unable to cast arrow array to literal type".to_owned(),
+            "unable to cast arrow array to textual type".to_owned(),
         ))
     }
 }
@@ -209,11 +209,11 @@ impl SquashedIterator for SchemaRef {
 }
 
 pub fn stats_from_arrow_field(field: &Field) -> types::Stats {
-    use types::{NumericStats, Stats, TextStats};
+    use types::{NumericStats, Stats, TextualStats};
 
     match field.data_type() {
         dt if is_numeric(dt) => Stats::Numeric(NumericStats::new()),
-        dt if is_text(dt) => Stats::Text(TextStats::new()),
+        dt if is_textual(dt) => Stats::Textual(TextualStats::new()),
         _ => Stats::Unsupported,
     }
 }
@@ -242,8 +242,8 @@ pub fn stats_inspect_array(stats: &mut types::Stats, array: &ArrayRef) -> Result
 
             stats.merge(min_val, max_val, has_null, has_nan);
         }
-        Stats::Text(stats) => {
-            let sarray = cast_array_to_text(array)?;
+        Stats::Textual(stats) => {
+            let sarray = cast_array_to_textual(array)?;
             let string_array = sarray.as_string::<i32>();
 
             // Use SIMD-optimized min/max from Arrow compute

--- a/mosaicod/src/query/filter.rs
+++ b/mosaicod/src/query/filter.rs
@@ -32,7 +32,7 @@ pub type Float = f64;
 pub type Integer = i64;
 /// Timestam type alias
 pub type Timestamp = types::Timestamp;
-/// Literal type alias
+/// Text type alias
 pub type Text = String;
 
 #[derive(Debug, thiserror::Error)]

--- a/mosaicod/src/repo/sql_models/data_catalog.rs
+++ b/mosaicod/src/repo/sql_models/data_catalog.rs
@@ -53,9 +53,9 @@ impl Chunk {
     }
 }
 
-/// Chunk of literal data associated with a column.
+/// Chunk of textual data associated with a column.
 #[derive(Debug)]
-pub struct ColumnChunkLiteral {
+pub struct ColumnChunkTextual {
     pub column_id: i32,
     pub chunk_id: i32,
 
@@ -67,7 +67,7 @@ pub struct ColumnChunkLiteral {
     pub has_null: bool,
 }
 
-impl ColumnChunkLiteral {
+impl ColumnChunkTextual {
     pub fn try_new(
         column_id: i32,
         chunk_id: i32,
@@ -85,7 +85,7 @@ impl ColumnChunkLiteral {
     }
 }
 
-/// Chunk of literal data associated with a column.
+/// Chunk of textual data associated with a column.
 #[derive(Debug)]
 pub struct ColumnChunkNumeric {
     pub column_id: i32,

--- a/mosaicod/src/repo/sql_models/pg_queries/builders.rs
+++ b/mosaicod/src/repo/sql_models/pg_queries/builders.rs
@@ -68,7 +68,7 @@ fn build_clause(where_clauses: String, v: &query::Value) -> String {
         query::Value::Text(_) => {
             let select = r#"
             SELECT chunk_id FROM chunk_t 
-            JOIN column_chunk_literal_t __stats__ USING(chunk_id) 
+            JOIN column_chunk_textual_t __stats__ USING(chunk_id) 
             JOIN column_t __column__ USING(column_id)
             "#;
 

--- a/mosaicod/src/repo/sql_models/pg_queries/data_catalog.rs
+++ b/mosaicod/src/repo/sql_models/pg_queries/data_catalog.rs
@@ -49,13 +49,13 @@ pub async fn chunk_create(
     Ok(res)
 }
 
-pub async fn column_chunk_literal_create(
+pub async fn column_chunk_textual_create(
     exec: &mut impl repo::AsExec,
-    val: &sql_models::ColumnChunkLiteral,
-) -> Result<sql_models::ColumnChunkLiteral, repo::Error> {
+    val: &sql_models::ColumnChunkTextual,
+) -> Result<sql_models::ColumnChunkTextual, repo::Error> {
     let res = sqlx::query_as!(
-        sql_models::ColumnChunkLiteral,
-        r#"INSERT INTO column_chunk_literal_t(
+        sql_models::ColumnChunkTextual,
+        r#"INSERT INTO column_chunk_textual_t(
             column_id, chunk_id,
             min_value, max_value,
             has_null 
@@ -125,18 +125,18 @@ pub async fn column_chunk_numeric_create_batch(
     Ok(())
 }
 
-/// Batch insert multiple literal column chunk stats in a single query.
+/// Batch insert multiple textual column chunk stats in a single query.
 /// More efficient than individual inserts when inserting many stats.
-pub async fn column_chunk_literal_create_batch(
+pub async fn column_chunk_textual_create_batch(
     exec: &mut impl repo::AsExec,
-    values: &[sql_models::ColumnChunkLiteral],
+    values: &[sql_models::ColumnChunkTextual],
 ) -> Result<(), repo::Error> {
     if values.is_empty() {
         return Ok(());
     }
 
     let mut query_builder: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(
-        "INSERT INTO column_chunk_literal_t(column_id, chunk_id, min_value, max_value, has_null) ",
+        "INSERT INTO column_chunk_textual_t(column_id, chunk_id, min_value, max_value, has_null) ",
     );
 
     query_builder.push_values(values, |mut b, val| {

--- a/mosaicod/src/rw/chunk_writer.rs
+++ b/mosaicod/src/rw/chunk_writer.rs
@@ -207,7 +207,7 @@ mod tests {
 
         // Check stats for "label", and check that the computed bloom filter has
         // all the values in the set
-        if let Some(types::Stats::Text(s)) = cstats.cols.get("label") {
+        if let Some(types::Stats::Textual(s)) = cstats.cols.get("label") {
             assert_eq!(s.min.as_deref(), Some("a"));
             assert_eq!(s.max.as_deref(), Some("c"));
 

--- a/mosaicod/src/types/chunk.rs
+++ b/mosaicod/src/types/chunk.rs
@@ -20,7 +20,7 @@ impl OntologyModelStats {
 #[derive(Debug, PartialEq)]
 pub enum Stats {
     Numeric(NumericStats),
-    Text(TextStats),
+    Textual(TextualStats),
     Unsupported,
 }
 
@@ -98,20 +98,20 @@ impl NumericStats {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct TextStats {
+pub struct TextualStats {
     pub min: Option<String>,
     pub max: Option<String>,
 
     pub has_null: bool,
 }
 
-impl Default for TextStats {
+impl Default for TextualStats {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl TextStats {
+impl TextualStats {
     pub fn new() -> Self {
         Self {
             min: None,
@@ -121,7 +121,7 @@ impl TextStats {
         }
     }
 
-    /// Evaluates a new literal value and updates the column statistics.
+    /// Evaluates a new text value and updates the column statistics.
     /// If the provided value is [`None`], it is condered a null value.
     pub fn eval(&mut self, val: &Option<&str>) {
         if let Some(val) = val {
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn text_stats_empty_string_is_valid_min() {
-        let mut stats = TextStats::new();
+        let mut stats = TextualStats::new();
         stats.eval(&Some(""));
         stats.eval(&Some("a"));
         stats.eval(&Some("b"));
@@ -186,7 +186,7 @@ mod tests {
 
     #[test]
     fn text_stats_normal_values() {
-        let mut stats = TextStats::new();
+        let mut stats = TextualStats::new();
         stats.eval(&Some("b"));
         stats.eval(&Some("a"));
         stats.eval(&Some("c"));
@@ -197,7 +197,7 @@ mod tests {
 
     #[test]
     fn text_stats_only_nulls() {
-        let mut stats = TextStats::new();
+        let mut stats = TextualStats::new();
         stats.eval(&None);
         stats.eval(&None);
 
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn text_stats_merge_with_empty_string() {
-        let mut stats = TextStats::new();
+        let mut stats = TextualStats::new();
         stats.merge(Some("a"), Some("z"), false);
         stats.merge(Some(""), Some("b"), false);
 


### PR DESCRIPTION
Renamed also the table holding statistics and since schema is changed I've updated the sqlx cache.