### PR TITLE
ci: fixed github action workflow tag pattern matching

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on:
   push:
     tags:
-      - 'doc/v[0-9]+.[0-9]+'
+      - 'doc/v[0-9].*'
 
 jobs:
   deploy-main:

--- a/.github/workflows/mosaicod-rc-docker.yml
+++ b/.github/workflows/mosaicod-rc-docker.yml
@@ -3,7 +3,7 @@ name: mosaicod Release Candidate Container
 on:
   push:
     branches:
-      - 'release/v[0-9]+.[0-9]+'
+      - 'release/v[0-9].*'
 
 permissions:
   contents: read

--- a/.github/workflows/mosaicod-release-docker.yml
+++ b/.github/workflows/mosaicod-release-docker.yml
@@ -3,7 +3,7 @@ name: mosaicod Release Container
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9].*.*'
 
 permissions:
   contents: read

--- a/.github/workflows/mosaicod-release-precompiled.yml
+++ b/.github/workflows/mosaicod-release-precompiled.yml
@@ -3,7 +3,7 @@ name: mosaicod Precompiled Binaries
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9].*.*'
 
 permissions:
   contents: write


### PR DESCRIPTION
Moved from `[0-9]+` to `*` in tag pattern matching for github workflows. 