### PR TITLE
feat(mosaicod): Add regex support for sequence and topic name using match operator 

### DIFF
--- a/mosaico-sdk-py/src/testing/integration/test_query_regex.py
+++ b/mosaico-sdk-py/src/testing/integration/test_query_regex.py
@@ -1,0 +1,154 @@
+import pytest
+from pyarrow import ArrowInvalid
+from pyarrow.flight import FlightError
+
+from mosaicolabs.comm import MosaicoClient
+from mosaicolabs.models.query import QuerySequence, QueryTopic
+from testing.integration.config import (
+    UPLOADED_GPS_TOPIC,
+    UPLOADED_IMU_CAMERA_TOPIC,
+    UPLOADED_IMU_FRONT_TOPIC,
+    UPLOADED_SEQUENCE_NAME,
+)
+
+
+def test_query_topic_name_regex_start_anchor(
+    mosaico_client: MosaicoClient,
+    inject_synthetic_sequence,
+):
+    # ^/front matches only topics whose name starts with /front
+    query_resp = mosaico_client.query(
+        QuerySequence().with_name(UPLOADED_SEQUENCE_NAME),
+        QueryTopic().with_name_match("^/front"),
+    )
+    assert query_resp is not None and not query_resp.is_empty()
+    assert len(query_resp) == 1
+    assert len(query_resp[0].topics) == 1
+    assert query_resp[0].topics[0].name == UPLOADED_IMU_FRONT_TOPIC
+
+    mosaico_client.close()
+
+
+def test_query_topic_name_regex_end_anchor(
+    mosaico_client: MosaicoClient,
+    inject_synthetic_sequence,
+):
+    # imu$ matches topics whose name ends with imu (both front and camera imu)
+    query_resp = mosaico_client.query(
+        QuerySequence().with_name(UPLOADED_SEQUENCE_NAME),
+        QueryTopic().with_name_match("imu$"),
+    )
+    assert query_resp is not None and not query_resp.is_empty()
+    assert len(query_resp) == 1
+    expected = [UPLOADED_IMU_FRONT_TOPIC, UPLOADED_IMU_CAMERA_TOPIC]
+    assert len(query_resp[0].topics) == len(expected)
+    assert all(t.name in expected for t in query_resp[0].topics)
+
+    mosaico_client.close()
+
+
+def test_query_topic_name_regex_or(
+    mosaico_client: MosaicoClient,
+    inject_synthetic_sequence,
+):
+    # (imu|gps) matches topics containing either imu or gps
+    query_resp = mosaico_client.query(
+        QuerySequence().with_name(UPLOADED_SEQUENCE_NAME),
+        QueryTopic().with_name_match("(imu|gps)"),
+    )
+    assert query_resp is not None and not query_resp.is_empty()
+    assert len(query_resp) == 1
+    expected = [UPLOADED_IMU_FRONT_TOPIC, UPLOADED_IMU_CAMERA_TOPIC, UPLOADED_GPS_TOPIC]
+    assert len(query_resp[0].topics) == len(expected)
+    assert all(t.name in expected for t in query_resp[0].topics)
+
+    mosaico_client.close()
+
+
+def test_query_topic_name_regex_catch_all(
+    mosaico_client: MosaicoClient,
+    inject_synthetic_sequence,
+):
+    # .* matches all topics in the sequence
+    query_resp = mosaico_client.query(
+        QuerySequence().with_name(UPLOADED_SEQUENCE_NAME),
+        QueryTopic().with_name_match(".*"),
+    )
+    assert query_resp is not None and not query_resp.is_empty()
+    assert len(query_resp) == 1
+    assert len(query_resp[0].topics) == 4
+
+    mosaico_client.close()
+
+
+def test_query_sequence_name_regex_anchor(
+    mosaico_client: MosaicoClient,
+    inject_synthetic_sequence,
+):
+    # ^<exact-name>$ matches exactly one sequence
+    query_resp = mosaico_client.query(
+        QuerySequence().with_name_match(f"^{UPLOADED_SEQUENCE_NAME}$"),
+    )
+    assert query_resp is not None and not query_resp.is_empty()
+    assert len(query_resp) == 1
+    assert query_resp[0].sequence.name == UPLOADED_SEQUENCE_NAME
+
+    mosaico_client.close()
+
+
+def test_query_topic_name_match_empty_pattern_rejected(
+    mosaico_client: MosaicoClient,
+    inject_synthetic_sequence,
+):
+    with pytest.raises(ArrowInvalid):
+        mosaico_client.query(QueryTopic().with_name_match(""))
+
+    mosaico_client.close()
+
+
+def test_query_sequence_name_match_empty_pattern_rejected(
+    mosaico_client: MosaicoClient,
+    inject_synthetic_sequence,
+):
+    with pytest.raises(ArrowInvalid):
+        mosaico_client.query(QuerySequence().with_name_match(""))
+
+    mosaico_client.close()
+
+
+def test_query_topic_name_match_invalid_regex_rejected(
+    mosaico_client: MosaicoClient,
+    inject_synthetic_sequence,
+):
+    with pytest.raises(FlightError):
+        mosaico_client.query(QueryTopic().with_name_match("((unclosed"))
+
+    mosaico_client.close()
+
+
+def test_query_sequence_name_match_invalid_regex_rejected(
+    mosaico_client: MosaicoClient,
+    inject_synthetic_sequence,
+):
+    with pytest.raises(FlightError):
+        mosaico_client.query(QuerySequence().with_name_match("((unclosed"))
+
+    mosaico_client.close()
+
+
+def test_query_sequence_with_percentage(
+    mosaico_client: MosaicoClient, inject_synthetic_sequence
+):
+    query_resp = mosaico_client.query(QuerySequence().with_name_match("%"))
+    assert query_resp is not None and query_resp.is_empty()
+
+    mosaico_client.close()
+
+
+def test_query_topic_with_percentage(
+    mosaico_client: MosaicoClient, inject_synthetic_sequence
+):
+    query_resp = mosaico_client.query(QueryTopic().with_name_match("%"))
+    assert query_resp is not None and query_resp.is_empty()
+
+    mosaico_client.close()

--- a/mosaicod/crates/mosaicod-db/src/sql/pg_queries/compilers.rs
+++ b/mosaicod/crates/mosaicod-db/src/sql/pg_queries/compilers.rs
@@ -128,9 +128,11 @@ impl query::CompileClause for SqlQueryCompiler {
                     if text.is_empty() {
                         return Err(query::Error::empty_pattern(field.to_owned()));
                     }
-                    let value = query::Value::Text(format!("%{}%", text));
-                    let clause = format!("{} LIKE {}", field, self.consume_placeholder());
-                    query::CompiledClause::new(clause, vec![value])
+                    let clause = format!(
+                        "mosaico_regex_match({field}, {})",
+                        self.consume_placeholder()
+                    );
+                    query::CompiledClause::new(clause, vec![query::Value::Text(text)])
                 } else {
                     return Err(query::Error::unsupported_op(field.to_owned()));
                 }
@@ -367,9 +369,9 @@ mod tests {
         if let Some(idx) = qr
             .clauses
             .iter()
-            .position(|c| c == r#"topic.locator_name LIKE $1"#)
+            .position(|c| c == r#"mosaico_regex_match(topic.locator_name, $1)"#)
         {
-            assert_eq!(qr.values[idx], query::Value::Text("%my-topic%".to_owned()));
+            assert_eq!(qr.values[idx], query::Value::Text("my-topic".to_owned()));
         } else {
             panic!("match not found");
         }

--- a/mosaicod/tests/tests/query.rs
+++ b/mosaicod/tests/tests/query.rs
@@ -516,3 +516,98 @@ async fn test_query_match_empty_pattern_rejected(pool: sqlx::Pool<db::DatabaseTy
 
     server.shutdown().await;
 }
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_query_topic_name_match_percent(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_topic_match";
+    setup_topics_with_metadata(
+        &mut client,
+        seq,
+        &[("topic_a", json!({})), ("topic_b", json!({}))],
+    )
+    .await;
+
+    let result = actions::query(
+        &mut client,
+        json!({
+            "topic": { "locator": { "$match": "%" } }
+        }),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 0);
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_query_topic_name_match_all(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_topic_match_1";
+    setup_topics_with_metadata(
+        &mut client,
+        seq,
+        &[("topic_a", json!({})), ("topic_b", json!({}))],
+    )
+    .await;
+
+    let seq = "seq_topic_match_2";
+    setup_topics_with_metadata(
+        &mut client,
+        seq,
+        &[("topic_c", json!({})), ("topic_d", json!({}))],
+    )
+    .await;
+
+    let result = actions::query(
+        &mut client,
+        json!({
+            "topic": { "locator": { "$match": ".*" } }
+        }),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 2);
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_query_topic_name_match_empty_is_rejected(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_topic_match";
+    setup_topics_with_metadata(
+        &mut client,
+        seq,
+        &[("topic_a", json!({})), ("topic_b", json!({}))],
+    )
+    .await;
+
+    let result = actions::query(
+        &mut client,
+        json!({
+            "topic": { "locator": { "$match": "" } }
+        }),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(result.code(), tonic::Code::InvalidArgument);
+
+    server.shutdown().await;
+}


### PR DESCRIPTION
Replace LIKE-based matching with mosaico_regex_match for topic and sequence locator name filters, aligning their behaviour with the existing user_metadata $match operator.

