### PR TITLE
Bind Docker database and storage ports to localhost only

### DIFF
--- a/docker/devel/compose.yml
+++ b/docker/devel/compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: mosaico
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
@@ -20,8 +20,8 @@ services:
       MINIO_ROOT_PASSWORD: password
     command: server /data --console-address ":9001"
     ports:
-      - "9000:9000"  # API
-      - "9001:9001"  # Web UI
+      - "127.0.0.1:9000:9000"  # API
+      - "127.0.0.1:9001:9001"  # Web UI
     volumes:
       - /tmp/minio:/data
     healthcheck:

--- a/docker/quick_start/compose.yml
+++ b/docker/quick_start/compose.yml
@@ -10,8 +10,10 @@ services:
       POSTGRES_DB: mosaico
     networks:
       - mosaico-qs
+    # Bind to localhost only — exposing PostgreSQL to 0.0.0.0 with default
+    # credentials is a known ransomware attack vector (Docker bypasses ufw/iptables).
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - mosaico-qs-pg-data:/var/lib/postgresql/data
     healthcheck: # Ensure the DB is ready for the compilation step

--- a/docker/testing/compose.yml
+++ b/docker/testing/compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: mosaico
     ports:
-      - "6543:5432"
+      - "127.0.0.1:6543:5432"
     volumes:
       - mosaico-testing-pg-data:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
Even if I undestand that the quick start docker build was meant to be used on **localhost**, I tried it on a server online and only few hours later the server was compromised by a **ransomware bot**.

All compose files exposed PostgreSQL (and MinIO in devel) to 0.0.0.0, making them reachable from the internet. Combined with default credentials, this is a known ransomware attack vector — Docker port mappings bypass ufw/iptables rules. 

Binding to 127.0.0.1 ensures these services are only reachable from the host while container-to-container communication via Docker networks remains unaffected.

