### PR TITLE
fix(mosaicod): Field ontology tag is not validated

### DIFF
--- a/mosaicod/crates/mosaicod-query/src/filter.rs
+++ b/mosaicod/crates/mosaicod-query/src/filter.rs
@@ -388,6 +388,10 @@ impl OntologyFilter {
         self.ontology.get(field)
     }
 
+    pub fn ontology_tags(&self) -> impl Iterator<Item = &str> + '_ {
+        self.ontology.keys().map(|f| f.ontology_tag())
+    }
+
     /// Exports filter data as a unique expression group
     pub fn into_expr_group(self) -> OntologyExprGroup<Value> {
         OntologyExprGroup {

--- a/mosaicod/crates/mosaicod-query/src/filter.rs
+++ b/mosaicod/crates/mosaicod-query/src/filter.rs
@@ -388,6 +388,7 @@ impl OntologyFilter {
         self.ontology.get(field)
     }
 
+    /// Returns an iterator over the ontology tags.
     pub fn ontology_tags(&self) -> impl Iterator<Item = &str> + '_ {
         self.ontology.keys().map(|f| f.ontology_tag())
     }

--- a/mosaicod/crates/mosaicod-server/src/endpoint/actions/topic.rs
+++ b/mosaicod/crates/mosaicod-server/src/endpoint/actions/topic.rs
@@ -150,7 +150,7 @@ pub async fn query_by_timestamp(
     for filter_tag in ontology_filter.ontology_tags() {
         if filter_tag != topic_tag {
             return Err(core::Error::bad_request(format!(
-                "unknown ontology tag {filter_tag}, topic uses {topic_tag}"
+                "wrong ontology tag {filter_tag}, topic uses {topic_tag}"
             )))?;
         }
     }

--- a/mosaicod/crates/mosaicod-server/src/endpoint/actions/topic.rs
+++ b/mosaicod/crates/mosaicod-server/src/endpoint/actions/topic.rs
@@ -144,6 +144,17 @@ pub async fn query_by_timestamp(
 ) -> Result<SendableRecordBatchStream> {
     let meta = facade::topic::metadata(context, handle).await?;
     let format = meta.ontology_metadata.properties.serialization_format;
+    let topic_tag = &meta.ontology_metadata.properties.ontology_tag;
+
+    // check if topic tag is already registered
+    for filter_tag in ontology_filter.ontology_tags() {
+        if filter_tag != topic_tag {
+            return Err(core::Error::bad_request(format!(
+                "unknown ontology tag {filter_tag}, topic uses {topic_tag}"
+            )))?;
+        }
+    }
+
     let batch_size = facade::topic::compute_optimal_batch_size(context, handle)
         .await
         .ok();

--- a/mosaicod/crates/mosaicod-server/src/endpoint/actions/topic.rs
+++ b/mosaicod/crates/mosaicod-server/src/endpoint/actions/topic.rs
@@ -146,7 +146,7 @@ pub async fn query_by_timestamp(
     let format = meta.ontology_metadata.properties.serialization_format;
     let topic_tag = &meta.ontology_metadata.properties.ontology_tag;
 
-    // check if topic tag is already registered
+    // check if filter tag is registered before execute query
     for filter_tag in ontology_filter.ontology_tags() {
         if filter_tag != topic_tag {
             return Err(core::Error::bad_request(format!(

--- a/mosaicod/tests/tests/topic.rs
+++ b/mosaicod/tests/tests/topic.rs
@@ -573,7 +573,7 @@ async fn setup_topic_with_batches(
 
 fn ontology_accel_x_gt_5() -> Ontology {
     serde_json::from_value(json!({
-        "imu.value": { "$gt": 5 }
+        "mock.value": { "$gt": 5 }
     }))
     .unwrap()
 }


### PR DESCRIPTION
The DataFusion filter in query_by_timestamp was silently ignoring the ontology tag prefix, allowing any arbitrary prefix to match valid fields.

Added validation that rejects filter tags not matching the topic's registered ontology tag, and fixed the test helper to use the correct tag.

Close #535 