### PR TITLE
fix(mosaicod): Cleanup unit tests being stuck 

### DIFF
--- a/mosaicod/Cargo.lock
+++ b/mosaicod/Cargo.lock
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "mosaicod"
-version = "0.4.0"
+version = "0.6.0-dev"
 dependencies = [
  "chrono",
  "clap",
@@ -2602,14 +2602,14 @@ dependencies = [
 
 [[package]]
 name = "mosaicod-build"
-version = "0.4.0"
+version = "0.6.0-dev"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "mosaicod-core"
-version = "0.4.0"
+version = "0.6.0-dev"
 dependencies = [
  "bytes",
  "chrono",
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "mosaicod-db"
-version = "0.4.0"
+version = "0.6.0-dev"
 dependencies = [
  "chrono",
  "log",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "mosaicod-ext"
-version = "0.4.0"
+version = "0.6.0-dev"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "mosaicod-facade"
-version = "0.4.0"
+version = "0.6.0-dev"
 dependencies = [
  "arrow",
  "futures",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "mosaicod-marshal"
-version = "0.4.0"
+version = "0.6.0-dev"
 dependencies = [
  "bincode",
  "bytes",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "mosaicod-query"
-version = "0.4.0"
+version = "0.6.0-dev"
 dependencies = [
  "arrow",
  "datafusion",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "mosaicod-rw"
-version = "0.4.0"
+version = "0.6.0-dev"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "mosaicod-server"
-version = "0.4.0"
+version = "0.6.0-dev"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2739,6 +2739,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tonic",
  "tower",
  "tracing",
@@ -2746,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "mosaicod-store"
-version = "0.4.0"
+version = "0.6.0-dev"
 dependencies = [
  "bytes",
  "chrono",
@@ -2763,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "mosaicod-task"
-version = "0.4.0"
+version = "0.6.0-dev"
 dependencies = [
  "chrono",
  "filetime",
@@ -2773,6 +2774,7 @@ dependencies = [
  "rand 0.9.2",
  "sqlx",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -4134,7 +4136,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.4.0"
+version = "0.6.0-dev"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4154,6 +4156,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
+ "tokio-util",
  "tonic",
  "tower",
  "tracing-subscriber",
@@ -4292,6 +4295,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/mosaicod/Cargo.lock
+++ b/mosaicod/Cargo.lock
@@ -4295,7 +4295,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/mosaicod/Cargo.toml
+++ b/mosaicod/Cargo.toml
@@ -59,7 +59,7 @@ sqlx = { version = "0.8.6", features = [
 ] }
 thiserror = "2.0.18"
 tokio = { version = "1.50.0", features = ["rt-multi-thread"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio-util = { version = "0.7" }
 url = "2.5.8"
 uuid = { version = "1.23.1", features = [ "v4" ] }
 ulid = "1.2.1"

--- a/mosaicod/Cargo.toml
+++ b/mosaicod/Cargo.toml
@@ -59,6 +59,7 @@ sqlx = { version = "0.8.6", features = [
 ] }
 thiserror = "2.0.18"
 tokio = { version = "1.50.0", features = ["rt-multi-thread"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 url = "2.5.8"
 uuid = { version = "1.23.1", features = [ "v4" ] }
 ulid = "1.2.1"

--- a/mosaicod/crates/mosaicod-server/Cargo.toml
+++ b/mosaicod/crates/mosaicod-server/Cargo.toml
@@ -22,6 +22,7 @@ mosaicod-task = { workspace = true }
 
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 log = { workspace = true }
 serde_json = { workspace = true }
 futures = { workspace = true }

--- a/mosaicod/crates/mosaicod-server/src/core.rs
+++ b/mosaicod/crates/mosaicod-server/src/core.rs
@@ -61,7 +61,7 @@ impl Server {
                     .with_time_interval(cleanup_time_interval)
                     .with_retention_duration(cleanup_retention_duration);
 
-                cleanup.run((*shutdown_cleanup.inner()).clone()).await
+                cleanup.run((shutdown_cleanup.token()).clone()).await
             });
 
             let server_store = self.store.clone();

--- a/mosaicod/crates/mosaicod-server/src/flight.rs
+++ b/mosaicod/crates/mosaicod-server/src/flight.rs
@@ -19,32 +19,32 @@ use mosaicod_marshal as marshal;
 use mosaicod_query as query;
 use mosaicod_store as store;
 use std::sync::Arc;
-use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
 use tonic::{Request, Response, Status, Streaming, codec::CompressionEncoding, transport::Server};
 
 /// To stop the server use the following command on
 /// `ShutdownNotifier`
-#[derive(Clone)]
-pub struct ShutdownNotifier(Arc<Notify>);
+#[derive(Clone, Default, Debug)]
+pub struct ShutdownNotifier(CancellationToken);
 
 impl ShutdownNotifier {
-    // Notifies the server to be shut down
+    // Notifies the server to be shutdown
     pub fn shutdown(&self) {
-        self.0.notify_waiters();
+        self.0.cancel();
     }
 
     pub async fn wait_for_shutdown(&self) {
-        self.0.notified().await;
+        self.0.cancelled().await;
     }
 
-    pub fn inner(&self) -> &Arc<Notify> {
-        &self.0
+    pub fn is_shutdown(&self) -> bool {
+        self.0.is_cancelled()
     }
-}
 
-impl Default for ShutdownNotifier {
-    fn default() -> Self {
-        Self(Arc::new(Notify::new()))
+    /// Returns a cloned cancellation token for use across crate boundaries
+    /// (e.g. passing to background tasks defined in other crates).
+    pub fn token(&self) -> CancellationToken {
+        self.0.clone()
     }
 }
 

--- a/mosaicod/crates/mosaicod-task/Cargo.toml
+++ b/mosaicod/crates/mosaicod-task/Cargo.toml
@@ -16,6 +16,7 @@ mosaicod-store = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 
 [dev-dependencies]
 mosaicod-db = { workspace = true, features = ["postgres", "testing"] }

--- a/mosaicod/crates/mosaicod-task/src/cleanup.rs
+++ b/mosaicod/crates/mosaicod-task/src/cleanup.rs
@@ -5,8 +5,7 @@ use mosaicod_core::{error::PublicResult as Result, types};
 use mosaicod_db as db;
 use mosaicod_store as store;
 use std::ops::Deref;
-use std::sync::Arc;
-use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 const TO_DELETE_MARKER_FILE_NAME: &str = "TO_DELETE";
@@ -90,7 +89,7 @@ impl Cleanup {
     }
 
     /// Starts the cleanup routine that every [`time_interval`] tries to actually perform a cleanup of the store.
-    pub async fn run(mut self, shutdown_notifier: Arc<Notify>) {
+    pub async fn run(mut self, shutdown_notifier: CancellationToken) {
         info!("Launching cleanup background routine");
 
         loop {
@@ -147,7 +146,7 @@ impl Cleanup {
                 // Here we can call .unwrap() safely because duration is non-negative by construction.
                 _ = tokio::time::sleep(self.time_interval.to_std().unwrap()) => {
                 }
-                _ = shutdown_notifier.notified() => {
+                _ = shutdown_notifier.cancelled() => {
                     info!("Exiting cleanup background routine. Shutdown received.");
                     break; // Exit the loop immediately
                 }
@@ -270,8 +269,6 @@ mod tests {
     use mosaicod_core::types;
     use mosaicod_store as store;
     use rand::seq::IteratorRandom;
-    use std::sync::Arc;
-    use tokio::sync::Notify;
 
     struct TestContext {
         db: db::testing::Database,
@@ -592,7 +589,7 @@ mod tests {
         let test_stats =
             populate_random_store(&context, num_seqs, num_topics, retention_duration).await;
 
-        let notifier = Arc::new(Notify::new());
+        let notifier = CancellationToken::new();
 
         let notifier_clone = notifier.clone();
 
@@ -612,7 +609,7 @@ mod tests {
 
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
-        notifier.notify_one();
+        notifier.cancel();
 
         let _ = tokio::join!(handle_cleanup_task);
 

--- a/mosaicod/tests/Cargo.toml
+++ b/mosaicod/tests/Cargo.toml
@@ -22,6 +22,7 @@ arrow-flight = { workspace = true }
 tonic = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
 rand = { workspace = true }

--- a/mosaicod/tests/src/common.rs
+++ b/mosaicod/tests/src/common.rs
@@ -155,7 +155,7 @@ impl ServerBuilder {
                     .with_time_interval(cleanup_time_interval)
                     .with_retention_duration(cleanup_retention_duration);
 
-                cleanup.run((*cleanup_shutdown.inner()).clone()).await
+                cleanup.run(cleanup_shutdown.token()).await
             }
         });
 


### PR DESCRIPTION
The old shutdown signal worked like shouting "stop": only tasks that were already listening at that moment heard it; once shouted, the signal was gone for good.

Background tasks (cleanup, flight server) needed a brief moment after startup before they started listening, the cleanup task, for example, ran a full try_cleanup() first. If shutdown() was called during that window, the signal was shouted into an empty room and lost forever, and the task would keep sleeping and working as if nothing happened.

In serial test runs that window was tiny and never caught the signal too early. In parallel runs, filesystem and DB contention stretched the first try_cleanup() to seconds, opening the window wide enough to lose the signal and hang tests past the 60s threshold.

CancellationToken works like a flag that stays flipped: once cancel() is called, any task checking later, even much later, sees it immediately. The race is gone by construction.

- ShutdownNotifier public API (.shutdown(), .wait_for_shutdown(), Default, Clone) unchanged.
- inner() removed; .token() exposes a CancellationToken for use across crate boundaries (mosaicod-task cannot depend on mosaicod-server).
- Cleanup::run now takes CancellationToken directly.

Close #510 