### PR TITLE
Remove 'latest' from links in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ As Mosaico is in early development, documentation contributions are highly encou
 
 ### Backend
 
-The backend source code is located in the `mosaicod` directory. For detailed instructions on building from source, please refer to the [official daemon documentation](https://docs.mosaico.dev/latest/daemon). 
+The backend source code is located in the `mosaicod` directory. For detailed instructions on building from source, please refer to the [official daemon documentation](https://docs.mosaico.dev/daemon). 
 
 #### Update DBMS Schema
 

--- a/README.md
+++ b/README.md
@@ -34,21 +34,21 @@ The transition from classical robotics to Physical AI represents a fundamental s
 
 **Physical AI** requires synchronous, dense, and tabular data. Models expect fixed-size tensors arriving at a constant frequency (e.g., a batch of state vectors at exactly 50Hz).
 
-Mosaico’s [ML module](https://docs.mosaico.dev/latest/SDK/bridges/ml/) automates this tedious *data plumbing*. It ingests raw, unsynchronized data and transforms it on the fly into the aligned, flattened formats ready for model training, eliminating the need for massive intermediate CSV files.
+Mosaico’s [ML module](https://docs.mosaico.dev/SDK/bridges/ml/) automates this tedious *data plumbing*. It ingests raw, unsynchronized data and transforms it on the fly into the aligned, flattened formats ready for model training, eliminating the need for massive intermediate CSV files.
 
 ## What you'll find
 This repo contains both the Python SDK (`mosaico-sdk-py`) and the Rust backend (`mosaicod`). We have chosen to keep the code in a monorepo configuration to simplify the testing and reduce compatibility issues.
 
 Mosaico takes a strictly code-first approach. 
 We didn't want to force you to learn yet another SQL-like sublanguage just to move data around. 
-Instead, we provide native SDKs (starting with [Python](https://docs.mosaico.dev/latest/SDK)) so you can query and upload data using the programming language you are already comfortable with.
+Instead, we provide native SDKs (starting with [Python](https://docs.mosaico.dev/SDK)) so you can query and upload data using the programming language you are already comfortable with.
 
 Under the hood, the system operates on a standard client-server model. 
-The server daemon, [`mosaicod`](https://docs.mosaico.dev/latest/daemon), acts as the central hub that takes care of the heavy lifting, like data conversion, compression, and organized storage. 
+The server daemon, [`mosaicod`](https://docs.mosaico.dev/daemon), acts as the central hub that takes care of the heavy lifting, like data conversion, compression, and organized storage. 
 On the other side, the client SDK is what you actually import into your scripts; it manages the communication logic and abstracts away the implementation details to keep your API usage stable, even as the platform evolves in the background.
 
 ## Documentation
-For a comprehensive description, please visit our [documentation](https://docs.mosaico.dev). If you are building with AI, you can find specialized technical guides in the [Agent-ready](https://docs.mosaico.dev/latest/agents_docs) section.
+For a comprehensive description, please visit our [documentation](https://docs.mosaico.dev). If you are building with AI, you can find specialized technical guides in the [Agent-ready](https://docs.mosaico.dev/agents_docs) section.
 
 ### Cite Us
 

--- a/mosaico-sdk-py/README.md
+++ b/mosaico-sdk-py/README.md
@@ -12,7 +12,7 @@ The **Mosaico SDK** is the primary interface for interacting with the **Mosaico 
 
 It provides a seamless bridge between raw data formats (like ROS bags) and the Mosaico high-performance storage layer, leveraging technologies like **PyArrow**, **Pandas**, and **Pydantic**.
 
-For full documentation, see the [Mosaico SDK Documentation](https://docs.mosaico.dev/latest/SDK/).
+For full documentation, see the [Mosaico SDK Documentation](https://docs.mosaico.dev/SDK/).
 
 ## Key Features
 
@@ -42,7 +42,7 @@ The SDK comes with built-in command-line tools to speed up your workflow.
 
 Before running any mosaico service via SDK, ensure your **Mosaico Infrastructure** is active and running. 
 The easiest way to start is using the provided **Quick Start environment**.
-Please, refer to the **[daemon Setup](https://docs.mosaico.dev/latest/daemon/install/)** for setting up the environment.
+Please, refer to the **[daemon Setup](https://docs.mosaico.dev/daemon/install/)** for setting up the environment.
 
 ```python
 from mosaicolabs import MosaicoClient


### PR DESCRIPTION
This PR fixes the broken links in documentation: 'latest/' sub-path does not exist anymore