### PR TITLE
fix(py): register futures and ROS data_ontology modules in __init__.py

### DIFF
--- a/mosaico-sdk-py/src/mosaicolabs/__init__.py
+++ b/mosaico-sdk-py/src/mosaicolabs/__init__.py
@@ -52,6 +52,11 @@ from .models import (
     MosaicoType as MosaicoType,
     Serializable as Serializable,
     VarianceMixin as VarianceMixin,
+    # Force registration into Serializable registry
+    # (fix deserializing messages from topics that contain these data types,
+    # with no registration side-effects)
+    # !!DO NOT REMOVE!!
+    futures as futures,
 )
 
 # --- Base Types ---
@@ -128,6 +133,12 @@ from .models.sensors import (
     RobotJoint as RobotJoint,
     Temperature as Temperature,
 )
+
+# Force registration into Serializable registry
+# (fix deserializing messages from topics that contain these data types,
+# with no registration side-effects)
+# !!DO NOT REMOVE!!
+from .ros_bridge import data_ontology  # noqa: F401
 
 # --- Types ---
 from .types import Time as Time

--- a/mosaico-sdk-py/src/mosaicolabs/models/futures/lidar.py
+++ b/mosaico-sdk-py/src/mosaicolabs/models/futures/lidar.py
@@ -7,7 +7,7 @@ obtained from a LiDAR sensor.
 
 from typing import Optional
 
-from mosaicolabs import MosaicoField, MosaicoType, Serializable
+from mosaicolabs.models import MosaicoField, MosaicoType, Serializable
 
 
 class Lidar(Serializable):

--- a/mosaico-sdk-py/src/mosaicolabs/models/futures/radar.py
+++ b/mosaico-sdk-py/src/mosaicolabs/models/futures/radar.py
@@ -7,7 +7,7 @@ of detections obtained from a Radar sensor.
 
 from typing import Optional
 
-from mosaicolabs import MosaicoField, MosaicoType, Serializable
+from mosaicolabs.models import MosaicoField, MosaicoType, Serializable
 
 
 class Radar(Serializable):

--- a/mosaico-sdk-py/src/testing/unit/models/test_registration.py
+++ b/mosaico-sdk-py/src/testing/unit/models/test_registration.py
@@ -1,3 +1,7 @@
+import subprocess
+import sys
+import textwrap
+
 import pydantic
 import pytest
 
@@ -47,3 +51,32 @@ def test_message_generation():
     ):
         # This must fail: Unregistered type cannot be sent to mosaico
         Message(timestamp_ns=0, data=UnregisteredSensor(field=0))  # type: ignore (disable pylance complaining)
+
+
+def test_futures_registration():
+    code = textwrap.dedent(
+        # Generate a fresh environmnent
+        """
+            from mosaicolabs.models.serializable import Serializable
+
+            _FUTURES_TAGS = [
+                "rgbd_camera",
+                "tof_camera",
+                "stereo_camera",
+                "laser_scan",
+                "multi_echolaser_scan",
+                "lidar",
+                "radar",
+            ]
+
+            assert all(Serializable._is_registered(tag) for tag in _FUTURES_TAGS)
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/mosaico-sdk-py/src/testing/unit/query/test_query_metadata.py
+++ b/mosaico-sdk-py/src/testing/unit/query/test_query_metadata.py
@@ -46,6 +46,15 @@ class TestQueryTopicMetadataAPI:
         ):
             QueryTopic().with_user_metadata("some-field", lt="some_value")
 
+    def test_expected_operators(self):
+        # Simulate the User Query
+        QueryTopic().with_user_metadata("some-field", eq="some_value")
+        QueryTopic().with_user_metadata("some-field", lt=0)
+        QueryTopic().with_user_metadata("some-field", gt=0)
+        QueryTopic().with_user_metadata("some-field", geq=0)
+        QueryTopic().with_user_metadata("some-field", leq=0)
+        QueryTopic().with_user_metadata("some-field", between=[0, 1])
+
 
 class TestQuerySequenceMetadataAPI:
     def test_expression_generation(self):
@@ -86,3 +95,12 @@ class TestQuerySequenceMetadataAPI:
             match="Invalid type for '_QueryableDynamicValueField' comparison",
         ):
             QuerySequence().with_user_metadata("some-field", lt="some_value")
+
+    def test_expected_operators(self):
+        # Simulate the User Query
+        QuerySequence().with_user_metadata("some-field", eq="some_value")
+        QuerySequence().with_user_metadata("some-field", lt=0)
+        QuerySequence().with_user_metadata("some-field", gt=0)
+        QuerySequence().with_user_metadata("some-field", geq=0)
+        QuerySequence().with_user_metadata("some-field", leq=0)
+        QuerySequence().with_user_metadata("some-field", between=[0, 1])

--- a/mosaico-sdk-py/src/testing/unit/ros_bridge/test_registration.py
+++ b/mosaico-sdk-py/src/testing/unit/ros_bridge/test_registration.py
@@ -1,0 +1,29 @@
+import subprocess
+import sys
+import textwrap
+
+
+def test_ros_ontology_registration():
+    code = textwrap.dedent(
+        # Generate a fresh environmnent
+        """
+            from mosaicolabs.models.serializable import Serializable
+
+            _FUTURES_TAGS = [
+                "battery_state",
+                "frame_transform",
+                "point_cloud2",
+                "point_field",
+            ]
+
+            assert all(Serializable._is_registered(tag) for tag in _FUTURES_TAGS)
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
This PR fixes the registration errors due to missing global import of `futures` and ROS-related `data_ontology` modules.

**No breaking changes are expected with this fix.**

Closes #450 