### PR TITLE
perf(mosaicod): performance tuning

### DIFF
--- a/doc/docs/daemon/env.md
+++ b/doc/docs/daemon/env.md
@@ -4,7 +4,7 @@ Here we provide a complete list of environment variables that can be used to con
 
 ## General
 
-- `MOSAICOD_MAX_GRPC_MESSAGE_SIZE`: The maximum allowed [gRPC](https://grpc.io/) message size in bytes. If a message exceeds this size, a protocol error will be returned. Default is `25 MB`. **If you need to update this value** be aware that this value is tipically smaller than `Params::parquet_in_memory_encoding_buffer_size`.
+- `MOSAICOD_MAX_GRPC_MESSAGE_SIZE`: The maximum allowed [gRPC](https://grpc.io/) message size in bytes. If a message exceeds this size, a protocol error will be returned. Default is `50 MB`. **If you need to update this value** be aware that this value is tipically smaller than `Params::parquet_in_memory_encoding_buffer_size`.
 
 - `MOSAICOD_TARGET_MESSAGE_SIZE`: Target message size in bytes used during data streaming. The daemon will try to aggregate a number of [`RecordBatches`](https://arrow.apache.org/docs/python/generated/pyarrow.RecordBatch.html) to create a sufficiently large message. If the resulting batch size exceeds the limit, it will be capped by `MOSAICOD_MAX_BATCH_SIZE`. Defaults to `25MB`.
 
@@ -18,7 +18,7 @@ Here we provide a complete list of environment variables that can be used to con
 
 - `MOSAICOD_QUERY_ENGINE_MEMORY_POOL_SIZE`: Defines the amount of memory (in bytes) used by the query engine. Set this value to a number greater than 0 to enforce a hard limit on the memory allocated by the query engine. Use this setting if mosaicod encounters OOM (Out Of Memory) errors or you plan to use `mosaicod` in a memory constrained environment. Defaults to `0` (no limit).
 
-- `MOSAICOD_PARQUET_IN_MEMORY_ENCODING_BUFFER_SIZE`: Size (in bytes) of the in-memory buffer used for encoding parquet data. Defaults to `50MB`.
+- `MOSAICOD_PARQUET_IN_MEMORY_ENCODING_BUFFER_SIZE`: Size (in bytes) of the in-memory buffer used for encoding parquet data. Defaults to `75MB`.
 
 ## TLS
 

--- a/mosaicod/Cargo.toml
+++ b/mosaicod/Cargo.toml
@@ -25,7 +25,7 @@ mosaicod-server = { path = "crates/mosaicod-server" }
 mosaicod-store = { path = "crates/mosaicod-store" }
 
 # Arrow stack dependencies
-arrow = { version = "58.1.0", features = ["prettyprint"] }
+arrow = { version = "58.1.0", features = ["prettyprint", "ipc_compression"] }
 arrow-cast = "58.1.0"
 arrow-flight = "58.1.0"
 arrow-schema = "58.1.0"

--- a/mosaicod/crates/mosaicod-core/src/params.rs
+++ b/mosaicod/crates/mosaicod-core/src/params.rs
@@ -135,7 +135,7 @@ pub struct Params {
     /// If you need to update this value be aware that this value is tipically
     /// smaller than [`Params::parquet_in_memory_encoding_buffer_size`].
     ///
-    /// Defaults to 25 MB.
+    /// Defaults to 50 MB.
     pub max_grpc_message_size: Param<usize>,
 
     /// Target message size (in bytes) used during data streaming. Mosaicod will try to
@@ -237,7 +237,7 @@ pub fn load_params_from_env(config: ParamsLoadOptions) -> error::PublicResult<()
 
     let ev = Params {
         // general
-        max_grpc_message_size: Param::optional("MOSAICOD_MAX_GRPC_MESSAGE_SIZE", 25 * 1_000_000),
+        max_grpc_message_size: Param::optional("MOSAICOD_MAX_GRPC_MESSAGE_SIZE", 50 * 1_000_000),
         target_message_size: Param::optional("MOSAICOD_TARGET_MESSAGE_SIZE", 25 * 1_000_000),
         max_concurrent_chunk_queries: Param::optional("MOSAICOD_MAX_CONCURRENT_CHUNK_QUERIES", 4),
         max_db_connections: Param::optional("MOSAICOD_MAX_DB_CONNECTIONS", 10),
@@ -248,7 +248,7 @@ pub fn load_params_from_env(config: ParamsLoadOptions) -> error::PublicResult<()
         default_parallelism: Param::optional("MOSAICOD_DEFAULT_PARALLELISM", default_parallelism),
         parquet_in_memory_encoding_buffer_size: Param::optional(
             "MOSAICOD_PARQUET_IN_MEMORY_ENCODING_BUFFER_SIZE",
-            50 * 1_000_000,
+            75 * 1_000_000,
         ),
         max_batch_size: Param::optional("MOSAICOD_MAX_BATCH_SIZE", 8192),
         query_engine_memory_pool_size: Param::optional("MOSAICOD_QUERY_ENGINE_MEMORY_POOL_SIZE", 0),

--- a/mosaicod/crates/mosaicod-core/src/params.rs
+++ b/mosaicod/crates/mosaicod-core/src/params.rs
@@ -188,7 +188,7 @@ pub struct Params {
 
     /// Size (in bytes) of the in-memory buffer used for encoding parquet data.
     ///
-    /// Default to 50 MB
+    /// Default to 75 MB
     pub parquet_in_memory_encoding_buffer_size: Param<usize>,
 
     /// Path of the `cert.pem` file used as TLS certificate

--- a/mosaicod/crates/mosaicod-query/src/timeseries.rs
+++ b/mosaicod/crates/mosaicod-query/src/timeseries.rs
@@ -74,7 +74,13 @@ impl TimeseriesEngine {
 
         let mut conf = SessionConfig::new();
         if let Some(batch_size) = batch_size {
-            conf = conf.with_batch_size(batch_size);
+            conf = conf
+                .with_batch_size(batch_size)
+                // Reduce the number of partition used to avoid management overhead
+                .with_target_partitions(1)
+                // Parquet specific optimizations
+                .set_bool("datafusion.execution.parquet.pushdown_filters", true)
+                .set_bool("datafusion.execution.parquet.reorder_filters", true);
         }
 
         let ctx = SessionContext::new_with_config_rt(conf, self.runtime.clone());

--- a/mosaicod/crates/mosaicod-rw/src/format.rs
+++ b/mosaicod/crates/mosaicod-rw/src/format.rs
@@ -7,6 +7,7 @@
 
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::ListingOptions;
+use datafusion::prelude::*;
 use mosaicod_core::{params, traits::AsExtension, types};
 use parquet::{
     basic::{Compression, ZstdLevel},
@@ -88,6 +89,9 @@ impl ParquetFormatProperties for DefaultFormatProperties {
     fn listing_options(&self) -> ListingOptions {
         ListingOptions::new(Arc::new(ParquetFormat::default()))
             .with_file_extension(format!(".{}", self.as_extension()))
+            .with_file_sort_order(vec![vec![
+                col(params::ARROW_SCHEMA_COLUMN_NAME_INDEX_TIMESTAMP).sort(true, true),
+            ]])
     }
 }
 
@@ -138,6 +142,9 @@ impl ParquetFormatProperties for RaggedFormatProperties {
     fn listing_options(&self) -> ListingOptions {
         ListingOptions::new(Arc::new(ParquetFormat::default()))
             .with_file_extension(format!(".{}", self.as_extension()))
+            .with_file_sort_order(vec![vec![
+                col(params::ARROW_SCHEMA_COLUMN_NAME_INDEX_TIMESTAMP).sort(true, true),
+            ]])
     }
 }
 
@@ -188,6 +195,9 @@ impl ParquetFormatProperties for ImageFormatProperties {
     fn listing_options(&self) -> ListingOptions {
         ListingOptions::new(Arc::new(ParquetFormat::default()))
             .with_file_extension(format!(".{}", self.as_extension()))
+            .with_file_sort_order(vec![vec![
+                col(params::ARROW_SCHEMA_COLUMN_NAME_INDEX_TIMESTAMP).sort(true, true),
+            ]])
     }
 
     fn buffer_capacity(&self) -> usize {

--- a/mosaicod/crates/mosaicod-server/src/endpoint/do_get.rs
+++ b/mosaicod/crates/mosaicod-server/src/endpoint/do_get.rs
@@ -1,4 +1,6 @@
 use crate::error::Result;
+use arrow::ipc::CompressionType;
+use arrow::ipc::writer::IpcWriteOptions;
 use arrow_flight::{
     Ticket,
     encode::{FlightDataEncoder, FlightDataEncoderBuilder},
@@ -62,7 +64,17 @@ pub async fn do_get(ctx: &facade::Context, ticket: Ticket) -> Result<FlightDataE
     // Convert the data stream to a flight stream casting the returned error
     let stream = stream.map_err(|e| FlightError::ExternalError(Box::new(e)));
 
+    // We enable by default LZ4_FRAME compression for all streams.
+    // As `.try_with_compression()` states the function throws an error at runtime
+    // if the ipc_compression feature is not enabled. So we should never see this terror.
+    let ipc_options = IpcWriteOptions::default()
+        .try_with_compression(Some(CompressionType::LZ4_FRAME))
+        .map_err(|_| {
+            core::Error::internal(Some("arrow ipc lz4 compression not available".to_owned()))
+        })?;
+
     Ok(FlightDataEncoderBuilder::new()
         .with_schema(schema)
+        .with_options(ipc_options)
         .build(stream))
 }


### PR DESCRIPTION
- Enabled pushdown filters and reorder filters in datafusion queries
- Enabled LZ4 compression by default in do_get
- Enabled direct streaming for pre-sorted data
- Increased max grpc message size to 50MB
- Limited the maximum number of target partitions of datafusion queries

Closes #451