### PR TITLE
fix: replace placeholder Google search URLs with links to the same repo.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ As Mosaico is in early development, documentation contributions are highly encou
 The backend source code is located in the `mosaicod` directory.
 
 * **Setup:** Ensure you have a working [Rust toolchain](https://rust-lang.org/tools/install/) installed.
-* **Build Instructions:** Refer to the [`mosaicod` main guide](https://www.google.com/search?q=./mosaicod/README.md) for detailed instructions on building from source.
+* **Build Instructions:** Refer to the [`mosaicod` main guide](./mosaicod/README.md) for detailed instructions on building from source.
 * **Database Schema:** If you modify the database schema, you **must** run `cargo sqlx prepare` and commit the generated `.sqlx` directory.
 * **Safety:** Avoid `unsafe` blocks unless strictly necessary for FFI or zero-copy buffer handling.
 * **Style & Linting:** Your code must be formatted via `cargo fmt` and pass `cargo clippy` without warnings.

--- a/mosaico-sdk-py/doc-md/queries.md
+++ b/mosaico-sdk-py/doc-md/queries.md
@@ -108,7 +108,7 @@ Filters specific topics within a sequence.
 > [\!NOTE]
 > **Querying `user_metadata` in Topic/Sequence**
 >
-> The `user_metadata` field supports all [available operators](https://www.google.com/search?q=%23supported-operators). To query a value, access the specific metadata key using bracket notation (`[]`) and chain the desired comparison method.
+> The `user_metadata` field supports all [available operators](#supported-operators). To query a value, access the specific metadata key using bracket notation (`[]`) and chain the desired comparison method.
 >
 > For nested dictionaries, use **dot notation** (`.`) within the key string to traverse sub-fields.
 >


### PR DESCRIPTION
# fix: replace placeholder Google search URLs with correct links in docs

Two documentation links were pointing to Google search queries instead of their intended targets, making them broken for anyone who clicked them.

## Changes

- **`CONTRIBUTING.md`**: fixed link to the `mosaicod` build guide. It was a Google search URL, now points to `./mosaicod/README.md`.
- **`mosaico-sdk-py/doc-md/queries.md`**: fixed link to the "Supported Operators" section. It was a Google search URL, now points to the `#supported-operators` section in the same file.

---

- [x] I have read and understood the `CONTRIBUTING.md` file.
- [x] I confirm that this contribution does not include code (or comments) copied from proprietary sources or from open-source projects with incompatible licenses.
- [ ] I have opened a discussion related to this feature or bug.
- [ ] This work was previously discussed and agreed upon by maintainers.

I figured the other two were not needed for a change this small but I'm happy to open an issue if that is better for the team.
