### PR TITLE
feat(py): Implement ROS Adapters for Futures ontology

### DIFF
--- a/doc/docs/SDK/API_reference/bridges/ros/adapters/override_msgs.md
+++ b/doc/docs/SDK/API_reference/bridges/ros/adapters/override_msgs.md
@@ -1,0 +1,6 @@
+---
+title: override_msgs Adapters
+description: API Reference for override_msgs Adapters
+---
+
+::: mosaicolabs.ros_bridge.adapters.override_msgs

--- a/doc/docs/SDK/bridges/ros.md
+++ b/doc/docs/SDK/bridges/ros.md
@@ -258,7 +258,7 @@ from .my_adapter import MyLidarAdapter
 
 config = ROSInjectionConfig(
     file_path=Path("sensor_data.mcap"),
-    sequence_name="custom_laser_run",
+    sequence_name="custom_lidar_run",
     # Explicitly tell the bridge to use your custom adapter for this topic
     adapter_override={
         "/lidar/front/pointcloud": MyLidarAdapter,

--- a/doc/docs/SDK/bridges/ros.md
+++ b/doc/docs/SDK/bridges/ros.md
@@ -162,22 +162,55 @@ Through the **`adapter_override`** parameter in the `ROSInjectionConfig`, you ca
 !!! important "Override adapter usage"
     Use adapter overrides for versatile message types like [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html), where different sensors (LiDAR, Radar, etc.) share the same ROS type but require unique parsing logic. Overrides should be defined and used when a given ROS message type has its own **default adapter** registered in the `ROSBridge` registry, but such an adapter cannot satisfy topic-specific requirements. If your message type is used consistently across all topics, simply use the [`@register_default_adapter`][mosaicolabs.ros_bridge.register_default_adapter] decorator to establish a global fallback.
 
-##### Implementing a Custom Adapter Override
-To create a custom adapter, you must inherit from `ROSAdapterBase` and define the transformation logic.
-Here is a structural example of a custom LiDAR adapter; note that the adapter is not registered as **default**, since the message type `sensor_msgs/msg/PointCloud2` already has it:
+##### Available Adapters override 
+
+Built-in adapters are provided for the most common sensor types and are ready to use out of the box:
+
+| Sensor type   | Adapter class         |
+|---------------|-----------------------|
+| LiDAR         | [`LidarAdapter`][mosaicolabs.ros_bridge.adapters.override_msgs.LidarAdapter]        |
+| Radar         | [`RadarAdapter`][mosaicolabs.ros_bridge.adapters.override_msgs.RadarAdapter]        |
+| RGBD Camera   | [`RGBDCameraAdapter`][mosaicolabs.ros_bridge.adapters.override_msgs.RGBDCameraAdapter]   |
+| ToF Camera    | [`ToFCameraAdapter`][mosaicolabs.ros_bridge.adapters.override_msgs.ToFCameraAdapter]    |
+| Stereo Camera | [`StereoCameraAdapter`][mosaicolabs.ros_bridge.adapters.override_msgs.StereoCameraAdapter] |
+
+All of them extend [`PointCloudAdapterBase`][mosaicolabs.ros_bridge.adapters.sensor_msgs.PointCloudAdapterBase], which exposes the following interface:
+
+- **`decode`**: deserializes the binary buffer of a `PointCloud2` message into named field arrays.
+- **`_build`** *(abstract)*: constructs and returns an instance of the target ontology object from the decoded fields. Must be overridden in every concrete subclass.
+- **`from_dict`**: validates that all required fields of the ontology are present before delegating to `_build`. A field is considered required when its [`MosaicoField`][mosaicolabs.models.MosaicoField] declaration has no explicit default (i.e. `default=...`) or it is declared **no Optional**.
+
+##### Implementing a Custom PointCloud2 Adapter Override
+To create a custom `PointCloud2` adapter, inherit from [`PointCloudAdapterBase`][mosaicolabs.ros_bridge.adapters.sensor_msgs.PointCloudAdapterBase].
+You only need to define:
+
+- `_build`: the mapping logic from decoded field arrays to your ontology instance.
+- `_REQUIRED_FIELDS`: the list of fields that must be present in the decoded payload.
+- `__mosaico_ontology_type__`: the target ontology class.
+
+All core business logic is encapsulated inside `PointCloudAdapterBase`.
+
+The following example shows a custom LiDAR adapter whose encoding differs from the generic [`LidarAdapter`][mosaicolabs.ros_bridge.adapters.override_msgs.LidarAdapter] already provided by Mosaico. 
+Note that the adapter is **not** registered as default, since `sensor_msgs/msg/PointCloud2` already has one.
 
 ```python
-from typing import Any, Optional, Type, Tuple
-from mosaicolabs.ros_bridge import ROSAdapterBase, ROSMessage
+from typing import Any, Optional, Type
+from mosaicolabs.ros_bridge import PointCloudAdapterBase, ROSMessage
 from mosaicolabs.models import Message
 from my_ontology import MyLidar # Your target Ontology class
 
-class MyCustomLidarAdapter(ROSAdapterBase[MyLidar]):
-    # Define which ROS type this adapter handles
-    ros_msgtype: str | Tuple[str, ...] = "sensor_msgs/msg/PointCloud2"
-
+class MyLidarAdapter(PointCloudAdapterBase[MyVelodyneLidar]):
     # Define the target Mosaico Ontology class
-    __mosaico_ontology_type__: Type[MyLidar] = MyLidar
+    __mosaico_ontology_type__: Type[MyLidar] = MyVelodyneLidar
+
+    _REQUIRED_FIELDS = [
+        name for name, field in MyLidar.model_fields.items() 
+        if field.is_required()
+    ]
+
+    @classmethod
+    def _build(cls, decoded_fields: dict[str, list]) -> MyLidar:
+        return MyLidar(...)
 
     @classmethod
     def translate(
@@ -200,9 +233,7 @@ class MyCustomLidarAdapter(ROSAdapterBase[MyLidar]):
         Converts the deserialized ROS dictionary into a Mosaico object.
         """
         # Core transformation logic: map raw ROS fields to your ontology type.
-        return MyLidar(
-            # ... map ros_data fields to MyLidar fields
-        )
+        return super().from_dict(ros_data)
 
 
     @classmethod
@@ -214,27 +245,23 @@ class MyCustomLidarAdapter(ROSAdapterBase[MyLidar]):
         return None
 ```
 
-##### Key Methods
-**`from_dict(ros_data)`**: This is the most important method. It receives the ROS message as a Python dictionary and must return an instance of your target Mosaico Ontology class.
-
-**`translate(ros_msg)`**: This is the entry point called by the ROSBridge. It just calls `from_dict`, but you can override it if you need access to the message metadata during conversion.
-
-**`schema_metadata(ros_data)`**: Use this to extract metadata information about the sensor configuration that is useful for the platform to know.
+!!! tip "Optional overrides"
+    Only `_build` is mandatory. Override `translate`, `from_dict`, or `schema_metadata` only when the default behaviour of the base class does not meet your needs.
 
 ##### Registering the Override
 Once implemented, the adapter is registered against a specific topic via `adapter_override` in [ROSInjectionConfig][mosaicolabs.ros_bridge.ROSInjectionConfig]:
 
 ```python
-from .my_adapter import MyCustomLidarAdapter
+from .my_adapter import MyLidarAdapter
 
 ...
 
 config = ROSInjectionConfig(
     file_path=Path("sensor_data.mcap"),
-    sequence_name="custom_lidar_run",
+    sequence_name="custom_laser_run",
     # Explicitly tell the bridge to use your custom adapter for this topic
     adapter_override={
-        "/lidar/front/pointcloud": MyCustomLidarAdapter,
+        "/lidar/front/pointcloud": MyLidarAdapter,
     }
 )
 
@@ -244,9 +271,13 @@ ingestor = RosbagInjector(config)
 ingestor.run()
 ```
 
-With this configuration, all the [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html) message received on `/lidar/front/pointcloud`, will be processed exclusively by `MyCustomLidarAdapter`. All other topics continue to use the standard resolution logic.
+With this configuration, all the [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html) message received on `/lidar/front/pointcloud`, will be processed exclusively by `MyLidarAdapter`. All other topics continue to use the standard resolution logic.
 
 By using this pattern, you can maintain a clean separation between your raw ROS data and your high-level Mosaico data models, ensuring that even the most "exotic" sensor data is correctly ingested and indexed.
+
+##### Implementing a Custom Adapter Override
+To create a custom adapter that overrides a existing ROS message, you must inherit from `ROSAdapterBase` and define the transformation logic.
+Follow the steps described [here](#extending-the-bridge-custom-adapters) with the only caveat not to register the adapter with `@register_default_adapter` but insted [register the override](#registering-the-override)
 
 #### CLI Usage
 

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
                       - SDK/API_reference/bridges/ros/adapters/sensor_msgs.md
                       - SDK/API_reference/bridges/ros/adapters/nav_msgs.md
                       - SDK/API_reference/bridges/ros/adapters/tf2_msgs.md
+                      - SDK/API_reference/bridges/ros/adapters/override_msgs.md
   - Daemon:
       - daemon/index.md
       - daemon/install.md

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/__init__.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/__init__.py
@@ -12,6 +12,13 @@ from .geometry_msgs import (
 from .nav_msgs import (
     OdometryAdapter as OdometryAdapter,
 )
+from .override_msgs import (
+    LidarAdapter as LidarAdapter,
+    RadarAdapter as RadarAdapter,
+    RGBDCameraAdapter as RGBDCameraAdapter,
+    StereoCameraAdapter as StereoCameraAdapter,
+    ToFCameraAdapter as ToFCameraAdapter,
+)
 from .sensor_msgs import (
     BatteryStateAdapter as BatteryStateAdapter,
     CameraInfoAdapter as CameraInfoAdapter,
@@ -19,9 +26,12 @@ from .sensor_msgs import (
     GPSAdapter as GPSAdapter,
     ImageAdapter as ImageAdapter,
     IMUAdapter as IMUAdapter,
+    LaserScanAdapter as LaserScanAdapter,
+    MultiEchoLaserScanAdapter as MultiEchoLaserScanAdapter,
     NavSatStatusAdapter as NavSatStatusAdapter,
     NMEASentenceAdapter as NMEASentenceAdapter,
     PointCloudAdapter as PointCloudAdapter,
+    PointCloudAdapterBase as PointCloudAdapterBase,
     RobotJointAdapter as RobotJointAdapter,
     ROIAdapter as ROIAdapter,
 )

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/helpers.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/helpers.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import List, Type
 
 from ..adapter_base import ROSAdapterBase
 
@@ -23,4 +23,24 @@ def _validate_msgdata(
         raise ValueError(
             f"Malformed ROS message '{cls.ros_msgtype}': missing required keys {missing_keys}. "
             f"Available keys: {list(ros_data.keys())}"
+        )
+
+
+def _validate_required_fields(
+    cls: Type[ROSAdapterBase], required_fields: List, data: dict
+):
+    """
+    Validate that all required fields are present in the decoded data dictionary.
+
+    Args:
+        cls (Type[ROSAdapterBase]): The adapter class being validated.
+        data (dict): The decoded data dictionary to validate against.
+
+    Raises:
+        ValueError: If one or more required fields are missing from the data.
+    """
+    if not all(field in data for field in required_fields):
+        raise ValueError(
+            f"Required fields of {cls.__name__} are missing: "
+            f"Required = {cls._REQUIRED_KEYS}, Actual =  {data.keys()}"
         )

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/override_msgs.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/override_msgs.py
@@ -1,0 +1,378 @@
+from typing import Any, Optional, Type
+
+from mosaicolabs import Message
+from mosaicolabs.models.futures import Lidar, Radar, RGBDCamera, StereoCamera, ToFCamera
+from mosaicolabs.ros_bridge.adapters.sensor_msgs import PointCloudAdapterBase
+from mosaicolabs.ros_bridge.ros_message import ROSMessage
+
+
+class LidarAdapter(PointCloudAdapterBase[Lidar]):
+    """
+    Adapter for translating ROS PointCloud2 messages to Mosaico `Lidar`.
+    This Adapter needs to be specified in the field `adapters_override` of `RosInjectionConfig`.
+
+    **Supported ROS Types:**
+
+    - [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html)
+
+    """
+
+    __mosaico_ontology_type__: Type[Lidar] = Lidar
+    _REQUIRED_FIELDS = [
+        name for name, field in Lidar.model_fields.items() if field.is_required()
+    ]
+
+    @classmethod
+    def _build(cls, decoded_fields: dict[str, list]) -> Lidar:
+        return Lidar(
+            x=decoded_fields["x"],
+            y=decoded_fields["y"],
+            z=decoded_fields["z"],
+            intensity=decoded_fields.get("intensity"),
+            reflectivity=decoded_fields.get("reflectivity"),
+            beam_id=decoded_fields.get("beam_id"),
+            range=decoded_fields.get("range"),
+            near_ir=decoded_fields.get("near_ir"),
+            azimuth=decoded_fields.get("azimuth"),
+            elevation=decoded_fields.get("elevation"),
+            confidence=decoded_fields.get("confidence"),
+            return_type=decoded_fields.get("return_type"),
+            point_timestamp=decoded_fields.get("point_timestamp"),
+        )
+
+    @classmethod
+    def translate(cls, ros_msg: ROSMessage, **kwargs: Any) -> Message:
+        """
+        Translates a ROS message into a Mosaico Message.
+
+        Returns:
+            Message: The translated message containing a `Lidar` object.
+
+        Raises:
+            Exception: Wraps any translation error with context (topic name, timestamp).
+        """
+        return super().translate(ros_msg, **kwargs)
+
+    @classmethod
+    def from_dict(cls, ros_data: dict) -> Lidar:
+        """
+        Create a Lidar instance from a ROS message dictionary.
+
+        Example:
+        ```python
+        ros_data = {
+            "height": 1,
+            "width": 3,
+            "fields": [...],
+            "is_bigendian": False,
+            "point_step": 16,
+            "row_step": 48,
+            "data": [...],
+            "is_dense": True,
+        }
+        # Automatically resolves to a flat Mosaico Lidar with attached data
+        mosaico_lidar = LidarAdapter.from_dict(ros_data)
+        ```
+        """
+        return super().from_dict(ros_data)
+
+    @classmethod
+    def schema_metadata(cls, ros_data: dict, **kwargs: Any) -> Optional[dict]:
+        """
+        Extract the ROS message specific schema metadata, if any.
+        """
+        return None
+
+
+class RadarAdapter(PointCloudAdapterBase[Radar]):
+    """
+    Adapter for translating ROS PointCloud2 messages to Mosaico `Radar`.
+    This Adapter needs to be specified in the field `adapters_override` of `RosInjectionConfig`.
+
+    **Supported ROS Types:**
+
+    - [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html)
+
+    """
+
+    __mosaico_ontology_type__: Type[Radar] = Radar
+    _REQUIRED_FIELDS = [
+        name for name, field in Radar.model_fields.items() if field.is_required()
+    ]
+
+    @classmethod
+    def translate(cls, ros_msg: ROSMessage, **kwargs: Any) -> Message:
+        """
+        Translates a ROS message into a Mosaico Message.
+
+        Returns:
+            Message: The translated message containing a `Radar` object.
+
+        Raises:
+            Exception: Wraps any translation error with context (topic name, timestamp).
+        """
+        return super().translate(ros_msg, **kwargs)
+
+    @classmethod
+    def _build(cls, decoded_fields: dict[str, list]) -> Radar:
+        return Radar(
+            x=decoded_fields["x"],
+            y=decoded_fields["y"],
+            z=decoded_fields["z"],
+            range=decoded_fields.get("range"),
+            azimuth=decoded_fields.get("azimuth"),
+            elevation=decoded_fields.get("elevation"),
+            rcs=decoded_fields.get("rcs"),
+            snr=decoded_fields.get("snr"),
+            doppler_velocity=decoded_fields.get("doppler_velocity"),
+            vx=decoded_fields.get("vx"),
+            vy=decoded_fields.get("vy"),
+            vx_comp=decoded_fields.get("vx_comp"),
+            vy_comp=decoded_fields.get("vy_comp"),
+            ax=decoded_fields.get("ax"),
+            ay=decoded_fields.get("ay"),
+            radial_speed=decoded_fields.get("radial_speed"),
+        )
+
+    @classmethod
+    def from_dict(cls, ros_data: dict) -> Radar:
+        """
+        Create a Radar instance from a ROS message dictionary.
+        Example:
+        ```python
+        ros_data = {
+            "height": 1,
+            "width": 3,
+            "fields": [...],
+            "is_bigendian": False,
+            "point_step": 16,
+            "row_step": 48,
+            "data": [...],
+            "is_dense": True,
+        }
+        # Automatically resolves to a flat Mosaico Radar with attached data
+        mosaico_radar = RadarAdapter.from_dict(ros_data)
+        ```
+        """
+        return super().from_dict(ros_data)
+
+    @classmethod
+    def schema_metadata(cls, ros_data: dict, **kwargs: Any) -> Optional[dict]:
+        """
+        Extract the ROS message specific schema metadata, if any.
+        """
+        return None
+
+
+class RGBDCameraAdapter(PointCloudAdapterBase[RGBDCamera]):
+    """
+    Adapter for translating ROS PointCloud2 messages to Mosaico `RGBDCamera`.
+    This Adapter needs to be specified in the field `adapters_override` of `RosInjectionConfig`.
+
+    **Supported ROS Types:**
+
+    - [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html)
+
+    """
+
+    __mosaico_ontology_type__: Type[RGBDCamera] = RGBDCamera
+    _REQUIRED_FIELDS = [
+        name for name, field in RGBDCamera.model_fields.items() if field.is_required()
+    ]
+
+    @classmethod
+    def translate(cls, ros_msg: ROSMessage, **kwargs: Any) -> Message:
+        """
+        Translates a ROS message into a Mosaico Message.
+
+        Returns:
+            Message: The translated message containing a `RGBDCamera` object.
+
+        Raises:
+            Exception: Wraps any translation error with context (topic name, timestamp).
+        """
+        return super().translate(ros_msg, **kwargs)
+
+    @classmethod
+    def _build(cls, decoded_fields: dict[str, list]) -> RGBDCamera:
+        return RGBDCamera(
+            x=decoded_fields["x"],
+            y=decoded_fields["y"],
+            z=decoded_fields["z"],
+            rgb=decoded_fields.get("rgb"),
+            intensity=decoded_fields.get("intensity"),
+        )
+
+    @classmethod
+    def from_dict(cls, ros_data: dict) -> RGBDCamera:
+        """
+        Create a RGBDCamera instance from a ROS message dictionary.
+
+        Example:
+        ```python
+        ros_data = {
+            "height": 1,
+            "width": 3,
+            "fields": [...],
+            "is_bigendian": False,
+            "point_step": 16,
+            "row_step": 48,
+            "data": [...],
+            "is_dense": True,
+        }
+        # Automatically resolves to a flat Mosaico RGBDCamera with attached data
+        mosaico_rgbd_camera = RGBDCameraAdapter.from_dict(ros_data)
+        ```
+        """
+        return super().from_dict(ros_data)
+
+    @classmethod
+    def schema_metadata(cls, ros_data: dict, **kwargs: Any) -> Optional[dict]:
+        """
+        Extract the ROS message specific schema metadata, if any.
+        """
+        return None
+
+
+class ToFCameraAdapter(PointCloudAdapterBase[ToFCamera]):
+    """
+    Adapter for translating ROS PointCloud2 messages to Mosaico `ToFCamera`.
+    This Adapter needs to be specified in the field `adapters_override` of `RosInjectionConfig`.
+
+    **Supported ROS Types:**
+
+    - [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html)
+
+    """
+
+    __mosaico_ontology_type__: Type[ToFCamera] = ToFCamera
+    _REQUIRED_FIELDS = [
+        name for name, field in ToFCamera.model_fields.items() if field.is_required()
+    ]
+
+    @classmethod
+    def translate(cls, ros_msg: ROSMessage, **kwargs: Any) -> Message:
+        """
+        Translates a ROS message into a Mosaico Message.
+
+        Returns:
+            Message: The translated message containing a `ToFCamera` object.
+
+        Raises:
+            Exception: Wraps any translation error with context (topic name, timestamp).
+        """
+        return super().translate(ros_msg, **kwargs)
+
+    @classmethod
+    def _build(cls, decoded_fields: dict[str, list]) -> ToFCamera:
+        return ToFCamera(
+            x=decoded_fields["x"],
+            y=decoded_fields["y"],
+            z=decoded_fields["z"],
+            rgb=decoded_fields.get("rgb"),
+            intensity=decoded_fields.get("intensity"),
+            noise=decoded_fields.get("noise"),
+            grayscale=decoded_fields.get("grayscale"),
+        )
+
+    @classmethod
+    def from_dict(cls, ros_data: dict) -> ToFCamera:
+        """
+        Create a ToFCamera instance from a ROS message dictionary.
+
+        Example:
+        ```python
+        ros_data = {
+            "height": 1,
+            "width": 3,
+            "fields": [...],
+            "is_bigendian": False,
+            "point_step": 16,
+            "row_step": 48,
+            "data": [...],
+            "is_dense": True,
+        }
+        # Automatically resolves to a flat Mosaico ToFCamera with attached data
+        mosaico_tof_camera = ToFCameraAdapter.from_dict(ros_data)
+        ```
+        """
+        return super().from_dict(ros_data)
+
+    @classmethod
+    def schema_metadata(cls, ros_data: dict, **kwargs: Any) -> Optional[dict]:
+        """
+        Extract the ROS message specific schema metadata, if any.
+        """
+        return None
+
+
+class StereoCameraAdapter(PointCloudAdapterBase[StereoCamera]):
+    """
+    Adapter for translating ROS PointCloud2 messages to Mosaico `StereoCamera`.
+    This Adapter needs to be specified in the field `adapters_override` of `RosInjectionConfig`.
+
+    **Supported ROS Types:**
+
+    - [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html)
+
+    """
+
+    __mosaico_ontology_type__: Type[StereoCamera] = StereoCamera
+    _REQUIRED_FIELDS = [
+        name for name, field in StereoCamera.model_fields.items() if field.is_required()
+    ]
+
+    @classmethod
+    def translate(cls, ros_msg: ROSMessage, **kwargs: Any) -> Message:
+        """
+        Translates a ROS message into a Mosaico Message.
+
+        Returns:
+            Message: The translated message containing a `StereoCamera` object.
+
+        Raises:
+            Exception: Wraps any translation error with context (topic name, timestamp).
+        """
+        return super().translate(ros_msg, **kwargs)
+
+    @classmethod
+    def _build(cls, decoded_fields: dict[str, list]) -> StereoCamera:
+        return StereoCamera(
+            x=decoded_fields["x"],
+            y=decoded_fields["y"],
+            z=decoded_fields["z"],
+            rgb=decoded_fields.get("rgb"),
+            intensity=decoded_fields.get("intensity"),
+            luma=decoded_fields.get("luma"),
+            cost=decoded_fields.get("cost"),
+        )
+
+    @classmethod
+    def from_dict(cls, ros_data: dict) -> StereoCamera:
+        """
+        Create a StereoCamera instance from a ROS message dictionary.
+
+        Example:
+        ```python
+        ros_data = {
+            "height": 1,
+            "width": 3,
+            "fields": [...],
+            "is_bigendian": False,
+            "point_step": 16,
+            "row_step": 48,
+            "data": [...],
+            "is_dense": True,
+        }
+        # Automatically resolves to a flat Mosaico StereoCamera with attached data
+        mosaico_stereo_camera = StereoCameraAdapter.from_dict(ros_data)
+        ```
+        """
+        return super().from_dict(ros_data)
+
+    @classmethod
+    def schema_metadata(cls, ros_data: dict, **kwargs: Any) -> Optional[dict]:
+        """
+        Extract the ROS message specific schema metadata, if any.
+        """
+        return None

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/sensor_msgs.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/sensor_msgs.py
@@ -1,8 +1,15 @@
+from abc import abstractmethod
 from typing import Any, List, Optional, Tuple, Type, TypeVar
 
+import numpy as np
+
+from mosaicolabs import Serializable
 from mosaicolabs.models import Message
 from mosaicolabs.models.data import ROI, Point3d, Vector2d
-from mosaicolabs.models.futures.laser import LaserScan, MultiEchoLaserScan
+from mosaicolabs.models.futures import (
+    LaserScan,
+    MultiEchoLaserScan,
+)
 from mosaicolabs.models.sensors import (
     GPS,
     IMU,
@@ -22,7 +29,7 @@ from .geometry_msgs import (
     QuaternionAdapter,
     Vector3Adapter,
 )
-from .helpers import _validate_msgdata
+from .helpers import _validate_msgdata, _validate_required_fields
 
 
 @register_default_adapter
@@ -1112,52 +1119,19 @@ class RobotJointAdapter(ROSAdapterBase[RobotJoint]):
         return None
 
 
-@register_default_adapter
-class PointCloudAdapter(ROSAdapterBase[PointCloud2]):
+PointCloudModel = TypeVar(
+    "PointCloudModel",
+    bound=Serializable,
+)
+
+
+class PointCloudAdapterBase(ROSAdapterBase[PointCloudModel]):
     """
-        Adapter for translating ROS PointCloud2 messages to Mosaico `PointCloud2`.
-
-        **Supported ROS Types:**
-
-        - [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html)
-
-        Example:
-        ```python
-            ros_msg = ROSMessage(
-                timestamp=17000,
-                topic="/point_cloud",
-                msg_type="sensor_msgs/PointCloud2",
-                data={
-                    "height": 1,
-                    "width": 3,
-                    "fields": [
-                        {"name": "x", "offset": 0,  "datatype": 7, "count": 1},
-                        {"name": "y", "offset": 4,  "datatype": 7, "count": 1},
-                        {"name": "z", "offset": 8,  "datatype": 7, "count": 1},
-                    ],
-                    "is_bigendian": False,
-                    "point_step": 12,
-                    "row_step": 36,
-                    "data": b'\x00\x00\x80\x3f'  # x=1.0
-                            b'\x00\x00\x00\x40'  # y=2.0
-                            b'\x00\x00\x40\x40'  # z=3.0
-                            b'\x00\x00\x80\x3f'  # x=1.0
-                            b'\x00\x00\x00\x40'  # y=2.0
-                            b'\x00\x00\x40\x40'  # z=3.0
-                            b'\x00\x00\x80\x3f'  # x=1.0
-                            b'\x00\x00\x00\x40'  # y=2.0
-                            b'\x00\x00\x40\x40', # z=3.0
-                    "is_dense": True,
-                }
-            )
-            # Automatically resolves to a flat Mosaico PointCloud2 with attached metadata
-            mosaico_point_cloud = PointCloudAdapter.translate(ros_msg)
-    ```
+    Base adapter for translating ROS PointCloud2 message to Mosaico specific ontology.
     """
 
-    ros_msgtype: str | Tuple[str, ...] = "sensor_msgs/msg/PointCloud2"
+    ros_msgtype: str = "sensor_msgs/msg/PointCloud2"
 
-    __mosaico_ontology_type__: Type[PointCloud2] = PointCloud2
     _REQUIRED_KEYS = (
         "height",
         "width",
@@ -1169,12 +1143,164 @@ class PointCloudAdapter(ROSAdapterBase[PointCloud2]):
         "is_dense",
     )
 
+    _REQUIRED_FIELDS: list[str] = []
+
+    _DATATYPE_MAP = {
+        1: (1, np.int8),
+        2: (1, np.uint8),
+        3: (2, np.int16),
+        4: (2, np.uint16),
+        5: (4, np.int32),
+        6: (4, np.uint32),
+        7: (4, np.float32),
+        8: (8, np.float64),
+    }
+
     @classmethod
-    def translate(
-        cls,
-        ros_msg: ROSMessage,  # ROSMessage
-        **kwargs: Any,
-    ) -> Message:
+    def decode(cls, ros_data: dict) -> dict[str, list]:
+        """
+        Deserialize the binary buffer of a ROS [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html) message into named field arrays.
+
+        Args:
+            ros_data: Raw ROS message payload. Relevant keys: `data`, `height`, `width`,
+                    `fields`, `is_bigendian`, `point_step`.
+
+        Returns:
+            Dictionary mapping each field name to a list of decoded values. Returns empty lists for all fields if `height * width == 0`.
+
+        Raises:
+            ValueError: If a field exposes an unsupported `datatype`.
+
+        """
+        _validate_msgdata(cls, ros_data)
+
+        height = ros_data["height"]
+        width = ros_data["width"]
+        fields = [PointField(**f) for f in ros_data["fields"]]
+        is_bigendian = ros_data["is_bigendian"]
+        point_step = ros_data["point_step"]
+        data = bytes(ros_data["data"])
+
+        num_points = height * width
+
+        if num_points == 0:
+            return {field.name: [] for field in fields}
+
+        endian_prefix = ">" if is_bigendian else "<"
+
+        raw = np.frombuffer(bytes(data), dtype=np.uint8).reshape(num_points, point_step)
+
+        result = {}
+        for field in fields:
+            itemsize, np_dtype = cls._DATATYPE_MAP.get(field.datatype, (None, None))
+
+            if np_dtype is None:
+                raise ValueError(
+                    f"field datatype = {field.datatype} not supported. Supported data types: {cls._DATATYPE_MAP.items()}"
+                )
+
+            dtype = np.dtype(np_dtype).newbyteorder(endian_prefix)
+
+            field_raw = np.ascontiguousarray(
+                raw[:, field.offset : field.offset + itemsize * field.count]
+            )
+            values = field_raw.view(dtype)
+            if field.count == 1:
+                values = values.reshape(num_points)
+
+            result[field.name] = values.astype(np_dtype, copy=False)
+
+        return {name: arr.tolist() for name, arr in result.items()}
+
+    @classmethod
+    @abstractmethod
+    def _build(cls, decoded_fields: dict[str, list]) -> PointCloudModel: ...
+
+    @classmethod
+    def from_dict(cls, ros_data: dict) -> PointCloudModel:
+        """
+        Convert a raw ROS PointCloud2 message dictionary into a typed Mosaico model.
+
+        Args:
+            ros_data: Raw ROS message payload as a dictionary.
+
+        Returns:
+            A fully populated instance of the target `PointCloudModel` subtype (e.g. `Lidar`, `Radar`, `RGBDCamera`, ...).
+
+        Raises:
+            ValueError: If any required message key is missing from `ros_data`,
+                or if any required field is absent after decoding.
+
+        Note:
+            This method is **not** meant to be overridden in most subclasses.
+            Only [`PointCloudAdapter`][mosaicolabs.ros_bridge.adapters.sensor_msgs.PointCloudAdapter] overrides it,
+            as it operates at a different abstraction level, returning the raw
+            [`PointCloud2`][mosaicolabs.ros_bridge.data_ontology.PointCloud2] message instead of a decoded model.
+        """
+        decoded_fields = cls.decode(ros_data)
+        _validate_required_fields(cls, cls._REQUIRED_FIELDS, decoded_fields)
+        return cls._build(decoded_fields)
+
+    @classmethod
+    def schema_metadata(cls, ros_data: dict, **kwargs: Any) -> Optional[dict]:
+        """
+        Extract the ROS message specific schema metadata, if any.
+        """
+        return None
+
+
+@register_default_adapter
+class PointCloudAdapter(PointCloudAdapterBase[PointCloud2]):
+    """
+    Adapter for translating ROS PointCloud2 messages to Mosaico `PointCloud2`.
+
+    **Supported ROS Types:**
+
+    - [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html)
+
+    Example:
+    ```python
+    ros_msg = ROSMessage(
+                timestamp=17000,
+                topic="/point_cloud",
+                msg_type="sensor_msgs/PointCloud2",
+                data = {
+                    "height": 1,
+                    "width": 3,
+                    "fields": [
+                        {"name": "x", "offset": 0,  "datatype": 7, "count": 1},
+                        {"name": "y", "offset": 4,  "datatype": 7, "count": 1},
+                        {"name": "z", "offset": 8,  "datatype": 7, "count": 1},
+                    ],
+                "is_bigendian": False,
+                "point_step": 12,
+                "row_step": 36,
+                "data": ...,
+                "is_dense": True,
+                }
+            )
+    # Automatically resolves to a flat Mosaico PointCloud2 with attached metadata
+    mosaico_point_cloud = PointCloudAdapter.translate(ros_msg)
+    ```
+    """
+
+    __mosaico_ontology_type__: Type[PointCloud2] = PointCloud2
+
+    @classmethod
+    def _build(cls, decoded_fields: dict[str, list]) -> PointCloud2:
+        raise NotImplementedError("PointCloudAdapter uses from_dict directly.")
+
+    @classmethod
+    def translate(cls, ros_msg: ROSMessage, **kwargs: Any) -> Message:
+        """
+        Translates a ROS message into a Mosaico Message.
+
+        Returns:
+            Message: The translated message containing a `PointCloud2` object.
+
+        Raises:
+            Exception: Wraps any translation error with context (topic name, timestamp).
+        """
         return super().translate(ros_msg, **kwargs)
 
     @classmethod
@@ -1183,37 +1309,37 @@ class PointCloudAdapter(ROSAdapterBase[PointCloud2]):
         Converts the raw dictionary data into the specific Mosaico type.
 
         Example:
-            ```python
-            ros_data = {
-                "height": 1,           # unorganized point cloud = 1 row
-                "width": 3,            # 3 points
-                "fields": [
-                    {
-                        "name": "x",
-                        "offset": 0,
-                        "datatype": 7,  # FLOAT32
-                        "count": 1
-                    },
-                    {
-                        "name": "y",
-                        "offset": 4,
-                        "datatype": 7,  # FLOAT32
-                        "count": 1
-                    },
-                    {
-                        "name": "z",
-                        "offset": 8,
-                        "datatype": 7,  # FLOAT32
-                        "count": 1
-                    },
-                ],
-                "is_bigendian": False,
-                "point_step": 12,      # 3 fields * 4 bytes (float32) = 12 bytes per point
-                "row_step": 36,        # point_step * width = 12 * 3 = 36 bytes per row
-                "data": b'\x00\x00\x80\x3f'  # x=1.0
-                        b'\x00\x00\x00\x40'  # y=2.0
-                        b'\x00\x00\x40\x40'  # z=3.0
+        ```python
+        ros_data = {
+            "height": 1,           # unorganized point cloud = 1 row
+            "width": 3,            # 3 points
+            "fields": [
+                {
+                    "name": "x",
+                    "offset": 0,
+                    "datatype": 7,  # FLOAT32
+                    "count": 1
+                },
+                {
+                    "name": "y",
+                    "offset": 4,
+                    "datatype": 7,  # FLOAT32
+                    "count": 1
+                },
+                {
+                    "name": "z",
+                    "offset": 8,
+                    "datatype": 7,  # FLOAT32
+                    "count": 1
+                },
+            ],
+            "is_bigendian": False,
+            "point_step": 12,      # 3 fields * 4 bytes (float32) = 12 bytes per point
+            "row_step": 36,        # point_step * width = 12 * 3 = 36 bytes per row
+            "data": ...,
+            "is_dense": True
             }
+        ```
         """
 
         _validate_msgdata(cls, ros_data)
@@ -1258,10 +1384,6 @@ class LaserScannerAdapterBase(ROSAdapterBase[_LT]):
     )
 
     @classmethod
-    def translate(cls, ros_msg: ROSMessage, **kwargs: Any) -> Message:
-        return super().translate(ros_msg, **kwargs)
-
-    @classmethod
     def from_dict(cls, ros_data: dict) -> _LT:
         """
         Create a LaserScan/MultiEchoLaserScan instance from a ROS message dictionary.
@@ -1303,22 +1425,35 @@ class LaserScanAdapter(LaserScannerAdapterBase[LaserScan]):
     __mosaico_ontology_type__: Type[LaserScan] = LaserScan
 
     @classmethod
+    def translate(cls, ros_msg: ROSMessage, **kwargs: Any) -> Message:
+        """
+        Translates a ROS message into a Mosaico Message.
+
+        Returns:
+            Message: The translated message containing a `LaserScan` object.
+
+        Raises:
+            Exception: Wraps any translation error with context (topic name, timestamp).
+        """
+        return super().translate(ros_msg, **kwargs)
+
+    @classmethod
     def from_dict(cls, ros_data: dict) -> LaserScan:
         """
         Create a LaserScan instance from a ROS message dictionary.
 
         Example:
         ```python
-            ros_data = {
-                "angle_min": -1.57,
-                "angle_max":  1.57,
-                "angle_increment": 0.01,
-                "time_increment": 0.0,
-                "scan_time": 0.1,
-                "range_min": 0.2,
-                "range_max": 10.0,
-                "ranges": [1.0, 1.1, 1.2],
-                "intensities": [100.0, 110.0, 120.0],
+        ros_data = {
+            "angle_min": -1.57,
+            "angle_max":  1.57,
+            "angle_increment": 0.01,
+            "time_increment": 0.0,
+            "scan_time": 0.1,
+            "range_min": 0.2,
+            "range_max": 10.0,
+            "ranges": [1.0, 1.1, 1.2],
+            "intensities": [100.0, 110.0, 120.0],
         }
         # Automatically resolves to a flat Mosaico LaserScan with attached data
         mosaico_laser_scan = LaserScanAdapter.from_dict(ros_data)
@@ -1343,22 +1478,35 @@ class MultiEchoLaserScanAdapter(LaserScannerAdapterBase[MultiEchoLaserScan]):
     __mosaico_ontology_type__: Type[MultiEchoLaserScan] = MultiEchoLaserScan
 
     @classmethod
+    def translate(cls, ros_msg: ROSMessage, **kwargs: Any) -> Message:
+        """
+        Translates a ROS message into a Mosaico Message.
+
+        Returns:
+            Message: The translated message containing a `MultiEchoLaserScan` object.
+
+        Raises:
+            Exception: Wraps any translation error with context (topic name, timestamp).
+        """
+        return super().translate(ros_msg, **kwargs)
+
+    @classmethod
     def from_dict(cls, ros_data: dict) -> MultiEchoLaserScan:
         """
         Create a MultiEchoLaserScan instance from a ROS message dictionary.
 
         Example:
         ```python
-            ros_data = {
-                "angle_min": -1.57,
-                "angle_max":  1.57,
-                "angle_increment": 0.01,
-                "time_increment": 0.0,
-                "scan_time": 0.1,
-                "range_min": 0.2,
-                "range_max": 10.0,
-                "ranges": [[1.0, 1.1, 1.2], [2.0, 2.1, 2.2], [3.0, 3.1, 3.2]],
-                "intensities": [[100.0, 110.0, 120.0], [200.0, 210.0, 220.0], [300.0, 310.0, 320.0]],
+        ros_data = {
+            "angle_min": -1.57,
+            "angle_max":  1.57,
+            "angle_increment": 0.01,
+            "time_increment": 0.0,
+            "scan_time": 0.1,
+            "range_min": 0.2,
+            "range_max": 10.0,
+            "ranges": [[1.0, 1.1, 1.2], [2.0, 2.1, 2.2], [3.0, 3.1, 3.2]],
+            "intensities": [[100.0, 110.0, 120.0], [200.0, 210.0, 220.0], [300.0, 310.0, 320.0]],
         }
         # Automatically resolves to a flat Mosaico MultiEchoLaserScanAdapter with attached data
         mosaico_laser_scan = MultiEchoLaserScanAdapter.from_dict(ros_data)

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/sensor_msgs.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/sensor_msgs.py
@@ -1242,7 +1242,7 @@ _LT = TypeVar("_LT", LaserScan, MultiEchoLaserScan)
 
 class LaserScannerAdapterBase(ROSAdapterBase[_LT]):
     """
-    Base adapter for translating ROS LaserScan messages to Mosaico `LaserScan`/`MultiEchoLaserScan` .
+    Base adapter for translating ROS LaserScan and MultiEchoLaserScan messages to Mosaico `LaserScan` and `MultiEchoLaserScan` .
     """
 
     _REQUIRED_KEYS = (
@@ -1258,11 +1258,7 @@ class LaserScannerAdapterBase(ROSAdapterBase[_LT]):
     )
 
     @classmethod
-    def translate(
-        cls,
-        ros_msg: ROSMessage,  # ROSMessage
-        **kwargs: Any,
-    ) -> Message:
+    def translate(cls, ros_msg: ROSMessage, **kwargs: Any) -> Message:
         return super().translate(ros_msg, **kwargs)
 
     @classmethod

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/sensor_msgs.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/sensor_msgs.py
@@ -2,6 +2,7 @@ from typing import Any, List, Optional, Tuple, Type
 
 from mosaicolabs.models import Message
 from mosaicolabs.models.data import ROI, Point3d, Vector2d
+from mosaicolabs.models.futures.laser import LaserScan
 from mosaicolabs.models.sensors import (
     GPS,
     IMU,
@@ -1226,6 +1227,79 @@ class PointCloudAdapter(ROSAdapterBase[PointCloud2]):
             row_step=ros_data["row_step"],
             data=bytes(ros_data["data"]),
             is_dense=ros_data["is_dense"],
+        )
+
+    @classmethod
+    def schema_metadata(cls, ros_data: dict, **kwargs: Any) -> Optional[dict]:
+        """
+        Extract the ROS message specific schema metadata, if any.
+        """
+        return None
+
+
+@register_default_adapter
+class LaserScanAdapter(ROSAdapterBase[LaserScan]):
+    """
+    Adapter for translating ROS LaserScan messages to Mosaico `LaserScan`.
+
+    **Supported ROS Types:**
+
+    - [`sensor_msgs/msg/LaserScan`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/LaserScan.html)
+
+    """
+
+    ros_msgtype: str | Tuple[str, ...] = "sensor_msgs/msg/LaserScan"
+
+    __mosaico_ontology_type__: Type[LaserScan] = LaserScan
+    _REQUIRED_KEYS = (
+        "angle_min",
+        "angle_max",
+        "angle_increment",
+        "time_increment",
+        "scan_time",
+        "range_min",
+        "range_max",
+        "ranges",
+        "intensities",
+    )
+
+    @classmethod
+    def translate(cls, ros_msg: ROSMessage, **kwargs: Any) -> Message:
+        return super().translate(ros_msg, **kwargs)
+
+    @classmethod
+    def from_dict(cls, ros_data: dict) -> LaserScan:
+        """
+        Create a LaserScan instance from a ROS message dictionary.
+
+        Example:
+        ```python
+            ros_data = {
+                "angle_min": -1.57,
+                "angle_max":  1.57,
+                "angle_increment": 0.01,
+                "time_increment": 0.0,
+                "scan_time": 0.1,
+                "range_min": 0.2,
+                "range_max": 10.0,
+                "ranges": [1.0, 1.1, 1.2],
+                "intensities": [100.0, 110.0, 120.0],
+        }
+        # Automatically resolves to a flat Mosaico LaserScan with attached data
+        mosaico_laser_scan = LaserScanAdapter.from_dict(ros_data)
+        ```
+        """
+        _validate_msgdata(cls, ros_data)
+        return LaserScan(
+            angle_min=ros_data["angle_min"],
+            angle_max=ros_data["angle_max"],
+            angle_increment=ros_data["angle_increment"],
+            time_increment=ros_data["time_increment"],
+            scan_time=ros_data["scan_time"],
+            range_min=ros_data["range_min"],
+            range_max=ros_data["range_max"],
+            ranges=ros_data["ranges"],
+            intensities=ros_data["intensities"],
         )
 
     @classmethod

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/sensor_msgs.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/sensor_msgs.py
@@ -1,8 +1,8 @@
-from typing import Any, List, Optional, Tuple, Type
+from typing import Any, List, Optional, Tuple, Type, TypeVar
 
 from mosaicolabs.models import Message
 from mosaicolabs.models.data import ROI, Point3d, Vector2d
-from mosaicolabs.models.futures.laser import LaserScan
+from mosaicolabs.models.futures.laser import LaserScan, MultiEchoLaserScan
 from mosaicolabs.models.sensors import (
     GPS,
     IMU,
@@ -1237,20 +1237,14 @@ class PointCloudAdapter(ROSAdapterBase[PointCloud2]):
         return None
 
 
-@register_default_adapter
-class LaserScanAdapter(ROSAdapterBase[LaserScan]):
+_LT = TypeVar("_LT", LaserScan, MultiEchoLaserScan)
+
+
+class LaserScannerAdapterBase(ROSAdapterBase[_LT]):
     """
-    Adapter for translating ROS LaserScan messages to Mosaico `LaserScan`.
-
-    **Supported ROS Types:**
-
-    - [`sensor_msgs/msg/LaserScan`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/LaserScan.html)
-
+    Base adapter for translating ROS LaserScan messages to Mosaico `LaserScan`/`MultiEchoLaserScan` .
     """
 
-    ros_msgtype: str | Tuple[str, ...] = "sensor_msgs/msg/LaserScan"
-
-    __mosaico_ontology_type__: Type[LaserScan] = LaserScan
     _REQUIRED_KEYS = (
         "angle_min",
         "angle_max",
@@ -1264,8 +1258,53 @@ class LaserScanAdapter(ROSAdapterBase[LaserScan]):
     )
 
     @classmethod
-    def translate(cls, ros_msg: ROSMessage, **kwargs: Any) -> Message:
+    def translate(
+        cls,
+        ros_msg: ROSMessage,  # ROSMessage
+        **kwargs: Any,
+    ) -> Message:
         return super().translate(ros_msg, **kwargs)
+
+    @classmethod
+    def from_dict(cls, ros_data: dict) -> _LT:
+        """
+        Create a LaserScan/MultiEchoLaserScan instance from a ROS message dictionary.
+        """
+        _validate_msgdata(cls, ros_data)
+        return cls.__mosaico_ontology_type__(
+            angle_min=ros_data["angle_min"],
+            angle_max=ros_data["angle_max"],
+            angle_increment=ros_data["angle_increment"],
+            time_increment=ros_data["time_increment"],
+            scan_time=ros_data["scan_time"],
+            range_min=ros_data["range_min"],
+            range_max=ros_data["range_max"],
+            ranges=ros_data["ranges"],
+            intensities=ros_data["intensities"],
+        )
+
+    @classmethod
+    def schema_metadata(cls, ros_data: dict, **kwargs: Any) -> Optional[dict]:
+        """
+        Extract the ROS message specific schema metadata, if any.
+        """
+        return None
+
+
+@register_default_adapter
+class LaserScanAdapter(LaserScannerAdapterBase[LaserScan]):
+    """
+    Adapter for translating ROS LaserScan messages to Mosaico `LaserScan`.
+
+    **Supported ROS Types:**
+
+    - [`sensor_msgs/msg/LaserScan`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/LaserScan.html)
+
+    """
+
+    ros_msgtype: str | Tuple[str, ...] = "sensor_msgs/msg/LaserScan"
+
+    __mosaico_ontology_type__: Type[LaserScan] = LaserScan
 
     @classmethod
     def from_dict(cls, ros_data: dict) -> LaserScan:
@@ -1289,22 +1328,44 @@ class LaserScanAdapter(ROSAdapterBase[LaserScan]):
         mosaico_laser_scan = LaserScanAdapter.from_dict(ros_data)
         ```
         """
-        _validate_msgdata(cls, ros_data)
-        return LaserScan(
-            angle_min=ros_data["angle_min"],
-            angle_max=ros_data["angle_max"],
-            angle_increment=ros_data["angle_increment"],
-            time_increment=ros_data["time_increment"],
-            scan_time=ros_data["scan_time"],
-            range_min=ros_data["range_min"],
-            range_max=ros_data["range_max"],
-            ranges=ros_data["ranges"],
-            intensities=ros_data["intensities"],
-        )
+        return super().from_dict(ros_data)
+
+
+@register_default_adapter
+class MultiEchoLaserScanAdapter(LaserScannerAdapterBase[MultiEchoLaserScan]):
+    """
+    Adapter for translating ROS MultiEchoLaserScan messages to Mosaico `MultiEchoLaserScan`.
+
+    **Supported ROS Types:**
+
+    - [`sensor_msgs/msg/MultiEchoLaserScan`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/MultiEchoLaserScan.html)
+
+    """
+
+    ros_msgtype: str | Tuple[str, ...] = "sensor_msgs/msg/MultiEchoLaserScan"
+
+    __mosaico_ontology_type__: Type[MultiEchoLaserScan] = MultiEchoLaserScan
 
     @classmethod
-    def schema_metadata(cls, ros_data: dict, **kwargs: Any) -> Optional[dict]:
+    def from_dict(cls, ros_data: dict) -> MultiEchoLaserScan:
         """
-        Extract the ROS message specific schema metadata, if any.
+        Create a MultiEchoLaserScan instance from a ROS message dictionary.
+
+        Example:
+        ```python
+            ros_data = {
+                "angle_min": -1.57,
+                "angle_max":  1.57,
+                "angle_increment": 0.01,
+                "time_increment": 0.0,
+                "scan_time": 0.1,
+                "range_min": 0.2,
+                "range_max": 10.0,
+                "ranges": [[1.0, 1.1, 1.2], [2.0, 2.1, 2.2], [3.0, 3.1, 3.2]],
+                "intensities": [[100.0, 110.0, 120.0], [200.0, 210.0, 220.0], [300.0, 310.0, 320.0]],
+        }
+        # Automatically resolves to a flat Mosaico MultiEchoLaserScanAdapter with attached data
+        mosaico_laser_scan = MultiEchoLaserScanAdapter.from_dict(ros_data)
+        ```
         """
-        return None
+        return super().from_dict(ros_data)


### PR DESCRIPTION
* Added LaserScanAdapterBase for LaserScan and MultiEchoLaserScan adapters.
* Added PointCloudAdapterBase for sensor data transmitted via sensor_msgs/msg/PointCloud2.
* Added ROS adapters for all ontologies in `model/futures/`.
* Updated documentation for adapter overrides and PointCloud2 custom adapter guide.