### PR TITLE
Harden name validation — replace blacklist with explicit supported-character sets

### DIFF
--- a/mosaico-sdk-py/src/testing/unit/conversion/test_pack_unpack.py
+++ b/mosaico-sdk-py/src/testing/unit/conversion/test_pack_unpack.py
@@ -1,4 +1,12 @@
+import pytest
+
 from mosaicolabs.helpers import pack_topic_resource_name, unpack_topic_full_path
+from mosaicolabs.handlers.helpers import (
+    _validate_sequence_name,
+    _validate_topic_name,
+    _SUPPORTED_SEQUENCE_NAME_CHARS,
+    _SUPPORTED_TOPIC_NAME_CHARS,
+)
 
 
 def test_pack_topic_resource_name():
@@ -34,3 +42,25 @@ def test_unpack_topic_resource_name():
 
     assert unpack_topic_full_path("not-unpacked-str") is None
     assert unpack_topic_full_path("/not-unpacked-str") is None
+
+
+@pytest.mark.parametrize(
+    "supported_char",
+    [p for p in _SUPPORTED_TOPIC_NAME_CHARS],
+)
+def test_validate_topic_name(supported_char: str):
+    _validate_topic_name("my/topic/name")
+    _validate_topic_name("/my/topic/name")
+    _validate_topic_name(f"my/topic{supported_char}name")
+    _validate_topic_name(f"/my/topic{supported_char}name")
+
+
+@pytest.mark.parametrize(
+    "supported_char",
+    [p for p in _SUPPORTED_SEQUENCE_NAME_CHARS],
+)
+def test_validate_sequence_name(supported_char: str):
+    _validate_sequence_name("my-sequence-name")
+    _validate_sequence_name("/my-sequence-name")
+    _validate_sequence_name(f"my-sequence{supported_char}name")
+    _validate_sequence_name(f"/my-sequence{supported_char}name")


### PR DESCRIPTION
- Replaces the previous blacklist approach with explicit `_SUPPORTED_SEQUENCE_NAME_CHARS` and `_SUPPORTED_TOPIC_NAME_CHARS` constants to define allowed characters.
- Improves validation in `handlers.helpers` to handle malformed `pathlib.Path` inputs, detect empty or leading-slash names, and return clear errors listing the exact invalid characters.
- Expands and refactors tests: parameterized tests for invalid/empty/double-slash sequence and topic names in `test_failures.py`, and added parametrized validation checks in `test_pack_unpack.py`.
- No external API changes; increases validation robustness and test coverage.
- Addresses the SDK portion of issue #93.