### PR TITLE
feat(mosaicod): Implement topic_filter_clusterize endpoint 

### DIFF
--- a/mosaicod/Cargo.lock
+++ b/mosaicod/Cargo.lock
@@ -2657,7 +2657,6 @@ name = "mosaicod-facade"
 version = "0.6.0-dev"
 dependencies = [
  "arrow",
- "datafusion",
  "futures",
  "log",
  "mosaicod-core",
@@ -2726,6 +2725,7 @@ version = "0.6.0-dev"
 dependencies = [
  "arrow",
  "arrow-flight",
+ "datafusion",
  "futures",
  "http",
  "log",

--- a/mosaicod/Cargo.lock
+++ b/mosaicod/Cargo.lock
@@ -2657,6 +2657,7 @@ name = "mosaicod-facade"
 version = "0.6.0-dev"
 dependencies = [
  "arrow",
+ "datafusion",
  "futures",
  "log",
  "mosaicod-core",

--- a/mosaicod/crates/mosaicod-ext/src/arrow.rs
+++ b/mosaicod/crates/mosaicod-ext/src/arrow.rs
@@ -375,8 +375,8 @@ pub fn ontology_model_stats_from_schema(schema: &SchemaRef) -> types::OntologyMo
 pub mod testing {
     use super::*;
 
-    use arrow::array::Int64Array;
-    use arrow::datatypes::Schema;
+    use arrow::array::{Int64Array, RecordBatch};
+    use arrow::datatypes::{DataType, Field, Schema};
 
     pub fn dummy_empty_batch() -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![
@@ -417,6 +417,32 @@ pub mod testing {
                     10000, 10005, 10010, 10015, 10020, 10025, 10030,
                 ])),
                 Arc::new(Int64Array::from(vec![1, 2, 3, 4, 5, 6, 7])),
+            ],
+        )
+        .unwrap()
+    }
+
+    pub fn clustering_test_batch(timestamps: &[i64], values: &[i64]) -> RecordBatch {
+        assert_eq!(
+            timestamps.len(),
+            values.len(),
+            "timestamps and values must have the same length"
+        );
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                params::ARROW_SCHEMA_COLUMN_NAME_INDEX_TIMESTAMP,
+                DataType::Int64,
+                false,
+            ),
+            Field::new("value", DataType::Int64, false),
+        ]));
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(timestamps.to_vec())),
+                Arc::new(Int64Array::from(values.to_vec())),
             ],
         )
         .unwrap()

--- a/mosaicod/crates/mosaicod-ext/src/arrow_filter.rs
+++ b/mosaicod/crates/mosaicod-ext/src/arrow_filter.rs
@@ -1,5 +1,5 @@
 use arrow::array::AsArray;
-use arrow::datatypes::UInt64Type;
+use arrow::datatypes::Int64Type;
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
 use futures::{Stream, StreamExt};
@@ -133,13 +133,32 @@ fn extract_timestamps<'a>(
     }
 
     // unwrap here is safe because the timestamp's datatype is enforced in do_put session.
-    let timestamp_array = timestamp_array.as_primitive_opt::<UInt64Type>().unwrap();
-    Ok(timestamp_array.values())
+    let timestamp_array = timestamp_array
+        .as_primitive_opt::<Int64Type>()
+        .unwrap()
+        .values();
+
+    // SAFETY: reinterpreting &[i64] as &[u64] is sound here because:
+    //   - i64 and u64 have the same size (8 bytes) and alignment, so the
+    //     pointer cast preserves the memory layout of the slice;
+    //   - the timestamp column is enforced to be Int64 at ingest time
+    //     (do_put session), so we never reach this code with a different type;
+    //   - timestamps represent nanoseconds since the Unix epoch and are always
+    //     non-negative, hence every value fits in the positive range of i64
+    //     and maps one-to-one to u64 without any change in numeric meaning;
+    let ts: &[u64] = unsafe {
+        std::slice::from_raw_parts(
+            timestamp_array.as_ptr() as *const u64,
+            timestamp_array.len(),
+        )
+    };
+    Ok(ts)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::Int64Array;
     use arrow::array::UInt64Array;
     use arrow::datatypes::DataType;
     use arrow::datatypes::{Field, Schema};
@@ -147,8 +166,9 @@ mod tests {
     use std::sync::Arc;
 
     fn batch(ts: &[u64]) -> RecordBatch {
-        let schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::UInt64, false)]));
-        let array = UInt64Array::from(ts.to_vec());
+        let schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::Int64, false)]));
+        let ts: Vec<i64> = ts.iter().map(|&v| v as i64).collect();
+        let array = Int64Array::from(ts);
         RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap()
     }
 

--- a/mosaicod/crates/mosaicod-ext/src/arrow_filter.rs
+++ b/mosaicod/crates/mosaicod-ext/src/arrow_filter.rs
@@ -24,20 +24,22 @@ pub enum ClusteringError {
     Arrow(#[from] ArrowError),
 }
 
-pub fn clustering_error_to_status(e: ClusteringError) -> tonic::Status {
-    use tonic::Status;
-    match e {
-        ClusteringError::ColumnNotFound(col) => {
-            Status::failed_precondition(format!("timestamp column `{col}` not found"))
+impl ClusteringError {
+    pub fn to_status(&self) -> tonic::Status {
+        use tonic::Status;
+        match self {
+            ClusteringError::ColumnNotFound(col) => {
+                Status::failed_precondition(format!("timestamp column `{col}` not found"))
+            }
+            ClusteringError::HasNulls(col) => {
+                Status::data_loss(format!("timestamp column `{col}` has null values"))
+            }
+            ClusteringError::UnsupportedClusteringDt => {
+                Status::invalid_argument("clustering_dt_ns must be greater than 0")
+            }
+            ClusteringError::Arrow(arr) => Status::internal(format!("arrow error: {arr}")),
+            ClusteringError::ChannelClosed => Status::cancelled("client disconnected"),
         }
-        ClusteringError::HasNulls(col) => {
-            Status::data_loss(format!("timestamp column `{col}` has null values"))
-        }
-        ClusteringError::UnsupportedClusteringDt => {
-            Status::invalid_argument("clustering_dt_ns must be greater than 0")
-        }
-        ClusteringError::Arrow(arr) => Status::internal(format!("arrow error: {arr}")),
-        ClusteringError::ChannelClosed => Status::cancelled("client disconnected"),
     }
 }
 
@@ -636,10 +638,8 @@ mod tests {
 
     #[tokio::test]
     async fn error_arrives_in_order_after_successful_clusters() {
-        // Primo batch: produce un cluster che si chiude (gap > dt)
-        let good = batch(&[1, 100]); // dt=10 → flush di {1,1,id:0}, apre {100,100,id:1}
+        let good = batch(&[1, 100]);
 
-        // Secondo batch: colonna sbagliata → errore
         let schema = Arc::new(Schema::new(vec![Field::new(
             "not_ts",
             DataType::Int64,

--- a/mosaicod/crates/mosaicod-ext/src/arrow_filter.rs
+++ b/mosaicod/crates/mosaicod-ext/src/arrow_filter.rs
@@ -24,11 +24,42 @@ pub enum ClusteringError {
     Arrow(#[from] ArrowError),
 }
 
+pub fn clustering_error_to_status(e: ClusteringError) -> tonic::Status {
+    use tonic::Status;
+    match e {
+        ClusteringError::ColumnNotFound(col) => {
+            Status::failed_precondition(format!("timestamp column `{col}` not found"))
+        }
+        ClusteringError::HasNulls(col) => {
+            Status::data_loss(format!("timestamp column `{col}` has null values"))
+        }
+        ClusteringError::UnsupportedClusteringDt => {
+            Status::invalid_argument("clustering_dt_ns must be greater than 0")
+        }
+        ClusteringError::Arrow(arr) => Status::internal(format!("arrow error: {arr}")),
+        ClusteringError::ChannelClosed => Status::cancelled("client disconnected"),
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Cluster {
     pub start_ns: u64,
     pub end_ns: u64,
     pub id: u64,
+}
+
+/// Sends a clustering error through the output channel.
+///
+/// Returns Ok(()) if the error was delivered (which is the only "success" path
+/// from the caller's perspective: it means the consumer will see the error).
+/// Returns `Err(ChannelClosed)` if the channel is closed.
+async fn forward_err(
+    out: mpsc::Sender<std::result::Result<Cluster, ClusteringError>>,
+    e: ClusteringError,
+) -> std::result::Result<(), ClusteringError> {
+    out.send(Err(e))
+        .await
+        .map_err(|_| ClusteringError::ChannelClosed)
 }
 
 /// Clusters strictly monotonically increasing timestamps from a single topic's
@@ -58,7 +89,7 @@ pub async fn topic_filter_clusterize<S>(
     mut batch_stream: S,
     clustering_dt_ns: u64,
     timestamp_column: &str,
-    out: mpsc::Sender<Cluster>,
+    out: mpsc::Sender<Result<Cluster, ClusteringError>>,
 ) -> Result<(), ClusteringError>
 where
     S: Stream<Item = Result<RecordBatch, ArrowError>> + Unpin,
@@ -68,12 +99,19 @@ where
     let mut id: u64 = 0;
 
     if clustering_dt_ns == 0 {
-        return Err(ClusteringError::UnsupportedClusteringDt);
+        return forward_err(out, ClusteringError::UnsupportedClusteringDt).await;
     }
 
     while let Some(batch) = batch_stream.next().await {
-        let batch = batch?;
-        let ts = extract_timestamps(&batch, timestamp_column)?;
+        let batch = match batch {
+            Ok(b) => b,
+            Err(e) => return forward_err(out, ClusteringError::Arrow(e)).await,
+        };
+
+        let ts = match extract_timestamps(&batch, timestamp_column) {
+            Ok(ts) => ts,
+            Err(e) => return forward_err(out, e).await,
+        };
 
         if ts.is_empty() {
             continue;
@@ -92,7 +130,7 @@ where
                     if (t - prev) <= clustering_dt_ns {
                         curr.end_ns = t;
                     } else {
-                        out.send(*curr)
+                        out.send(Ok(*curr))
                             .await
                             .map_err(|_| ClusteringError::ChannelClosed)?;
                         id += 1;
@@ -112,7 +150,7 @@ where
     }
 
     if let Some(cluster) = current {
-        out.send(cluster)
+        out.send(Ok(cluster))
             .await
             .map_err(|_| ClusteringError::ChannelClosed)?;
     }
@@ -172,9 +210,12 @@ mod tests {
         RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap()
     }
 
-    async fn run(batches: Vec<RecordBatch>, clustering_dt: u64) -> Vec<Cluster> {
+    async fn run_raw(
+        batches: Vec<RecordBatch>,
+        clustering_dt: u64,
+    ) -> Vec<std::result::Result<Cluster, ClusteringError>> {
         let s = stream::iter(batches.into_iter().map(Ok::<_, ArrowError>));
-        let (tx, mut rx) = mpsc::channel(64);
+        let (tx, mut rx) = mpsc::channel::<std::result::Result<Cluster, ClusteringError>>(64);
 
         let handle =
             tokio::spawn(async move { topic_filter_clusterize(s, clustering_dt, "ts", tx).await });
@@ -183,11 +224,20 @@ mod tests {
         while let Some(c) = rx.recv().await {
             out.push(c);
         }
+
         handle
             .await
             .expect("task panicked")
-            .expect("clustering failed");
+            .expect("task returned ChannelClosed unexpectedly");
         out
+    }
+
+    async fn run(batches: Vec<RecordBatch>, clustering_dt: u64) -> Vec<Cluster> {
+        run_raw(batches, clustering_dt)
+            .await
+            .into_iter()
+            .map(|item| item.expect("clustering returned an error"))
+            .collect()
     }
 
     async fn run_err(
@@ -196,20 +246,26 @@ mod tests {
         column: &'static str,
     ) -> ClusteringError {
         let s = stream::iter(batches.into_iter().map(Ok::<_, ArrowError>));
-        let (tx, mut rx) = mpsc::channel(64);
+        let (tx, mut rx) = mpsc::channel::<std::result::Result<Cluster, ClusteringError>>(64);
 
         let handle =
             tokio::spawn(
                 async move { topic_filter_clusterize(s, clustering_dt, column, tx).await },
             );
 
-        while rx.recv().await.is_some() {}
+        let mut captured = None;
+        while let Some(item) = rx.recv().await {
+            if let Err(e) = item {
+                captured = Some(e);
+            }
+        }
+
         handle
             .await
             .expect("task panicked")
-            .expect_err("expected clustering error")
+            .expect("task returned ChannelClosed unexpectedly");
+        captured.expect("expected clustering error in channel, found none")
     }
-
     #[tokio::test]
     async fn empty_stream_emits_nothing() {
         let clusters = run(vec![], 100).await;
@@ -495,10 +551,13 @@ mod tests {
             received.push(c);
         }
 
-        let result = handle.await.expect("task panicked");
-        assert!(matches!(result, Err(ClusteringError::Arrow(_))));
+        handle
+            .await
+            .expect("task panicked")
+            .expect("task returned ChannelClosed unexpectedly");
 
-        assert!(received.is_empty());
+        assert_eq!(received.len(), 1);
+        assert!(matches!(received[0], Err(ClusteringError::Arrow(_))));
     }
 
     #[tokio::test]
@@ -508,11 +567,11 @@ mod tests {
                 .into_iter()
                 .map(Ok::<_, ArrowError>),
         );
-        let (tx, mut rx) = mpsc::channel(1);
+        let (tx, mut rx) = mpsc::channel::<std::result::Result<Cluster, ClusteringError>>(1);
 
         let handle = tokio::spawn(async move { topic_filter_clusterize(s, 5, "ts", tx).await });
 
-        let mut got = Vec::new();
+        let mut got: Vec<std::result::Result<Cluster, ClusteringError>> = Vec::new();
         while let Some(c) = rx.recv().await {
             got.push(c);
         }
@@ -525,11 +584,11 @@ mod tests {
         for (i, c) in got.iter().enumerate() {
             let ts = (i as u64) * 100;
             assert_eq!(
-                *c,
+                *c.as_ref().unwrap(),
                 Cluster {
                     start_ns: ts,
                     end_ns: ts,
-                    id: i as u64
+                    id: i as u64,
                 }
             );
         }
@@ -573,5 +632,58 @@ mod tests {
             assert_eq!(c.start_ns, c.end_ns);
             assert_eq!(c.start_ns, (i as u64) * 1_000);
         }
+    }
+
+    #[tokio::test]
+    async fn error_arrives_in_order_after_successful_clusters() {
+        // Primo batch: produce un cluster che si chiude (gap > dt)
+        let good = batch(&[1, 100]); // dt=10 → flush di {1,1,id:0}, apre {100,100,id:1}
+
+        // Secondo batch: colonna sbagliata → errore
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "not_ts",
+            DataType::Int64,
+            false,
+        )]));
+        let arr = Int64Array::from(vec![200i64]);
+        let bad = RecordBatch::try_new(schema, vec![Arc::new(arr)]).unwrap();
+
+        let items = run_raw(vec![good, bad], 10).await;
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(
+            items[0].as_ref().unwrap(),
+            &Cluster {
+                start_ns: 1,
+                end_ns: 1,
+                id: 0
+            }
+        );
+        assert!(matches!(items[1], Err(ClusteringError::ColumnNotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn dropping_receiver_returns_channel_closed() {
+        let s = stream::iter(
+            vec![batch(&[0, 100, 200])]
+                .into_iter()
+                .map(Ok::<_, ArrowError>),
+        );
+        let (tx, rx) = mpsc::channel::<std::result::Result<Cluster, ClusteringError>>(1);
+
+        drop(rx);
+
+        let result = topic_filter_clusterize(s, 5, "ts", tx).await;
+        assert!(matches!(result, Err(ClusteringError::ChannelClosed)));
+    }
+
+    #[tokio::test]
+    async fn dt_zero_is_reported_through_channel() {
+        let items = run_raw(vec![batch(&[1, 2, 3])], 0).await;
+        assert_eq!(items.len(), 1);
+        assert!(matches!(
+            items[0],
+            Err(ClusteringError::UnsupportedClusteringDt)
+        ));
     }
 }

--- a/mosaicod/crates/mosaicod-facade/Cargo.toml
+++ b/mosaicod/crates/mosaicod-facade/Cargo.toml
@@ -22,7 +22,6 @@ arrow = { workspace = true }
 log = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }
-datafusion = { workspace = true }
 
 [dev-dependencies]
 sqlx = { workspace = true }

--- a/mosaicod/crates/mosaicod-facade/Cargo.toml
+++ b/mosaicod/crates/mosaicod-facade/Cargo.toml
@@ -22,6 +22,7 @@ arrow = { workspace = true }
 log = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }
+datafusion = { workspace = true }
 
 [dev-dependencies]
 sqlx = { workspace = true }

--- a/mosaicod/crates/mosaicod-facade/src/topic.rs
+++ b/mosaicod/crates/mosaicod-facade/src/topic.rs
@@ -1,11 +1,13 @@
 use super::{Context, Error, session};
 use arrow::datatypes::SchemaRef;
+use datafusion::physical_plan::SendableRecordBatchStream;
 use log::{trace, warn};
 use mosaicod_core::types::TopicMetadataProperties;
 use mosaicod_core::{self as core, error::PublicResult as Result, params, types};
 use mosaicod_db as db;
 use mosaicod_ext as ext;
 use mosaicod_marshal as marshal;
+use mosaicod_query::OntologyFilter;
 use mosaicod_rw::{self as rw, ToProperties};
 use mosaicod_store as store;
 use std::path;
@@ -577,6 +579,34 @@ impl std::ops::DerefMut for HandleWriter {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.writer
     }
+}
+
+pub async fn query_by_timestamp(
+    context: &Context,
+    handle: &Handle,
+    ts: Option<types::TimestampRange>,
+    ontology_filter: OntologyFilter,
+) -> Result<SendableRecordBatchStream> {
+    let meta = metadata(context, handle).await?;
+    let format = meta.ontology_metadata.properties.serialization_format;
+    let batch_size = compute_optimal_batch_size(context, handle).await.ok();
+
+    let path_in_store = handle
+        .path_in_store()
+        .ok_or(core::Error::not_found(handle.locator().to_string()))?;
+
+    let mut result = context
+        .timeseries_querier
+        .read(path_in_store.data_folder_path(), format, batch_size)
+        .await?;
+
+    if let Some(ts_range) = ts {
+        result = result.filter_by_timestamp_range(ts_range)?;
+    }
+
+    result = result.filter(ontology_filter.into_expr_group())?;
+
+    Ok(result.stream().await?)
 }
 
 #[cfg(test)]

--- a/mosaicod/crates/mosaicod-facade/src/topic.rs
+++ b/mosaicod/crates/mosaicod-facade/src/topic.rs
@@ -1,13 +1,12 @@
 use super::{Context, Error, session};
 use arrow::datatypes::SchemaRef;
-use datafusion::physical_plan::SendableRecordBatchStream;
+
 use log::{trace, warn};
 use mosaicod_core::types::TopicMetadataProperties;
 use mosaicod_core::{self as core, error::PublicResult as Result, params, types};
 use mosaicod_db as db;
 use mosaicod_ext as ext;
 use mosaicod_marshal as marshal;
-use mosaicod_query::OntologyFilter;
 use mosaicod_rw::{self as rw, ToProperties};
 use mosaicod_store as store;
 use std::path;
@@ -579,34 +578,6 @@ impl std::ops::DerefMut for HandleWriter {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.writer
     }
-}
-
-pub async fn query_by_timestamp(
-    context: &Context,
-    handle: &Handle,
-    ts: Option<types::TimestampRange>,
-    ontology_filter: OntologyFilter,
-) -> Result<SendableRecordBatchStream> {
-    let meta = metadata(context, handle).await?;
-    let format = meta.ontology_metadata.properties.serialization_format;
-    let batch_size = compute_optimal_batch_size(context, handle).await.ok();
-
-    let path_in_store = handle
-        .path_in_store()
-        .ok_or(core::Error::not_found(handle.locator().to_string()))?;
-
-    let mut result = context
-        .timeseries_querier
-        .read(path_in_store.data_folder_path(), format, batch_size)
-        .await?;
-
-    if let Some(ts_range) = ts {
-        result = result.filter_by_timestamp_range(ts_range)?;
-    }
-
-    result = result.filter(ontology_filter.into_expr_group())?;
-
-    Ok(result.stream().await?)
 }
 
 #[cfg(test)]

--- a/mosaicod/crates/mosaicod-marshal/src/flight.rs
+++ b/mosaicod/crates/mosaicod-marshal/src/flight.rs
@@ -346,6 +346,52 @@ impl FilterTimestampRange {
     }
 }
 
+impl TryFrom<types::TimestampRange> for FilterTimestampRange {
+    type Error = mosaicod_core::Error;
+
+    fn try_from(value: types::TimestampRange) -> Result<Self, Self::Error> {
+        let start_ns = if value.start.is_unbounded_neg() {
+            0
+        } else {
+            u64::try_from(value.start.as_i64()).map_err(|_| {
+                mosaicod_core::Error::bad_request(format!(
+                    "negative start timestamp not allowed: {}",
+                    value.start
+                ))
+            })?
+        };
+
+        let end_ns = if value.end.is_unbounded_pos() {
+            u64::MAX
+        } else {
+            u64::try_from(value.end.as_i64()).map_err(|_| {
+                mosaicod_core::Error::bad_request(format!(
+                    "negative end timestamp not allowed: {}",
+                    value.end
+                ))
+            })?
+        };
+
+        Ok(Self { start_ns, end_ns })
+    }
+}
+
+impl From<&FilterTimestampRange> for types::TimestampRange {
+    fn from(value: &FilterTimestampRange) -> Self {
+        let start = if value.start_ns == 0 {
+            types::Timestamp::unbounded_neg()
+        } else {
+            types::Timestamp::from(value.start_ns as i64)
+        };
+        let end = if value.end_ns == u64::MAX {
+            types::Timestamp::unbounded_pos()
+        } else {
+            types::Timestamp::from(value.end_ns as i64)
+        };
+        types::TimestampRange::between(start, end)
+    }
+}
+
 // ////////////////////////////////////////////////////////////////////////////
 // TESTS
 // ////////////////////////////////////////////////////////////////////////////

--- a/mosaicod/crates/mosaicod-server/Cargo.toml
+++ b/mosaicod/crates/mosaicod-server/Cargo.toml
@@ -34,6 +34,7 @@ semver = { workspace = true }
 tower = { workspace = true }
 http = { workspace = true }
 tracing = { workspace = true }
+datafusion = { workspace = true }
 
 [dev-dependencies]
 mosaicod-store = { workspace = true, features = ["testing"]}

--- a/mosaicod/crates/mosaicod-server/src/endpoint/actions/topic.rs
+++ b/mosaicod/crates/mosaicod-server/src/endpoint/actions/topic.rs
@@ -8,13 +8,15 @@ use mosaicod_core::{
     self as core,
     types::{self, MetadataBlob},
 };
+use mosaicod_ext;
 use mosaicod_facade::{self as facade};
 use mosaicod_marshal::{
     self as marshal, ActionResponse, ClusterTimestampRange, Ontology, flight::FilterTimestampRange,
     responses,
 };
-use std::time::Duration;
 
+use arrow::error::ArrowError;
+use futures::StreamExt;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -128,19 +130,27 @@ pub async fn notification_purge(ctx: &facade::Context, locator: String) -> Resul
     Ok(ActionResponse::topic_notification_purge())
 }
 
+type FlightTx = mpsc::Sender<std::result::Result<arrow_flight::Result, tonic::Status>>;
+
 pub async fn filter_clusterize(
-    _ctx: &facade::Context,
+    ctx: &facade::Context,
     locator: String,
-    _clustering_dt_ns: u64,
+    clustering_dt_ns: u64,
     ontology: Ontology,
     timestamp_range: Option<FilterTimestampRange>,
 ) -> Result<DoActionStream> {
     info!("filter clusterize for {}", locator);
 
-    if let Some(ts) = &timestamp_range {
-        ts.validate()?;
-    }
+    // 1. Validation and conversion to TimestampRange
+    let ts: Option<types::TimestampRange> = match timestamp_range.as_ref() {
+        Some(ftr) => {
+            ftr.validate()?;
+            Some(ftr.into())
+        }
+        None => None,
+    };
 
+    // 2. Check ontology parameter
     if ontology.len() > 1 || ontology.is_empty() {
         return Err(core::Error::bad_request(format!(
             "Only 1 filtering condition is allowed, found {}",
@@ -148,42 +158,105 @@ pub async fn filter_clusterize(
         )))?;
     }
 
+    // 3. Check clustering_dt_ns
+    let dt_ns = if clustering_dt_ns == 0 {
+        u64::MAX
+    } else {
+        clustering_dt_ns
+    };
+
+    // 4. Setup query
+    let topic_locator = locator.parse::<types::TopicLocator>()?;
+    let topic_handle = facade::topic::Handle::try_from_locator(ctx, topic_locator).await?;
+    let timestamp_column = core::params::ARROW_SCHEMA_COLUMN_NAME_INDEX_TIMESTAMP.to_owned();
+    let ontology_filter = ontology.try_into()?;
+
+    // 5. RecordBatch stram filtered by timestamp if any and ontology
+    let batch_stream = facade::topic::query_by_timestamp(ctx, &topic_handle, ts, ontology_filter)
+        .await?
+        .map(|item| item.map_err(|e| ArrowError::ExternalError(Box::new(e))));
+
+    // 6. Channel setup
     let (tx, rx) = mpsc::channel::<std::result::Result<arrow_flight::Result, tonic::Status>>(
         MAX_BUFFER_CHANNEL_SIZE,
     );
+    let (cluster_tx, cluster_rx) =
+        mpsc::channel::<mosaicod_ext::arrow_filter::Cluster>(MAX_BUFFER_CHANNEL_SIZE);
 
+    // 7. Spawn task
+    spawn_clusterize_task(
+        batch_stream,
+        dt_ns,
+        timestamp_column,
+        cluster_tx,
+        tx.clone(),
+    );
+    spawn_cluster_to_flight_bridge(cluster_rx, tx);
+
+    Ok(Box::pin(ReceiverStream::new(rx)))
+}
+
+fn spawn_clusterize_task<S>(
+    batch_stream: S,
+    clustering_dt_ns: u64,
+    timestamp_column: String,
+    cluster_tx: mpsc::Sender<mosaicod_ext::arrow_filter::Cluster>,
+    flight_tx: FlightTx,
+) where
+    S: futures::Stream<Item = std::result::Result<arrow::record_batch::RecordBatch, ArrowError>>
+        + Send
+        + Unpin
+        + 'static,
+{
     tokio::spawn(async move {
-        for id in 0u64..10 {
-            let res = responses::TopicFilterClusterize {
-                ts: ClusterTimestampRange {
-                    start_ns: id * 10,
-                    end_ns: id * 10 + 5,
-                },
-                id,
-            };
+        let result = mosaicod_ext::arrow_filter::topic_filter_clusterize(
+            batch_stream,
+            clustering_dt_ns,
+            &timestamp_column,
+            cluster_tx,
+        )
+        .await;
+        if let Err(e) = result {
+            let _ = flight_tx
+                .send(Err(tonic::Status::internal(format!(
+                    "clustering error: {e}"
+                ))))
+                .await;
+        }
+    });
+}
 
-            let bytes = match ActionResponse::topic_filter_clusterize(res).bytes() {
-                Ok(b) => b,
-                Err(e) => {
-                    let _ = tx.send(Err(tonic::Status::internal(e.to_string()))).await;
-                    return;
-                }
-            };
-
-            let mut payload = bytes.to_vec();
-            payload.push(b'\n');
-
-            if tx
-                .send(Ok(arrow_flight::Result::new(payload)))
-                .await
-                .is_err()
-            {
+fn spawn_cluster_to_flight_bridge(
+    mut cluster_rx: mpsc::Receiver<mosaicod_ext::arrow_filter::Cluster>,
+    flight_tx: FlightTx,
+) {
+    tokio::spawn(async move {
+        while let Some(cluster) = cluster_rx.recv().await {
+            let msg = cluster_to_flight_result(cluster);
+            if flight_tx.send(msg).await.is_err() {
                 warn!("client disconnected, aborting clusterize stream");
                 return;
             }
-            tokio::time::sleep(Duration::from_secs(1)).await;
         }
     });
+}
 
-    Ok(Box::pin(ReceiverStream::new(rx)))
+fn cluster_to_flight_result(
+    cluster: mosaicod_ext::arrow_filter::Cluster,
+) -> std::result::Result<arrow_flight::Result, tonic::Status> {
+    let res = responses::TopicFilterClusterize {
+        ts: ClusterTimestampRange {
+            start_ns: cluster.start_ns,
+            end_ns: cluster.end_ns,
+        },
+        id: cluster.id,
+    };
+
+    let bytes = ActionResponse::topic_filter_clusterize(res)
+        .bytes()
+        .map_err(|e| tonic::Status::internal(e.to_string()))?;
+
+    let mut payload = bytes.to_vec();
+    payload.push(b'\n');
+    Ok(arrow_flight::Result::new(payload))
 }

--- a/mosaicod/crates/mosaicod-server/src/endpoint/actions/topic.rs
+++ b/mosaicod/crates/mosaicod-server/src/endpoint/actions/topic.rs
@@ -3,6 +3,9 @@ use crate::{
     error::{Error, Result},
     flight::DoActionStream,
 };
+use arrow::error::ArrowError;
+use datafusion::physical_plan::SendableRecordBatchStream;
+use futures::StreamExt;
 use log::{info, trace, warn};
 use mosaicod_core::{
     self as core,
@@ -14,9 +17,7 @@ use mosaicod_marshal::{
     self as marshal, ActionResponse, ClusterTimestampRange, Ontology, flight::FilterTimestampRange,
     responses,
 };
-
-use arrow::error::ArrowError;
-use futures::StreamExt;
+use mosaicod_query as query;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -130,7 +131,40 @@ pub async fn notification_purge(ctx: &facade::Context, locator: String) -> Resul
     Ok(ActionResponse::topic_notification_purge())
 }
 
-type FlightTx = mpsc::Sender<std::result::Result<arrow_flight::Result, tonic::Status>>;
+/// Builds a filtered streaming query over a topic.
+///
+/// Reads the topic's Parquet data with the provided ontology_filter and
+/// optional ts window applied as predicate pushdown, returning a lazy
+/// SendableRecordBatchStream of matching record batches.
+pub async fn query_by_timestamp(
+    context: &facade::Context,
+    handle: &facade::topic::Handle,
+    ts: Option<types::TimestampRange>,
+    ontology_filter: query::OntologyFilter,
+) -> Result<SendableRecordBatchStream> {
+    let meta = facade::topic::metadata(context, handle).await?;
+    let format = meta.ontology_metadata.properties.serialization_format;
+    let batch_size = facade::topic::compute_optimal_batch_size(context, handle)
+        .await
+        .ok();
+
+    let path_in_store = handle
+        .path_in_store()
+        .ok_or(core::Error::not_found(handle.locator().to_string()))?;
+
+    let mut result = context
+        .timeseries_querier
+        .read(path_in_store.data_folder_path(), format, batch_size)
+        .await?;
+
+    if let Some(ts_range) = ts {
+        result = result.filter_by_timestamp_range(ts_range)?;
+    }
+
+    result = result.filter(ontology_filter.into_expr_group())?;
+
+    Ok(result.stream().await?)
+}
 
 pub async fn filter_clusterize(
     ctx: &facade::Context,
@@ -172,73 +206,34 @@ pub async fn filter_clusterize(
     let ontology_filter = ontology.try_into()?;
 
     // 5. RecordBatch stram filtered by timestamp if any and ontology
-    let batch_stream = facade::topic::query_by_timestamp(ctx, &topic_handle, ts, ontology_filter)
+    let batch_stream = query_by_timestamp(ctx, &topic_handle, ts, ontology_filter)
         .await?
         .map(|item| item.map_err(|e| ArrowError::ExternalError(Box::new(e))));
 
     // 6. Channel setup
-    let (tx, rx) = mpsc::channel::<std::result::Result<arrow_flight::Result, tonic::Status>>(
-        MAX_BUFFER_CHANNEL_SIZE,
-    );
-    let (cluster_tx, cluster_rx) =
-        mpsc::channel::<mosaicod_ext::arrow_filter::Cluster>(MAX_BUFFER_CHANNEL_SIZE);
+    let (tx, rx) = mpsc::channel::<
+        std::result::Result<
+            mosaicod_ext::arrow_filter::Cluster,
+            mosaicod_ext::arrow_filter::ClusteringError,
+        >,
+    >(MAX_BUFFER_CHANNEL_SIZE);
 
-    // 7. Spawn task
-    spawn_clusterize_task(
-        batch_stream,
-        dt_ns,
-        timestamp_column,
-        cluster_tx,
-        tx.clone(),
-    );
-    spawn_cluster_to_flight_bridge(cluster_rx, tx);
-
-    Ok(Box::pin(ReceiverStream::new(rx)))
-}
-
-fn spawn_clusterize_task<S>(
-    batch_stream: S,
-    clustering_dt_ns: u64,
-    timestamp_column: String,
-    cluster_tx: mpsc::Sender<mosaicod_ext::arrow_filter::Cluster>,
-    flight_tx: FlightTx,
-) where
-    S: futures::Stream<Item = std::result::Result<arrow::record_batch::RecordBatch, ArrowError>>
-        + Send
-        + Unpin
-        + 'static,
-{
     tokio::spawn(async move {
-        let result = mosaicod_ext::arrow_filter::topic_filter_clusterize(
+        let _ = mosaicod_ext::arrow_filter::topic_filter_clusterize(
             batch_stream,
-            clustering_dt_ns,
+            dt_ns,
             &timestamp_column,
-            cluster_tx,
+            tx,
         )
         .await;
-        if let Err(e) = result {
-            let _ = flight_tx
-                .send(Err(tonic::Status::internal(format!(
-                    "clustering error: {e}"
-                ))))
-                .await;
-        }
     });
-}
 
-fn spawn_cluster_to_flight_bridge(
-    mut cluster_rx: mpsc::Receiver<mosaicod_ext::arrow_filter::Cluster>,
-    flight_tx: FlightTx,
-) {
-    tokio::spawn(async move {
-        while let Some(cluster) = cluster_rx.recv().await {
-            let msg = cluster_to_flight_result(cluster);
-            if flight_tx.send(msg).await.is_err() {
-                warn!("client disconnected, aborting clusterize stream");
-                return;
-            }
-        }
+    let stream = ReceiverStream::new(rx).map(|res| match res {
+        Ok(cluster) => cluster_to_flight_result(cluster),
+        Err(e) => Err(mosaicod_ext::arrow_filter::clustering_error_to_status(e)),
     });
+
+    Ok(Box::pin(stream))
 }
 
 fn cluster_to_flight_result(

--- a/mosaicod/crates/mosaicod-server/src/endpoint/actions/topic.rs
+++ b/mosaicod/crates/mosaicod-server/src/endpoint/actions/topic.rs
@@ -150,7 +150,7 @@ pub async fn query_by_timestamp(
 
     let path_in_store = handle
         .path_in_store()
-        .ok_or(core::Error::not_found(handle.locator().to_string()))?;
+        .ok_or(facade::Error::MissingDbData(handle.locator().to_string()))?;
 
     let mut result = context
         .timeseries_querier
@@ -230,7 +230,7 @@ pub async fn filter_clusterize(
 
     let stream = ReceiverStream::new(rx).map(|res| match res {
         Ok(cluster) => cluster_to_flight_result(cluster),
-        Err(e) => Err(mosaicod_ext::arrow_filter::clustering_error_to_status(e)),
+        Err(e) => Err(e.to_status()),
     });
 
     Ok(Box::pin(stream))

--- a/mosaicod/tests/tests/topic.rs
+++ b/mosaicod/tests/tests/topic.rs
@@ -2,6 +2,7 @@
 use mosaicod_core::types;
 use mosaicod_db as db;
 use mosaicod_ext as ext;
+use mosaicod_ext::arrow::testing::clustering_test_batch;
 use mosaicod_marshal::{self as marshal, Ontology, flight::FilterTimestampRange};
 use serde_json::json;
 use tests::{self, actions, common};
@@ -545,35 +546,348 @@ async fn test_topic_delete_unlocked(pool: sqlx::Pool<db::DatabaseType>) {
     server.shutdown().await;
 }
 
+/// Setup: sequence + session + topic + batch upload + finalize.
+async fn setup_topic_with_batches(
+    client: &mut common::Client,
+    sequence_name: &str,
+    topic_name: &str,
+    batches: Vec<arrow::array::RecordBatch>,
+) {
+    actions::sequence_create(client, sequence_name, None)
+        .await
+        .unwrap();
+    let (_, session_uuid) = actions::session_create(client, sequence_name)
+        .await
+        .unwrap();
+    let topic_uuid = actions::topic_create(client, &session_uuid, topic_name, None)
+        .await
+        .unwrap();
+
+    actions::do_put(client, &topic_uuid, topic_name, batches, false)
+        .await
+        .unwrap();
+    actions::session_finalize(client, &session_uuid)
+        .await
+        .unwrap();
+}
+
+fn ontology_accel_x_gt_5() -> Ontology {
+    serde_json::from_value(json!({
+        "imu.value": { "$gt": 5 }
+    }))
+    .unwrap()
+}
+
 #[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
-async fn test_topic_filter_clusterize_stub(pool: sqlx::Pool<db::DatabaseType>) {
+async fn test_topic_filter_clusterize_three_clusters(pool: sqlx::Pool<db::DatabaseType>) {
     let server = common::ServerBuilder::new(common::HOST, pool).build().await;
     let mut client = common::ClientBuilder::new(common::HOST, server.port())
         .build()
         .await;
 
-    let sequence_name = "test_sequence";
-    let topic_name = &format!("{}/test_topic", sequence_name);
-    let clustering_dt_ns: u64 = 10;
-    let ontology: Ontology = serde_json::from_value(json!({
-        "imu.acceleration.x": { "$gt": 5 }
-    }))
+    let sequence_name = "seq_three";
+    let topic_name = &format!("{sequence_name}/topic");
+
+    let ts: Vec<i64> = vec![100, 110, 120, 200, 210, 220, 300, 310, 320];
+    let val: Vec<i64> = vec![10, 10, 10, 10, 10, 10, 10, 10, 10];
+    let batch = clustering_test_batch(&ts, &val);
+
+    setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
+
+    let clusters = actions::topic_filter_clusterize(
+        &mut client,
+        topic_name,
+        50,
+        ontology_accel_x_gt_5(),
+        None,
+    )
+    .await
     .unwrap();
 
-    let res =
-        actions::topic_filter_clusterize(&mut client, topic_name, clustering_dt_ns, ontology, None)
+    assert_eq!(clusters.len(), 3, "expected 3 clusters, got: {clusters:?}");
+
+    let expected = [(100u64, 120u64), (200, 220), (300, 320)];
+    for (i, (exp_start, exp_end)) in expected.iter().enumerate() {
+        let start = clusters[i]["ts"]["start_ns"].as_u64().unwrap();
+        let end = clusters[i]["ts"]["end_ns"].as_u64().unwrap();
+        let id = clusters[i]["id"].as_u64().unwrap();
+        assert_eq!(start, *exp_start, "cluster {i} start");
+        assert_eq!(end, *exp_end, "cluster {i} end");
+        assert_eq!(id, i as u64, "cluster {i} id");
+    }
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_topic_filter_clusterize_single_cluster_via_gap(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let sequence_name = "seq_single";
+    let topic_name = &format!("{sequence_name}/topic");
+
+    let ts: Vec<i64> = vec![1_000, 1_010, 1_020, 1_030, 1_040, 1_050];
+    let val: Vec<i64> = vec![10; 6];
+    let batch = clustering_test_batch(&ts, &val);
+
+    setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
+
+    let clusters = actions::topic_filter_clusterize(
+        &mut client,
+        topic_name,
+        100, // dt_ns >> max gap → un cluster
+        ontology_accel_x_gt_5(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(clusters.len(), 1);
+    assert_eq!(clusters[0]["ts"]["start_ns"].as_u64().unwrap(), 1_000);
+    assert_eq!(clusters[0]["ts"]["end_ns"].as_u64().unwrap(), 1_050);
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_topic_filter_clusterize_dt_zero_returns_full_range(
+    pool: sqlx::Pool<db::DatabaseType>,
+) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let sequence_name = "seq_dt_zero";
+    let topic_name = &format!("{sequence_name}/topic");
+
+    let ts: Vec<i64> = vec![100, 500, 1_000, 5_000, 10_000];
+    let val: Vec<i64> = vec![10; 5];
+    let batch = clustering_test_batch(&ts, &val);
+
+    setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
+
+    let clusters =
+        actions::topic_filter_clusterize(&mut client, topic_name, 0, ontology_accel_x_gt_5(), None)
             .await
             .unwrap();
 
-    for (i, x) in res.iter().enumerate() {
-        let start = x["ts"]["start_ns"].as_u64().unwrap();
-        let end = x["ts"]["end_ns"].as_u64().unwrap();
-        let id = x["id"].as_u64().unwrap();
+    assert_eq!(clusters.len(), 1, "dt_ns=0 must yield exactly one cluster");
+    assert_eq!(clusters[0]["ts"]["start_ns"].as_u64().unwrap(), 100);
+    assert_eq!(clusters[0]["ts"]["end_ns"].as_u64().unwrap(), 10_000);
 
-        assert_eq!(start, i as u64 * 10);
-        assert_eq!(end, i as u64 * 10 + 5);
-        assert_eq!(id, i as u64);
-    }
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_topic_filter_clusterize_ontology_actually_filters(
+    pool: sqlx::Pool<db::DatabaseType>,
+) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let sequence_name = "seq_filter";
+    let topic_name = &format!("{sequence_name}/topic");
+
+    let ts: Vec<i64> = vec![100, 110, 120, 130, 140, 500, 510, 520];
+    let val: Vec<i64> = vec![10, 1, 10, 1, 10, 10, 1, 10];
+    let batch = clustering_test_batch(&ts, &val);
+
+    setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
+
+    let clusters = actions::topic_filter_clusterize(
+        &mut client,
+        topic_name,
+        50,
+        ontology_accel_x_gt_5(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(clusters.len(), 2, "got: {clusters:?}");
+    assert_eq!(clusters[0]["ts"]["start_ns"].as_u64().unwrap(), 100);
+    assert_eq!(clusters[0]["ts"]["end_ns"].as_u64().unwrap(), 140);
+    assert_eq!(clusters[1]["ts"]["start_ns"].as_u64().unwrap(), 500);
+    assert_eq!(clusters[1]["ts"]["end_ns"].as_u64().unwrap(), 520);
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_topic_filter_clusterize_empty_result(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let sequence_name = "seq_empty";
+    let topic_name = &format!("{sequence_name}/topic");
+
+    let ts: Vec<i64> = vec![100, 200, 300];
+    let val: Vec<i64> = vec![1, 2, 3];
+    let batch = clustering_test_batch(&ts, &val);
+
+    setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
+
+    let clusters = actions::topic_filter_clusterize(
+        &mut client,
+        topic_name,
+        50,
+        ontology_accel_x_gt_5(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        clusters.is_empty(),
+        "expected 0 clusters, got: {clusters:?}"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_topic_filter_clusterize_with_time_range(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let sequence_name = "seq_range";
+    let topic_name = &format!("{sequence_name}/topic");
+
+    let ts: Vec<i64> = vec![100, 200, 300, 1_000, 1_100, 2_000, 2_100];
+    let val: Vec<i64> = vec![10; 7];
+    let batch = clustering_test_batch(&ts, &val);
+
+    setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
+
+    let ts_range: FilterTimestampRange = serde_json::from_value(json!({
+        "start_ns": 500u64, "end_ns": 1_500u64
+    }))
+    .unwrap();
+
+    let clusters = actions::topic_filter_clusterize(
+        &mut client,
+        topic_name,
+        100,
+        ontology_accel_x_gt_5(),
+        Some(ts_range),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(clusters.len(), 1);
+    assert_eq!(clusters[0]["ts"]["start_ns"].as_u64().unwrap(), 1_000);
+    assert_eq!(clusters[0]["ts"]["end_ns"].as_u64().unwrap(), 1_100);
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_topic_filter_clusterize_single_row(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let sequence_name = "seq_one_row";
+    let topic_name = &format!("{sequence_name}/topic");
+
+    let ts: Vec<i64> = vec![100, 200, 300];
+    let val: Vec<i64> = vec![1, 10, 1];
+    let batch = clustering_test_batch(&ts, &val);
+
+    setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
+
+    let clusters = actions::topic_filter_clusterize(
+        &mut client,
+        topic_name,
+        50,
+        ontology_accel_x_gt_5(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(clusters.len(), 1);
+    assert_eq!(clusters[0]["ts"]["start_ns"].as_u64().unwrap(), 200);
+    assert_eq!(clusters[0]["ts"]["end_ns"].as_u64().unwrap(), 200);
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_topic_filter_clusterize_across_batches(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let sequence_name = "seq_multi";
+    let topic_name = &format!("{sequence_name}/topic");
+
+    let b1 = clustering_test_batch(&[100, 110, 120], &[10; 3]);
+    let b2 = clustering_test_batch(&[130, 140], &[10; 2]);
+    let b3 = clustering_test_batch(&[1_000, 1_010], &[10; 2]);
+
+    setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![b1, b2, b3]).await;
+
+    let clusters = actions::topic_filter_clusterize(
+        &mut client,
+        topic_name,
+        50,
+        ontology_accel_x_gt_5(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(clusters.len(), 2, "got: {clusters:?}");
+    assert_eq!(clusters[0]["ts"]["start_ns"].as_u64().unwrap(), 100);
+    assert_eq!(clusters[0]["ts"]["end_ns"].as_u64().unwrap(), 140);
+    assert_eq!(clusters[1]["ts"]["start_ns"].as_u64().unwrap(), 1_000);
+    assert_eq!(clusters[1]["ts"]["end_ns"].as_u64().unwrap(), 1_010);
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_topic_filter_clusterize_gap_equals_dt(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let sequence_name = "seq_gap_eq";
+    let topic_name = &format!("{sequence_name}/topic");
+
+    let ts: Vec<i64> = vec![100, 150, 200, 250];
+    let val: Vec<i64> = vec![10; 4];
+    let batch = clustering_test_batch(&ts, &val);
+
+    setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
+
+    let clusters = actions::topic_filter_clusterize(
+        &mut client,
+        topic_name,
+        50,
+        ontology_accel_x_gt_5(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(clusters.len(), 1, "got: {clusters:?}");
+
+    server.shutdown().await;
 }
 
 #[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]


### PR DESCRIPTION
Implemented the entire path from retreiving topic handler to get the data stream, clusterize and stream back the result.

Fetches Parquet via predicate pushdown, streams filtered batches into clustering (optionally bounded by timestamp_range), forwards clusters as JSONL  with no buffering.

Returns empty stream on non-overlapping ranges or incoherent data. Special-cases clustering_dt_ns=0 as a single [min, max] cluster.

