### PR TITLE
feat(py) Update SyncTransformer documentation to highlight its stateful nature.

### DIFF
--- a/doc/docs/SDK/bridges/ml.md
+++ b/doc/docs/SDK/bridges/ml.md
@@ -13,7 +13,8 @@ Working with robotics and multi-modal datasets presents three primary technical 
 
 
 ## From Sequences to DataFrames
-API Reference: [`mosaicolabs.ml.DataFrameExtractor`][mosaicolabs.ml.DataFrameExtractor]
+???question "API Reference"
+    [`mosaicolabs.ml.DataFrameExtractor`][mosaicolabs.ml.DataFrameExtractor]
 
 The [`DataFrameExtractor`][mosaicolabs.ml.DataFrameExtractor] is a specialized utility designed to convert Mosaico sequences into tabular formats. Unlike standard streamers that instantiate individual Python objects, this extractor operates at the **Batch Level** by pulling raw `RecordBatch` objects directly from the underlying stream to maximize throughput.
 
@@ -76,7 +77,8 @@ with MosaicoClient.connect("localhost", 6726):
 ```
 
 ## Sparse to Dense Representation
-API Reference: [`mosaicolabs.ml.SyncTransformer`][mosaicolabs.ml.SyncTransformer]
+???question "API Reference"
+    [`mosaicolabs.ml.SyncTransformer`][mosaicolabs.ml.SyncTransformer]
 
 The [`SyncTransformer`][mosaicolabs.ml.SyncTransformer] is a temporal resampler designed to solve the **Heterogeneous Sampling** problem inherent in robotics and Physical AI. 
 It aligns multi-rate sensor streams (for example, an IMU at 100Hz and a GPS at 5Hz) onto a uniform, fixed-frequency grid to prepare them for machine learning models.
@@ -88,11 +90,57 @@ Unlike standard resamplers that treat each data batch in isolation, this transfo
 * **Stateful Continuity**: It maintains an internal cache of the last known sensor values and the next expected grid tick, allowing signals to bridge the gap between independent DataFrame chunks.
 * **Semantic Integrity**: It respects the physical reality of data acquisition by yielding `None` for grid ticks that occur before a sensor's first physical measurement, avoiding data "hallucination".
 * **Vectorized Performance**: Internal kernels leverage high-speed lookups for high-throughput processing.
-* **Protocol-Based Extensibility**: The mathematical logic for resampling is decoupled through a `SynchPolicy` protocol, allowing for custom kernel injection.
+* **Protocol-Based Extensibility**: The mathematical logic for resampling is decoupled through a [`SyncPolicy`][mosaicolabs.ml.SyncPolicy] protocol, allowing for custom kernel injection.
 
+### Implementation and Stateful Lifecycle
+
+Architecturally, the [`SyncTransformer`][mosaicolabs.ml.SyncTransformer] is implemented as a **stateful state-machine** designed to maintain signal continuity across independent data chunks. Unlike standard library resamplers that often treat each input batch as an isolated event, this transformer is engineered to "stitch" the temporal gaps between the windowed DataFrames yielded by the [`DataFrameExtractor`][mosaicolabs.ml.DataFrameExtractor].
+
+#### Internal State Management
+The transformer maintains two critical internal buffers that persist for its entire lifecycle:
+
+* **`_next_timestamp_ns`**: A scalar value tracking the exact nanosecond where the next grid tick must occur. This prevents temporal drift across hours of recording by ensuring the fixed-frequency grid remains globally aligned.
+* **`_last_values`**: A dictionary that caches the final (timestamp, value) tuple for every topic processed in the previous chunk.
+
+
+#### The Transformation Pipeline
+When [`transform()`][mosaicolabs.ml.SyncTransformer.transform] is called on a new `sparse_chunk`, the following internal operations occur:
+
+1.  **Grid Synthesis**: The transformer generates a new time grid starting precisely from `_next_timestamp_ns` and extending to the end of the current chunk.
+2.  **Data Prepending**: Through the `_prepare_data` method, the transformer retrieves the last known value of each topic and **prepends** it to the current chunk's arrays. This ensures that the resampling algorithm (e.g., [`SyncHold`][mosaicolabs.ml.SyncHold]) has a reference point to fill the gap at the very beginning of the new window.
+3.  **Policy Delegation**: The actual mathematical mapping is delegated to the configured [`SyncPolicy`][mosaicolabs.ml.SyncPolicy], which yields the final dense values for the synthesized grid.
+
+
+!!!danger "The 'Re-instantiation' Trap"
+    A common architectural error is re-instantiating the `SyncTransformer` inside a processing loop. Because the transformer is stateful, **it must be instantiated once outside the loop** to function correctly.
+
+    Re-instantiating the transformer inside the loop destroys the internal cache, causing signal discontinuities and potential data "hallucination" at the start of every chunk.
+
+    ```python
+    # ERROR: Transformer is created inside the loop
+    for sparse_chunk in extractor.to_pandas_chunks():
+        # This resets the grid and last_values every iteration!
+        transformer = SyncTransformer(target_fps=50) 
+        dense_chunk = transformer.transform(sparse_chunk)
+    ```
+
+    #### Correct Pattern (Persistent State)
+    By keeping the instance outside the loop, the transformer correctly bridges the gap between `sparse_chunk_N` and `sparse_chunk_N+1`.
+
+    ```python
+    # CORRECT: Instantiate once
+    transformer = SyncTransformer(target_fps=50)
+
+    for sparse_chunk in extractor.to_pandas_chunks():
+        # transform() updates internal state and prepares it for the next call
+        dense_chunk = transformer.transform(sparse_chunk)
+    ```
+
+    If you need to reuse the same transformer instance for a different recording or sequence, you must call the [`.reset()`][mosaicolabs.ml.SyncTransformer.reset] method to clear the internal buffers and prepare for a new grid alignment.
 
 ### Implemented Synchronization Policies
-API Reference: [`mosaicolabs.ml.SyncPolicy`][mosaicolabs.ml.SyncPolicy]
+???question "API Reference"
+    [`mosaicolabs.ml.SyncPolicy`][mosaicolabs.ml.SyncPolicy]
 
 Each policy defines a specific logic for how the transformer bridges temporal gaps between sparse data points.
 
@@ -111,6 +159,39 @@ Each policy defines a specific logic for how the transformer bridges temporal ga
 * **Behavior**: Ensures a grid tick only receives a value if a new measurement actually occurred within that specific grid interval; otherwise, it returns `None`.
 * **Best For**: Downsampling high-frequency data where a strict 1-to-1 relationship between windows and unique hardware events is required.
 
+### Memory & Performance Best Practices
+
+The memory footprint of your ML pipeline is primarily governed by the product of two variables: the temporal window size (`window_sec`) in [`DataFrameExtractor.to_pandas_chunks()`][mosaicolabs.ml.DataFrameExtractor.to_pandas_chunks] and the synthesis frequency (`target_fps`) in [`SyncTransformer.transform()`][mosaicolabs.ml.SyncTransformer.transform].
+
+#### Resource Consumption Matrix
+
+| Parameter Configuration | Memory Impact | CPU Impact | Use Case |
+| :--- | :--- | :--- | :--- |
+| **Small Window / Low FPS**<br>(1s / 10Hz) | **Minimal**: Lowest RAM overhead per chunk. | Low | Real-time monitoring, low-power edge devices. |
+| **Large Window / Low FPS**<br>(60s / 10Hz) | **Moderate**: High memory usage in the `DataFrameExtractor` due to large sparse buffers. | Moderate | Batch analysis where global context is needed before transformation. |
+| **Small Window / High FPS**<br>(1s / 1000Hz) | **High**: Rapid creation of many dense rows. Heavy overhead on Python's Garbage Collector. | High | High-fidelity signal processing (e.g., vibration analysis). |
+| **Large Window / High FPS**<br>(60s / 1000Hz) | **Critical**: Risk of `MemoryError`. Can generate millions of rows in a single `transform()` call. | Very High | Deep Learning training on high-end workstations with 64GB+ RAM. |
+
+#### Optimization Strategies
+
+1.  **Avoid the "Full Load" Trap**:
+    The `DataFrameExtractor` is designed for (batched) streaming. If you set `window_sec` to a value greater than the total sequence duration, the extractor will fall back to a "Full Load" mode, attempting to load the entire recording into RAM, which can mean multi-GB batch for heavy datasets.
+
+2.  **The Rule of 100k Rows**:
+    As a general architectural guideline, aim for a configuration where `window_sec * target_fps < 100,000` rows per chunk (for time-series). This keeps the Pandas operations within the L3 cache limits of most modern CPUs and ensures the garbage collector can keep up with the loop iterations.
+
+3.  **Downsampling before Transformation**:
+    If you have high-frequency raw data (e.g., IMU at 400Hz) but only need 50Hz for your ML model, use the `SyncDrop` policy. It is significantly faster than `SyncHold` because it discards redundant intermediate samples before the dense grid is synthesized, reducing the internal array sizes during the `_prepare_data` phase.
+
+4.  **Garbage Collection in Long Loops**:
+    When processing sequences that span several hours, Python's automatic reference counting may not trigger fast enough. If you observe a "memory leak" (steadily increasing RAM usage), explicitly delete the `dense_chunk` at the end of your loop:
+
+    ```python
+    for sparse_chunk in extractor.to_pandas_chunks():
+        dense_chunk = transformer.transform(sparse_chunk)
+        # ... process ...
+        del dense_chunk # Explicitly signal for GC
+    ```
 
 ### Scikit-Learn Compatibility
 

--- a/doc/docs/SDK/bridges/ml.md
+++ b/doc/docs/SDK/bridges/ml.md
@@ -13,7 +13,7 @@ Working with robotics and multi-modal datasets presents three primary technical 
 
 
 ## From Sequences to DataFrames
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.ml.DataFrameExtractor`][mosaicolabs.ml.DataFrameExtractor]
 
 The [`DataFrameExtractor`][mosaicolabs.ml.DataFrameExtractor] is a specialized utility designed to convert Mosaico sequences into tabular formats. Unlike standard streamers that instantiate individual Python objects, this extractor operates at the **Batch Level** by pulling raw `RecordBatch` objects directly from the underlying stream to maximize throughput.
@@ -77,7 +77,7 @@ with MosaicoClient.connect("localhost", 6726):
 ```
 
 ## Sparse to Dense Representation
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.ml.SyncTransformer`][mosaicolabs.ml.SyncTransformer]
 
 The [`SyncTransformer`][mosaicolabs.ml.SyncTransformer] is a temporal resampler designed to solve the **Heterogeneous Sampling** problem inherent in robotics and Physical AI. 
@@ -111,7 +111,7 @@ When [`transform()`][mosaicolabs.ml.SyncTransformer.transform] is called on a ne
 3.  **Policy Delegation**: The actual mathematical mapping is delegated to the configured [`SyncPolicy`][mosaicolabs.ml.SyncPolicy], which yields the final dense values for the synthesized grid.
 
 
-!!!danger "The 'Re-instantiation' Trap"
+!!! danger "The 'Re-instantiation' Trap"
     A common architectural error is re-instantiating the `SyncTransformer` inside a processing loop. Because the transformer is stateful, **it must be instantiated once outside the loop** to function correctly.
 
     Re-instantiating the transformer inside the loop destroys the internal cache, causing signal discontinuities and potential data "hallucination" at the start of every chunk.
@@ -139,7 +139,7 @@ When [`transform()`][mosaicolabs.ml.SyncTransformer.transform] is called on a ne
     If you need to reuse the same transformer instance for a different recording or sequence, you must call the [`.reset()`][mosaicolabs.ml.SyncTransformer.reset] method to clear the internal buffers and prepare for a new grid alignment.
 
 ### Implemented Synchronization Policies
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.ml.SyncPolicy`][mosaicolabs.ml.SyncPolicy]
 
 Each policy defines a specific logic for how the transformer bridges temporal gaps between sparse data points.

--- a/doc/docs/SDK/client.md
+++ b/doc/docs/SDK/client.md
@@ -3,7 +3,8 @@ title: Client
 description: Architecture and design of the MosaicoClient.
 ---
 
-API Reference: [`mosaicolabs.comm.MosaicoClient`][mosaicolabs.comm.MosaicoClient].
+???question "API Reference"
+    [`mosaicolabs.comm.MosaicoClient`][mosaicolabs.comm.MosaicoClient].
 
 The `MosaicoClient` is a resource manager designed to orchestrate distinct **Layers** of communication and processing. 
 This layered architecture ensures that high-throughput sensor data does not block critical control operations or application logic.

--- a/doc/docs/SDK/client.md
+++ b/doc/docs/SDK/client.md
@@ -3,7 +3,7 @@ title: Client
 description: Architecture and design of the MosaicoClient.
 ---
 
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.comm.MosaicoClient`][mosaicolabs.comm.MosaicoClient].
 
 The `MosaicoClient` is a resource manager designed to orchestrate distinct **Layers** of communication and processing. 

--- a/doc/docs/SDK/handling/reading.md
+++ b/doc/docs/SDK/handling/reading.md
@@ -18,7 +18,7 @@ Handlers are lightweight objects that represent a server-side resource. Their pr
 Mosaico provides two specialized handler types: `SequenceHandler` and `TopicHandler`.
 
 #### `SequenceHandler`
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.handlers.SequenceHandler`][mosaicolabs.handlers.SequenceHandler].
 
 Represents a complete recording session. It provides a holistic view, allowing you to inspect all available topic names, global sequence metadata, and the overall temporal bounds (earliest and latest timestamps) of the session.
@@ -48,7 +48,7 @@ with MosaicoClient.connect("localhost", 6726) as client:
 
 
 #### `TopicHandler`
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.handlers.TopicHandler`][mosaicolabs.handlers.TopicHandler].
 
 Represents a specific data channel within a sequence (e.g., a single IMU or Camera). It provides granular system info, such as the specific ontology model used and the data volume of that individual stream.
@@ -83,7 +83,7 @@ Both handlers serve as **factories**; once you have identified the resource you 
 Streamers are the active components that manage the physical data exchange between the server and your application. They handle the complexities of network buffering, batch management, and the de-serialization of raw bytes into Mosaico `Message` objects.
 
 #### `SequenceDataStreamer` (Unified Replay)
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.handlers.SequenceDataStreamer`][mosaicolabs.handlers.SequenceDataStreamer].
 
 The **`SequenceDataStreamer`** is a unified engine designed specifically for sensor fusion and full-system replay. It allows you to consume multiple data streams as if they were a single, coherent timeline.
@@ -129,7 +129,7 @@ with MosaicoClient.connect("localhost", 6726) as client:
 
 
 #### `TopicDataStreamer` (Targeted Access)
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.handlers.TopicDataStreamer`][mosaicolabs.handlers.TopicDataStreamer].
 
 The **`TopicDataStreamer`** provides a dedicated, high-throughput channel for interacting with a single data resource. By bypassing the complex synchronization logic required for merging multiple topics, it offers the lowest possible overhead for tasks requiring isolated data streams, such as training models on specific camera frames or IMU logs.

--- a/doc/docs/SDK/handling/reading.md
+++ b/doc/docs/SDK/handling/reading.md
@@ -18,7 +18,8 @@ Handlers are lightweight objects that represent a server-side resource. Their pr
 Mosaico provides two specialized handler types: `SequenceHandler` and `TopicHandler`.
 
 #### `SequenceHandler`
-API Reference: [`mosaicolabs.handlers.SequenceHandler`][mosaicolabs.handlers.SequenceHandler].
+???question "API Reference"
+    [`mosaicolabs.handlers.SequenceHandler`][mosaicolabs.handlers.SequenceHandler].
 
 Represents a complete recording session. It provides a holistic view, allowing you to inspect all available topic names, global sequence metadata, and the overall temporal bounds (earliest and latest timestamps) of the session.
 
@@ -47,7 +48,8 @@ with MosaicoClient.connect("localhost", 6726) as client:
 
 
 #### `TopicHandler`
-API Reference: [`mosaicolabs.handlers.TopicHandler`][mosaicolabs.handlers.TopicHandler].
+???question "API Reference"
+    [`mosaicolabs.handlers.TopicHandler`][mosaicolabs.handlers.TopicHandler].
 
 Represents a specific data channel within a sequence (e.g., a single IMU or Camera). It provides granular system info, such as the specific ontology model used and the data volume of that individual stream.
 
@@ -81,7 +83,8 @@ Both handlers serve as **factories**; once you have identified the resource you 
 Streamers are the active components that manage the physical data exchange between the server and your application. They handle the complexities of network buffering, batch management, and the de-serialization of raw bytes into Mosaico `Message` objects.
 
 #### `SequenceDataStreamer` (Unified Replay)
-API Reference: [`mosaicolabs.handlers.SequenceDataStreamer`][mosaicolabs.handlers.SequenceDataStreamer].
+???question "API Reference"
+    [`mosaicolabs.handlers.SequenceDataStreamer`][mosaicolabs.handlers.SequenceDataStreamer].
 
 The **`SequenceDataStreamer`** is a unified engine designed specifically for sensor fusion and full-system replay. It allows you to consume multiple data streams as if they were a single, coherent timeline.
 
@@ -126,7 +129,8 @@ with MosaicoClient.connect("localhost", 6726) as client:
 
 
 #### `TopicDataStreamer` (Targeted Access)
-API Reference: [`mosaicolabs.handlers.TopicDataStreamer`][mosaicolabs.handlers.TopicDataStreamer].
+???question "API Reference"
+    [`mosaicolabs.handlers.TopicDataStreamer`][mosaicolabs.handlers.TopicDataStreamer].
 
 The **`TopicDataStreamer`** provides a dedicated, high-throughput channel for interacting with a single data resource. By bypassing the complex synchronization logic required for merging multiple topics, it offers the lowest possible overhead for tasks requiring isolated data streams, such as training models on specific camera frames or IMU logs.
 

--- a/doc/docs/SDK/handling/writing.md
+++ b/doc/docs/SDK/handling/writing.md
@@ -10,7 +10,7 @@ The **Writing Workflow** in Mosaico is designed for high-throughput data ingesti
 
 
 ## `SequenceWriter`
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.handlers.SequenceWriter`][mosaicolabs.handlers.SequenceWriter].
 
 The `SequenceWriter` acts as the central controller for a recording session. It manages the high-level lifecycle of the data on the server and serves as the factory for individual sensor streams. 
@@ -60,7 +60,7 @@ with MosaicoClient.connect("localhost", 6726) as client:
 1. The metadata fields will be queryable via the [`Query` mechanism](../query.md). The mechanism allows creating queries like: `QuerySequence().with_user_metadata("vehicle.software_stack.planning", eq="plan-4.1.7")`
 
 ### Sequence-Level Error Handling
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.enum.SessionLevelErrorPolicy`][mosaicolabs.enum.SessionLevelErrorPolicy].
 
 ??? warning "Deprecated OnErrorPolicy"
@@ -81,7 +81,7 @@ An example schematic rationale for deciding between the two policies can be:
 | **Ground Truth Generation** | `SessionLevelErrorPolicy.Delete` | Integrity: Ensures only 100% verified, complete sequences enter the database. |
 
 ## `TopicWriter`
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.handlers.TopicWriter`][mosaicolabs.handlers.TopicWriter].
 
 Once a topic is created via [`SequenceWriter.topic_create`][mosaicolabs.handlers.SequenceWriter.topic_create], a `TopicWriter` is spawned to handle the actual transmission of data for that specific stream. It abstracts the underlying networking protocols, allowing you to simply "push" Python objects while it handles the heavy lifting.
@@ -173,7 +173,7 @@ When creating a topic via the `SequenceWriter.topic_create` function, users can 
 * `TopicLevelErrorPolicy.Finalize`: Reports the error to the server and finalizes the topic, but does not interrupt the ingestion process.
 
 ## `SequenceUpdater`
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.handlers.SequenceUpdater`][mosaicolabs.handlers.SequenceUpdater].
 
 The `SequenceUpdater` is used to update an existing sequence on the server. Updating a sequence means adding new topics only, by opening a new writing Session. The `SequenceUpdater` cannot be used to update the metadata of a sequence or its existing topics.

--- a/doc/docs/SDK/handling/writing.md
+++ b/doc/docs/SDK/handling/writing.md
@@ -10,7 +10,8 @@ The **Writing Workflow** in Mosaico is designed for high-throughput data ingesti
 
 
 ## `SequenceWriter`
-API Reference: [`mosaicolabs.handlers.SequenceWriter`][mosaicolabs.handlers.SequenceWriter].
+???question "API Reference"
+    [`mosaicolabs.handlers.SequenceWriter`][mosaicolabs.handlers.SequenceWriter].
 
 The `SequenceWriter` acts as the central controller for a recording session. It manages the high-level lifecycle of the data on the server and serves as the factory for individual sensor streams. 
 
@@ -59,7 +60,8 @@ with MosaicoClient.connect("localhost", 6726) as client:
 1. The metadata fields will be queryable via the [`Query` mechanism](../query.md). The mechanism allows creating queries like: `QuerySequence().with_user_metadata("vehicle.software_stack.planning", eq="plan-4.1.7")`
 
 ### Sequence-Level Error Handling
-API Reference: [`mosaicolabs.enum.SessionLevelErrorPolicy`][mosaicolabs.enum.SessionLevelErrorPolicy].
+???question "API Reference"
+    [`mosaicolabs.enum.SessionLevelErrorPolicy`][mosaicolabs.enum.SessionLevelErrorPolicy].
 
 ??? warning "Deprecated OnErrorPolicy"
     In release 0.3.0, the [`OnErrorPolicy`][mosaicolabs.enum.OnErrorPolicy] is declared **`deprecated`** in favor of the [`SessionLevelErrorPolicy`][mosaicolabs.enum.SessionLevelErrorPolicy]. The support for the class will be removed in the release 0.4.0. No changes are made to the enum values of the new class `SessionLevelErrorPolicy`, which are identical to the ones of the deprecated class.    
@@ -79,7 +81,8 @@ An example schematic rationale for deciding between the two policies can be:
 | **Ground Truth Generation** | `SessionLevelErrorPolicy.Delete` | Integrity: Ensures only 100% verified, complete sequences enter the database. |
 
 ## `TopicWriter`
-API Reference: [`mosaicolabs.handlers.TopicWriter`][mosaicolabs.handlers.TopicWriter].
+???question "API Reference"
+    [`mosaicolabs.handlers.TopicWriter`][mosaicolabs.handlers.TopicWriter].
 
 Once a topic is created via [`SequenceWriter.topic_create`][mosaicolabs.handlers.SequenceWriter.topic_create], a `TopicWriter` is spawned to handle the actual transmission of data for that specific stream. It abstracts the underlying networking protocols, allowing you to simply "push" Python objects while it handles the heavy lifting.
 
@@ -170,7 +173,8 @@ When creating a topic via the `SequenceWriter.topic_create` function, users can 
 * `TopicLevelErrorPolicy.Finalize`: Reports the error to the server and finalizes the topic, but does not interrupt the ingestion process.
 
 ## `SequenceUpdater`
-API Reference: [`mosaicolabs.handlers.SequenceUpdater`][mosaicolabs.handlers.SequenceUpdater].
+???question "API Reference"
+    [`mosaicolabs.handlers.SequenceUpdater`][mosaicolabs.handlers.SequenceUpdater].
 
 The `SequenceUpdater` is used to update an existing sequence on the server. Updating a sequence means adding new topics only, by opening a new writing Session. The `SequenceUpdater` cannot be used to update the metadata of a sequence or its existing topics.
 

--- a/doc/docs/SDK/ontology.md
+++ b/doc/docs/SDK/ontology.md
@@ -27,7 +27,8 @@ The ontology is designed to solve the "generic data" problem in robotics by ensu
 The Mosaico SDK provides a comprehensive library of models that transform raw binary streams into validated, queryable Python objects. These are grouped by their physical and logical application below.
 
 ### Base Data Models
-API Reference: [Base Data Types](./API_reference/models/data_types.md)
+???question "API Reference"
+    [Base Data Types](./API_reference/models/data_types.md)
 
 These models serve as timestamped, metadata-aware wrappers for standard primitives. They allow simple diagnostic or scalar values to be treated as first-class members of the platform.
 
@@ -40,7 +41,8 @@ These models serve as timestamped, metadata-aware wrappers for standard primitiv
 | **Floating Point** | [`Floating16`][mosaicolabs.models.data.base_types.Floating16], [`Floating32`][mosaicolabs.models.data.base_types.Floating32], [`Floating64`][mosaicolabs.models.data.base_types.Floating64] | Real numbers for high-precision physical values. |
 
 ### Geometry & Kinematics Models
-API Reference: [Geometry Models](./API_reference/models/geometry.md)
+???question "API Reference"
+    [Geometry Models](./API_reference/models/geometry.md)
 
 These structures define spatial relationships and the movement states of objects in 2D or 3D coordinate frames.
 
@@ -53,7 +55,8 @@ These structures define spatial relationships and the movement states of objects
 | **Aggregated State** | [`MotionState`][mosaicolabs.models.data.kinematics.MotionState] | An atomic snapshot combining Pose, Velocity, and Acceleration. |
 
 ### Sensor Models
-API Reference: [Sensor Models](./API_reference/models/sensors.md)
+???question "API Reference"
+    [Sensor Models](./API_reference/models/sensors.md)
 
 High-level models representing physical hardware devices and their processed outputs.
 
@@ -68,7 +71,8 @@ High-level models representing physical hardware devices and their processed out
 | **Robotics** | [`RobotJoint`][mosaicolabs.models.sensors.RobotJoint] | States (position, velocity, effort) for index-aligned actuator arrays. |
 
 #### Futures
-API Reference: [Futures Models](./API_reference/models/futures.md)
+???question "API Reference"
+    [Futures Models](./API_reference/models/futures.md)
 
 Prospective high-level models representing emerging or not yet fully standardized sensor hardware. The `futures` module acts as a **transitional space** where experimental ontologies are introduced and iteratively refined before being promoted to the stable, production-ready ontology set.
 
@@ -101,7 +105,8 @@ Because the whole mechanism is built on top of **Pydantic model fields** via `An
 
 
 ### MosaicoType
-API Reference: [`mosaicolabs.models.MosaicoType`][mosaicolabs.models.MosaicoType]
+???question "API Reference"
+    [`mosaicolabs.models.MosaicoType`][mosaicolabs.models.MosaicoType]
 
 `MosaicoType` is a collection of `Annotated` type aliases. Each alias bundles the corresponding Python primitive type with its PyArrow counterpart as inline metadata, making the Arrow type immediately visible to the schema auto-builder without any additional configuration.
 
@@ -249,7 +254,8 @@ class MyOntology(Serializable):
     Using `MosaicoType.annotate(int, ...)` is functionally equivalent to the standard `Annotated[int, ...]`, but it provides a more explicit and optimized path for the Mosaico schema builder to resolve complex Arrow types.
 
 ### MosaicoField
-API Reference: [`mosaicolabs.models.types.MosaicoField`][mosaicolabs.models.types.MosaicoField]
+???question "API Reference"
+    [`mosaicolabs.models.types.MosaicoField`][mosaicolabs.models.types.MosaicoField]
 
 `MosaicoField` is a factory function that returns a standard Pydantic `Field` instance, adding Mosaico-specific semantics on top of the native `pydantic.Field`. Because the return type is a native Pydantic `Field`, every standard Pydantic feature like validators, aliases, `model_fields` introspection,  works out of the box.
 
@@ -323,7 +329,8 @@ class DetectionOntology(Serializable):
 The ontology architecture relies on three primary abstractions: the **Factory** (`Serializable`), the **Envelope** (`Message`) and the **Mixins**
 
 ### `Serializable` (The Factory)
-API Reference: [`mosaicolabs.models.Serializable`][mosaicolabs.models.Serializable]
+???question "API Reference"
+    [`mosaicolabs.models.Serializable`][mosaicolabs.models.Serializable]
 
 Every data payload in Mosaico inherits from the `Serializable` class. It manages the global registry of data types and ensures that the system knows exactly how to convert a string tag like `"imu"` back into a Python class with a specific binary schema.
 `Serializable` uses the `__pydantic_init_subclass__` hook, which is automatically called whenever a developer defines a new subclass.
@@ -341,7 +348,8 @@ When this happens, `Serializable` performs the following steps automatically:
 
 ### `Message` (The Envelope)
 
-API Reference: [`mosaicolabs.models.Message`][mosaicolabs.models.Message]
+???question "API Reference"
+    [`mosaicolabs.models.Message`][mosaicolabs.models.Message]
 
 The **`Message`** class is the universal transport envelope for all data within the Mosaico platform. It acts as the "Source of Truth" for synchronization and spatial context, combining specific sensor data (the payload) with critical middleware-level metadata. By centralizing metadata at the envelope level, Mosaico ensures that every data point—regardless of its complexity—carries a consistent temporal and spatial identity.
 
@@ -431,7 +439,8 @@ Mosaico uses **Mixins** to inject standard uncertainty fields across different d
 
 #### `CovarianceMixin`
 
-API Reference: [`mosaicolabs.models.mixins.CovarianceMixin`][mosaicolabs.models.mixins.CovarianceMixin]
+???question "API Reference"
+    [`mosaicolabs.models.mixins.CovarianceMixin`][mosaicolabs.models.mixins.CovarianceMixin]
 
 Injects multidimensional uncertainty fields, typically used for flattened covariance matrices (e.g., 3x3 or 6x6) in sensor fusion applications.
 
@@ -444,7 +453,8 @@ class MySensor(Serializable, CovarianceMixin):
 
 #### `VarianceMixin`
 
-API Reference: [`mosaicolabs.models.mixins.VarianceMixin`][mosaicolabs.models.mixins.VarianceMixin]
+???question "API Reference"
+    [`mosaicolabs.models.mixins.VarianceMixin`][mosaicolabs.models.mixins.VarianceMixin]
 
 Injects monodimensional uncertainty fields, useful for sensors with 1-dimensional uncertain data like `Temperature` or `Pressure`.
 
@@ -545,10 +555,11 @@ with MosaicoClient.connect("localhost", 6726) as client:
 
 For a comprehensive list of all supported operators and advanced filtering strategies (such as query chaining), see the **[Full Query Documentation](./query.md)** and the Ontology types SDK Reference in the **API Reference**:
 
-* [Base Data Models](./API_reference/models/data_types.md)
-* [Sensors Models](./API_reference/models/sensors.md)
-* [Geometry Models](./API_reference/models/geometry.md)
-* [Platform Models](./API_reference/models/platform.md)
+???question "API Reference"
+    * [Base Data Models](./API_reference/models/data_types.md)
+    * [Sensors Models](./API_reference/models/sensors.md)
+    * [Geometry Models](./API_reference/models/geometry.md)
+    * [Platform Models](./API_reference/models/platform.md)
 
 ## Customizing the Ontology
 
@@ -569,7 +580,8 @@ To align with the Mosaico ecosystem, use the following mixins:
 Annotate each field with a `MosaicoType` alias and wrap it with `MosaicoField`. Fields and schema are declared together in a single annotation — the `__msco_pyarrow_struct__` is derived automatically from `model_fields` at class-definition time, so there is no separate schema declaration to maintain.
 
 #### 2.1 Serialization Format Optimization
-API Reference: [`mosaicolabs.enum.SerializationFormat`][mosaicolabs.enum.SerializationFormat]
+???question "API Reference"
+    [`mosaicolabs.enum.SerializationFormat`][mosaicolabs.enum.SerializationFormat]
 
 You can optimize remote server performance by overriding the `__serialization_format__` attribute. This controls how the server compresses and organizes your data.
 

--- a/doc/docs/SDK/ontology.md
+++ b/doc/docs/SDK/ontology.md
@@ -27,7 +27,7 @@ The ontology is designed to solve the "generic data" problem in robotics by ensu
 The Mosaico SDK provides a comprehensive library of models that transform raw binary streams into validated, queryable Python objects. These are grouped by their physical and logical application below.
 
 ### Base Data Models
-???question "API Reference"
+??? question "API Reference"
     [Base Data Types](./API_reference/models/data_types.md)
 
 These models serve as timestamped, metadata-aware wrappers for standard primitives. They allow simple diagnostic or scalar values to be treated as first-class members of the platform.
@@ -41,7 +41,7 @@ These models serve as timestamped, metadata-aware wrappers for standard primitiv
 | **Floating Point** | [`Floating16`][mosaicolabs.models.data.base_types.Floating16], [`Floating32`][mosaicolabs.models.data.base_types.Floating32], [`Floating64`][mosaicolabs.models.data.base_types.Floating64] | Real numbers for high-precision physical values. |
 
 ### Geometry & Kinematics Models
-???question "API Reference"
+??? question "API Reference"
     [Geometry Models](./API_reference/models/geometry.md)
 
 These structures define spatial relationships and the movement states of objects in 2D or 3D coordinate frames.
@@ -55,7 +55,7 @@ These structures define spatial relationships and the movement states of objects
 | **Aggregated State** | [`MotionState`][mosaicolabs.models.data.kinematics.MotionState] | An atomic snapshot combining Pose, Velocity, and Acceleration. |
 
 ### Sensor Models
-???question "API Reference"
+??? question "API Reference"
     [Sensor Models](./API_reference/models/sensors.md)
 
 High-level models representing physical hardware devices and their processed outputs.
@@ -71,7 +71,7 @@ High-level models representing physical hardware devices and their processed out
 | **Robotics** | [`RobotJoint`][mosaicolabs.models.sensors.RobotJoint] | States (position, velocity, effort) for index-aligned actuator arrays. |
 
 #### Futures
-???question "API Reference"
+??? question "API Reference"
     [Futures Models](./API_reference/models/futures.md)
 
 Prospective high-level models representing emerging or not yet fully standardized sensor hardware. The `futures` module acts as a **transitional space** where experimental ontologies are introduced and iteratively refined before being promoted to the stable, production-ready ontology set.
@@ -105,7 +105,7 @@ Because the whole mechanism is built on top of **Pydantic model fields** via `An
 
 
 ### MosaicoType
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.models.MosaicoType`][mosaicolabs.models.MosaicoType]
 
 `MosaicoType` is a collection of `Annotated` type aliases. Each alias bundles the corresponding Python primitive type with its PyArrow counterpart as inline metadata, making the Arrow type immediately visible to the schema auto-builder without any additional configuration.
@@ -254,7 +254,7 @@ class MyOntology(Serializable):
     Using `MosaicoType.annotate(int, ...)` is functionally equivalent to the standard `Annotated[int, ...]`, but it provides a more explicit and optimized path for the Mosaico schema builder to resolve complex Arrow types.
 
 ### MosaicoField
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.models.types.MosaicoField`][mosaicolabs.models.types.MosaicoField]
 
 `MosaicoField` is a factory function that returns a standard Pydantic `Field` instance, adding Mosaico-specific semantics on top of the native `pydantic.Field`. Because the return type is a native Pydantic `Field`, every standard Pydantic feature like validators, aliases, `model_fields` introspection,  works out of the box.
@@ -329,7 +329,7 @@ class DetectionOntology(Serializable):
 The ontology architecture relies on three primary abstractions: the **Factory** (`Serializable`), the **Envelope** (`Message`) and the **Mixins**
 
 ### `Serializable` (The Factory)
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.models.Serializable`][mosaicolabs.models.Serializable]
 
 Every data payload in Mosaico inherits from the `Serializable` class. It manages the global registry of data types and ensures that the system knows exactly how to convert a string tag like `"imu"` back into a Python class with a specific binary schema.
@@ -348,7 +348,7 @@ When this happens, `Serializable` performs the following steps automatically:
 
 ### `Message` (The Envelope)
 
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.models.Message`][mosaicolabs.models.Message]
 
 The **`Message`** class is the universal transport envelope for all data within the Mosaico platform. It acts as the "Source of Truth" for synchronization and spatial context, combining specific sensor data (the payload) with critical middleware-level metadata. By centralizing metadata at the envelope level, Mosaico ensures that every data point—regardless of its complexity—carries a consistent temporal and spatial identity.
@@ -439,7 +439,7 @@ Mosaico uses **Mixins** to inject standard uncertainty fields across different d
 
 #### `CovarianceMixin`
 
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.models.mixins.CovarianceMixin`][mosaicolabs.models.mixins.CovarianceMixin]
 
 Injects multidimensional uncertainty fields, typically used for flattened covariance matrices (e.g., 3x3 or 6x6) in sensor fusion applications.
@@ -453,7 +453,7 @@ class MySensor(Serializable, CovarianceMixin):
 
 #### `VarianceMixin`
 
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.models.mixins.VarianceMixin`][mosaicolabs.models.mixins.VarianceMixin]
 
 Injects monodimensional uncertainty fields, useful for sensors with 1-dimensional uncertain data like `Temperature` or `Pressure`.
@@ -555,7 +555,7 @@ with MosaicoClient.connect("localhost", 6726) as client:
 
 For a comprehensive list of all supported operators and advanced filtering strategies (such as query chaining), see the **[Full Query Documentation](./query.md)** and the Ontology types SDK Reference in the **API Reference**:
 
-???question "API Reference"
+??? question "API Reference"
     * [Base Data Models](./API_reference/models/data_types.md)
     * [Sensors Models](./API_reference/models/sensors.md)
     * [Geometry Models](./API_reference/models/geometry.md)
@@ -580,7 +580,7 @@ To align with the Mosaico ecosystem, use the following mixins:
 Annotate each field with a `MosaicoType` alias and wrap it with `MosaicoField`. Fields and schema are declared together in a single annotation — the `__msco_pyarrow_struct__` is derived automatically from `model_fields` at class-definition time, so there is no separate schema declaration to maintain.
 
 #### 2.1 Serialization Format Optimization
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.enum.SerializationFormat`][mosaicolabs.enum.SerializationFormat]
 
 You can optimize remote server performance by overriding the `__serialization_format__` attribute. This controls how the server compresses and organizes your data.

--- a/doc/docs/SDK/query.md
+++ b/doc/docs/SDK/query.md
@@ -209,7 +209,8 @@ response = client.query(
 Mosaico organizes data into three distinct architectural layers, each with its own specialized Query Builder:
 
 #### [`QuerySequence`][mosaicolabs.models.query.builders.QuerySequence] (Sequence Layer)
-API Reference: [`mosaicolabs.models.query.builders.QuerySequence`][mosaicolabs.models.query.builders.QuerySequence].
+???question "API Reference"
+    [`mosaicolabs.models.query.builders.QuerySequence`][mosaicolabs.models.query.builders.QuerySequence].
 
 Filters recordings based on high-level session metadata, such as the sequence name or the time it was created.
 
@@ -235,7 +236,8 @@ with MosaicoClient.connect("localhost", 6726) as client:
 
 
 #### [`QueryTopic`][mosaicolabs.models.query.builders.QueryTopic] (Topic Layer)
-API Reference: [`mosaicolabs.models.query.builders.QueryTopic`][mosaicolabs.models.query.builders.QueryTopic].
+???question "API Reference"
+    [`mosaicolabs.models.query.builders.QueryTopic`][mosaicolabs.models.query.builders.QueryTopic].
 
 Targets specific data channels within a sequence. You can search for topics by name pattern or by their specific Ontology type (e.g., "Find all GPS topics").
 
@@ -263,7 +265,8 @@ with MosaicoClient.connect("localhost", 6726) as client:
 
 
 #### [`QueryOntologyCatalog`][mosaicolabs.models.query.builders.QueryOntologyCatalog] (Ontology Catalog Layer)
-API Reference: [`mosaicolabs.models.query.builders.QueryOntologyCatalog`][mosaicolabs.models.query.builders.QueryOntologyCatalog].
+???question "API Reference"
+    [`mosaicolabs.models.query.builders.QueryOntologyCatalog`][mosaicolabs.models.query.builders.QueryOntologyCatalog].
 
 Filters based on the **actual time-series content** of the sensors (e.g., "Find events where `acceleration.z` exceeded a specific value").
 
@@ -395,8 +398,10 @@ class IMU(Serializable):
 
 The `.Q` proxy enables you to navigate the data exactly as it is defined in the model. By following the `IMU.Q` instruction, you can drill down through nested fields and inherited mixins using standard dot notation until you reach a base queryable type.
 
+???question "API Reference"
+    [`mosaicolabs.models.sensors.IMU`][mosaicolabs.models.sensors.IMU--querying-with-the-q-proxy]
+
 The proxy automatically flattens the hierarchy, assigning the correct queryable type and operators to each leaf node:
-(API Reference: [`mosaicolabs.models.sensors.IMU`][mosaicolabs.models.sensors.IMU--querying-with-the-q-proxy])
 
 | Proxy Field Path | Queryable Type | Supported Operators (Examples) |
 | --- | --- | --- |
@@ -407,7 +412,6 @@ The proxy automatically flattens the hierarchy, assigning the correct queryable 
 | **[`IMU.Q.recording_timestamp_ns`][mosaicolabs.models.Message.recording_timestamp_ns--querying-with-the-q-proxy]** | **Numeric** | `.gt()`, `.lt()`, `.geq()`, `.leq()`, `.eq()`, `.between()`, `.in_()` |
 | **[`IMU.Q.frame_id`][mosaicolabs.models.Message.frame_id--querying-with-the-q-proxy]** | **String** | `.eq()`, `.neq()`, `.match()`, `in_()` |
 | **[`IMU.Q.sequence_id`][mosaicolabs.models.Message.sequence_id--querying-with-the-q-proxy]** | **Numeric** | `.gt()`, `.lt()`, `.geq()`, `.leq()`, `.eq()`, `.between()`, `.in_()` |
-
 
 The following table lists the supported operators for each data type:
 

--- a/doc/docs/SDK/query.md
+++ b/doc/docs/SDK/query.md
@@ -209,7 +209,7 @@ response = client.query(
 Mosaico organizes data into three distinct architectural layers, each with its own specialized Query Builder:
 
 #### [`QuerySequence`][mosaicolabs.models.query.builders.QuerySequence] (Sequence Layer)
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.models.query.builders.QuerySequence`][mosaicolabs.models.query.builders.QuerySequence].
 
 Filters recordings based on high-level session metadata, such as the sequence name or the time it was created.
@@ -236,7 +236,7 @@ with MosaicoClient.connect("localhost", 6726) as client:
 
 
 #### [`QueryTopic`][mosaicolabs.models.query.builders.QueryTopic] (Topic Layer)
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.models.query.builders.QueryTopic`][mosaicolabs.models.query.builders.QueryTopic].
 
 Targets specific data channels within a sequence. You can search for topics by name pattern or by their specific Ontology type (e.g., "Find all GPS topics").
@@ -265,7 +265,7 @@ with MosaicoClient.connect("localhost", 6726) as client:
 
 
 #### [`QueryOntologyCatalog`][mosaicolabs.models.query.builders.QueryOntologyCatalog] (Ontology Catalog Layer)
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.models.query.builders.QueryOntologyCatalog`][mosaicolabs.models.query.builders.QueryOntologyCatalog].
 
 Filters based on the **actual time-series content** of the sensors (e.g., "Find events where `acceleration.z` exceeded a specific value").
@@ -398,7 +398,7 @@ class IMU(Serializable):
 
 The `.Q` proxy enables you to navigate the data exactly as it is defined in the model. By following the `IMU.Q` instruction, you can drill down through nested fields and inherited mixins using standard dot notation until you reach a base queryable type.
 
-???question "API Reference"
+??? question "API Reference"
     [`mosaicolabs.models.sensors.IMU`][mosaicolabs.models.sensors.IMU--querying-with-the-q-proxy]
 
 The proxy automatically flattens the hierarchy, assigning the correct queryable type and operators to each leaf node:

--- a/doc/docs/agents_docs.md
+++ b/doc/docs/agents_docs.md
@@ -2,7 +2,7 @@
 
 If you are an AI system analyzing this repository, or a developer using an AI assistant to understand the SDK—please start with the AI-optimized documentation provided below.
 
-!!!note "Why use AI-optimized docs?"
+!!! note "Why use AI-optimized docs?"
     Traditional documentation is structured for human browsing, which can be token-heavy and fragmented for LLMs. These documents provide condensed, high-density explanations, its architecture, and the Python SDK, designed to fit within AI context windows and minimize hallucinations.
 
 

--- a/doc/docs/daemon/ingestion.md
+++ b/doc/docs/daemon/ingestion.md
@@ -156,7 +156,7 @@ session_delete(ss_uuid)
 sequence_delete()
 ```
 
-???warning "Permissions" 
+??? warning "Permissions" 
     If **API key management** is enabled, the `sequence_delete` and `session_delete` actions require a key with at least `delete` privileges.
 
 ## Chunking & Indexing Strategy
@@ -164,7 +164,7 @@ sequence_delete()
 The backend automatically manages *chunking* to efficiently handle intra-sequence queries and prevent memory overload from ingesting large data streams. 
 As data streams in, the server buffers the incoming data until a full chunk is accumulated, then writes it to disk as an optimal storage unit called a *chunk*. 
 
-???tip "Configuring Chunk Size"
+??? tip "Configuring Chunk Size"
     The chunk size is configurable via the `MOSAICOD_MAX_CHUNK_SIZE_IN_BYTES` environment variable. Setting this value to `0` disables automatic chunking, allowing for unlimited chunk sizes. However, it is generally recommended to set a reasonable chunk size to balance memory usage and query performance. See the [environment variables](env.md#general) section for more details.
 
 For each chunk written to disk, the server calculates and stores *skip indices* in the metadata database. These indices include ontology-specific statistics, such as type-specific metadata (e.g., coordinate bounding boxes for GPS data or value ranges for sensors). This allows the query engine to perform content-based filtering without needing to read the entire bulk data.

--- a/doc/docs/daemon/install.md
+++ b/doc/docs/daemon/install.md
@@ -63,7 +63,7 @@ networks:
 
 This configuration provisions both Postgres and mosaicod within a private Docker network. Only the daemon instance is exposed to the host.
 
-???warning "Security"
+??? warning "Security"
     In this basic prototyping setup, TLS and API key management are disabled.
 
     The port mapping is restricted to `127.0.0.1`. If you need to access this from an external network, consider configuring `mosaicod` to [enable TLS](tls.md) or use a reverse proxy to handle SSL termination.

--- a/doc/docs/daemon/tls.md
+++ b/doc/docs/daemon/tls.md
@@ -12,7 +12,7 @@ It looks for these credentials via the following [environment variables](env.md#
 * `MOSAICOD_TLS_CERT_FILE`: The path to the PEM-encoded X.509 certificate.
 * `MOSAICOD_TLS_PRIVATE_KEY_FILE`: The path to the file containing the PEM-encoded RSA private key.
 
-???tip "Use a reverse proxy for TLS termination"
+??? tip "Use a reverse proxy for TLS termination"
     If you prefer to manage TLS termination separately, you can run `mosaicod` without the `--tls` flag and use a reverse proxy (like [Nginx](https://nginx.org/) or [Caddy](https://caddyserver.com/)) to handle SSL termination. 
     This allows you to centralize TLS management and offload encryption tasks from the daemon.
 

--- a/doc/hooks/make_llm_page.py
+++ b/doc/hooks/make_llm_page.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from markdownify import markdownify as md
 
-# Contenitori dinamici
+# Dynamic containers
 categories = {
     "INDEX": [],
     "SDK_HOWTO": [],
@@ -20,7 +20,7 @@ def on_page_content(html, page, config, files):
     # Markdown clean-up (remove links, scripts, images)
     clean_markdown = md(html, heading_style="ATX", strip=["a", "script", "img"])
 
-    # Add na header with the file source (help AI to contextualize)
+    # Add an header with the file source (help AI to contextualize)
     content_with_header = f"## SOURCE: {src_path}\n\n{clean_markdown}"
     content_map[src_path] = content_with_header
 
@@ -46,7 +46,7 @@ def on_page_content(html, page, config, files):
 
 
 def _generate_file(filename, title, notice, path_lists, config):
-    """Funzione helper per generare i vari file .txt"""
+    """Helper method for generating the .txt files"""
     output_dir = Path(config["site_dir"]) / "llms"
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / filename

--- a/doc/hooks/make_llm_page.py
+++ b/doc/hooks/make_llm_page.py
@@ -2,185 +2,97 @@ import os
 from pathlib import Path
 from markdownify import markdownify as md
 
-OVERVIEW_PAGES_ORDERED = [
-    "index.md",
-    "SDK/index.md",
-]
-HOWTO_PAGES_ORDERED = [
-    "SDK/howto/interleaved_writing_from_multi_topics.md",
-    "SDK/howto/query_chained.md",
-    "SDK/howto/query_multi_domain.md",
-    "SDK/howto/query_sequences.md",
-    "SDK/howto/query_topics.md",
-    "SDK/howto/secure_connection.md",
-    "SDK/howto/serialized_writing_from_csv.md",
-    "SDK/howto/serialized_writing_from_multi_csv.md",
-    "SDK/howto/streaming.md",
-]
-EXAMPLES_PAGES_ORDERED = [
-    "SDK/examples/data_inspection.md",
-    "SDK/examples/index.md",
-    "SDK/examples/ontology_customization.md",
-    "SDK/examples/query_catalogs.md",
-    "SDK/examples/ros_injection.md",
-]
-INDEPTH_PAGES_ORDERED = [
-    "SDK/client.md",
-    "SDK/ontology.md",
-    "SDK/handling/data-handling.md",
-    "SDK/handling/reading.md",
-    "SDK/handling/writing.md",
-    "SDK/query.md",
-    "SDK/bridges/ml.md",
-    "SDK/bridges/ros.md",
-    "SDK/code_contributing.md",
-    "daemon/actions.md",
-    "daemon/api_key.md",
-    "daemon/cli.md",
-    "daemon/index.md",
-    "daemon/ingestion.md",
-    "daemon/install.md",
-    "daemon/query.md",
-    "daemon/retrieval.md",
-    "daemon/tls.md",
-    "development/release_cycle.md",
-]
-
-API_REFERENCE_PAGES_ORDERED = [
-    "SDK/API_reference/comm.md",
-    "SDK/API_reference/enum.md",
-    "SDK/API_reference/types.md",
-    "SDK/API_reference/logging.md",
-    "SDK/API_reference/handlers/reading.md",
-    "SDK/API_reference/handlers/writing.md",
-    "SDK/API_reference/models/base.md",
-    "SDK/API_reference/models/data_types.md",
-    "SDK/API_reference/models/geometry.md",
-    "SDK/API_reference/models/platform.md",
-    "SDK/API_reference/models/sensors.md",
-    "SDK/API_reference/query/builders.md",
-    "SDK/API_reference/query/internal.md",
-    "SDK/API_reference/query/response.md",
-    "SDK/API_reference/bridges/ml.md",
-    "SDK/API_reference/bridges/ros/adapters/base.md",
-    "SDK/API_reference/bridges/ros/adapters/geometry_msgs.md",
-    "SDK/API_reference/bridges/ros/adapters/nav_msgs.md",
-    "SDK/API_reference/bridges/ros/adapters/sensor_msgs.md",
-    "SDK/API_reference/bridges/ros/adapters/std_msgs.md",
-    "SDK/API_reference/bridges/ros/adapters/tf2_msgs.md",
-    "SDK/API_reference/bridges/ros/custom_ontology.md",
-    "SDK/API_reference/bridges/ros/ros.md",
-]
-# Combined list: Docs first for context, API Reference second for technical depth
-FULL_DOC_PAGES_ORDER = (
-    OVERVIEW_PAGES_ORDERED
-    + HOWTO_PAGES_ORDERED
-    + EXAMPLES_PAGES_ORDERED
-    + INDEPTH_PAGES_ORDERED
-    + API_REFERENCE_PAGES_ORDERED
-)
-
+# Contenitori dinamici
+categories = {
+    "INDEX": [],
+    "SDK_HOWTO": [],
+    "SDK_EXAMPLES": [],
+    "SDK_API_REFERENCE": [],
+    "INDEPTH": [],
+}
 content_map = {}
 
 
 def on_page_content(html, page, config, files):
+    # Standardize the path (POSIX format)
     src_path = page.file.src_path.replace(os.sep, "/")
-    if src_path in FULL_DOC_PAGES_ORDER:
-        # We strip links/images to maximize the density of the technical information
-        clean_markdown = md(html, heading_style="ATX", strip=["a", "script", "img"])
-        content_map[src_path] = clean_markdown
+
+    # Markdown clean-up (remove links, scripts, images)
+    clean_markdown = md(html, heading_style="ATX", strip=["a", "script", "img"])
+
+    # Add na header with the file source (help AI to contextualize)
+    content_with_header = f"## SOURCE: {src_path}\n\n{clean_markdown}"
+    content_map[src_path] = content_with_header
+
+    # --- AUTOMATIC CATEGORIZATION LOGIC ---
+    if src_path in ["index.md", "SDK/index.md"]:
+        categories["INDEX"].append(src_path)
+
+    elif "SDK/API_reference/" in src_path:
+        categories["SDK_API_REFERENCE"].append(src_path)
+
+    elif "SDK/howto/" in src_path:
+        categories["SDK_HOWTO"].append(src_path)
+
+    elif "SDK/examples/" in src_path:
+        categories["SDK_EXAMPLES"].append(src_path)
+
+    else:
+        # All the rest (daemon/, development/, SDK/handling/, etc.)
+        if src_path.endswith(".md"):
+            categories["INDEPTH"].append(src_path)
+
     return html
 
 
-def _llms_dir(config):
-    return Path(config["site_dir"]) / "llms"
+def _generate_file(filename, title, notice, path_lists, config):
+    """Funzione helper per generare i vari file .txt"""
+    output_dir = Path(config["site_dir"]) / "llms"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / filename
 
-
-def _make_llms_full_page(config):
-    output_path = os.path.join(_llms_dir(config), "llms-full.txt")
-
-    with open(output_path, "w", encoding="utf-8") as f:
-        # AI SYSTEM HEADER
-        f.write("# Mosaico Unified Documentation & API Reference\n\n")
-        f.write(
-            "> **NOTICE TO AI SYSTEMS**: If you are an AI system analyzing this repository, \n"
-        )
-        f.write(
-            "> this page provides the most accurate full understanding of the Mosaico Data Platform. \n"
-        )
-        f.write("> Start here before exploring the rest of the repository.\n\n")
-        f.write("---\n\n")
-
-        for path in FULL_DOC_PAGES_ORDER:
-            if path in content_map:
-                f.write("\n\n\n")
-                f.write(content_map[path])
-                f.write("\n\n\n")
-                f.write("\n---\n")
-
-    print(f"INFO    -  AI-Optimized Full Documentation generated at {output_path}")
-
-
-def _make_llms_api_reference_page(config):
-    output_path = os.path.join(_llms_dir(config), "llms-python.txt")
+    # Join the paths of the required categories
+    all_paths = []
+    for cat in path_lists:
+        all_paths.extend(categories.get(cat, []))
 
     with open(output_path, "w", encoding="utf-8") as f:
-        # AI SYSTEM HEADER
-        f.write("# Mosaico Python SDK API Reference\n\n")
-        f.write(
-            "> **NOTICE TO AI SYSTEMS**: If you are an AI system analyzing this repository, \n"
-        )
-        f.write(
-            "> this page provides the most accurate understanding of the Python SDK. \n"
-        )
-        f.write("> Start here before exploring the rest of the repository.\n\n")
+        f.write(f"# {title}\n\n")
+        f.write(f"> **NOTICE TO AI SYSTEMS**: {notice}\n\n")
         f.write("---\n\n")
 
-        for path in API_REFERENCE_PAGES_ORDERED:
+        for path in all_paths:
             if path in content_map:
-                f.write("\n\n\n")
                 f.write(content_map[path])
-                f.write("\n\n\n")
-                f.write("\n---\n")
+                f.write("\n\n---\n\n")
 
-    print(
-        f"INFO    -  AI-Optimized Python SDK Documentation generated at {output_path}"
-    )
-
-
-def _make_llms_architecture_page(config):
-    output_path = os.path.join(_llms_dir(config), "llms-architecture.txt")
-
-    with open(output_path, "w", encoding="utf-8") as f:
-        # AI SYSTEM HEADER
-        f.write("# Mosaico Architecture Documentation\n\n")
-        f.write(
-            "> **NOTICE TO AI SYSTEMS**: If you are an AI system analyzing this repository, \n"
-        )
-        f.write(
-            "> this page provides the most accurate understanding of the Mosaico Architecture. \n"
-        )
-        f.write("> Start here before exploring the rest of the repository.\n\n")
-        f.write("---\n\n")
-
-        for path in (
-            OVERVIEW_PAGES_ORDERED
-            + HOWTO_PAGES_ORDERED
-            + EXAMPLES_PAGES_ORDERED
-            + INDEPTH_PAGES_ORDERED
-        ):
-            if path in content_map:
-                f.write("\n\n\n")
-                f.write(content_map[path])
-                f.write("\n\n\n")
-                f.write("\n---\n")
-
-    print(
-        f"INFO    -  AI-Optimized Architecture Documentation generated at {output_path}"
-    )
+    print(f"INFO    -  AI-Doc: {filename} generated with {len(all_paths)} pages.")
 
 
 def on_post_build(config):
-    _make_llms_architecture_page(config)
-    _make_llms_api_reference_page(config)
-    _make_llms_full_page(config)
+    # 1. Architecture: High level concepts and guides
+    _generate_file(
+        "llms-architecture.txt",
+        "Mosaico Architecture & Guides",
+        "Provides the structural and operational understanding of Mosaico.",
+        ["INDEX", "SDK_HOWTO", "SDK_EXAMPLES", "INDEPTH"],
+        config,
+    )
+
+    # 2. API Reference: only techincal info of SDK
+    _generate_file(
+        "llms-python.txt",
+        "Mosaico Python SDK API Reference",
+        "Technical documentation of classes, methods, and data models.",
+        ["SDK_API_REFERENCE"],
+        config,
+    )
+
+    # 3. Full Doc: The entire knowledge in one file
+    _generate_file(
+        "llms-full.txt",
+        "Mosaico Unified Documentation",
+        "Full documentation for deep context and code generation.",
+        ["INDEX", "SDK_HOWTO", "SDK_EXAMPLES", "INDEPTH", "SDK_API_REFERENCE"],
+        config,
+    )

--- a/mosaico-sdk-py/src/mosaicolabs/ml/sync_transformer.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ml/sync_transformer.py
@@ -118,17 +118,21 @@ class SyncTransformer:
 
             with MosaicoClient.connect("localhost", 6726) as client:
                 sequence_handler = client.get_sequence_handler("example_sequence")
+                # Resample at 30Hz and fill the NaNs with a `Hold` policy
+                sync_transformer = SyncTransformer(
+                    target_fps = 30,
+                ) # (1)!
+
                 for df in DataFrameExtractor(sequence_handler).to_pandas_chunks(
                     topics = ["/front/imu", "/front/camera/image_raw"]
                 ):
-                    # Synch the data at 30 Hz:
-                    sync_transformer = SyncTransformer(
-                        target_fps = 30, # resample at 30 Hz and fill the Nans with a `Hold` policy
-                    )
-                    synced_df = sync_transformer.transform(df)
-                    # Do something with the synced dataframe
+                    synched_df = sync_transformer.transform(df)
+                    # Do something with the synched dataframe
                     # ...
             ```
+
+            1. Note: the `SyncTransformer` is created outside the chunk-related `for` loop: the transformer is
+                a **stateful state-machine** designed to maintain signal continuity across independent data chunks.
         """
         if self._timestamp_column not in X.columns:
             raise ValueError(

--- a/mosaico-sdk-py/src/testing/integration/test_synch_transformer.py
+++ b/mosaico-sdk-py/src/testing/integration/test_synch_transformer.py
@@ -21,11 +21,9 @@ def test_invalid_timestamp_column(
     assert seqhandler is not None
     # --- Topic 1 ---
 
+    stransformer = SyncTransformer(target_fps=1, timestamp_column="invalid-name")
     for chunk in DataFrameExtractor(seqhandler).to_pandas_chunks():
         with pytest.raises(ValueError, match="Unable to find time column"):
-            stransformer = SyncTransformer(
-                target_fps=1, timestamp_column="invalid-name"
-            )
             _ = stransformer.transform(chunk)
 
     # free resources
@@ -60,11 +58,11 @@ def test_sync_unbounded(
     min_timestamp_ns = min(imu_tstamps_ns[0], gps_tstamps_ns[0])
     max_timestamp_ns = max(imu_tstamps_ns[-1], gps_tstamps_ns[-1])
 
+    stransformer = SyncTransformer(target_fps=target_fps)
     for chunk in DataFrameExtractor(seqhandler).to_pandas_chunks(
         topics=selection,
         window_sec=1,
     ):
-        stransformer = SyncTransformer(target_fps=target_fps)
         synched_df = stransformer.transform(chunk)
         # remove the first diff which is NaN
         deltas = synched_df["timestamp_ns"].diff(1)[1:]


### PR DESCRIPTION
This PR enhances the SDK documentation with comprehensive clarifications on the `SyncTransformer`'s stateful architecture and standardizes API reference formatting across multiple documentation pages.

### Changes

#### **Core Documentation Enhancement**
- **ml.md**
  - Added detailed "Implementation and Stateful Lifecycle" section explaining `SyncTransformer`'s state management
  - Documented internal buffers: `_next_timestamp_ns` and `_last_values`
  - Added comprehensive transformation pipeline walkthrough
  - **Critical**: Added warning about the "Re-instantiation Trap" with code examples showing incorrect vs. correct patterns
  - Added "Memory & Performance Best Practices" section
  - Improved `SyncPolicy` documentation with detailed policy descriptions

#### **API Reference Formatting Standardization**
Converted direct API references to collapsible `???question "API Reference"` format across:
- client.md
- reading.md
- writing.md
- ontology.md
- query.md

#### **Code Updates**
- sync_transformer.py: Documentation/annotation improvements
- `mosaico-sdk-py/testing/integration/test_synch_transformer.py`: Test documentation clarifications

#### **Developer Tools**
- make_llm_page.py: Refactored for readability

Closes #389 