### PR TITLE
feat(mosaicod): Implement missing operators for ontology queries 

### DIFF
--- a/mosaicod/crates/mosaicod-db/src/sql/pg_queries/builders.rs
+++ b/mosaicod/crates/mosaicod-db/src/sql/pg_queries/builders.rs
@@ -54,21 +54,41 @@ pub fn build_query(joined_clauses: String) -> String {
     )
 }
 
+fn build_clause_union(where_clauses: &str) -> String {
+    let numeric = format!(
+        "SELECT chunk_id FROM chunk_t
+        JOIN column_chunk_numeric_t __stats__ USING(chunk_id)
+        JOIN column_t __column__ USING(column_id)
+        WHERE {where_clauses}"
+    );
+    let textual = format!(
+        "SELECT chunk_id FROM chunk_t
+        JOIN column_chunk_textual_t __stats__ USING(chunk_id)
+        JOIN column_t __column__ USING(column_id)
+        WHERE {where_clauses}"
+    );
+    format!("({numeric}) UNION ({textual})")
+}
+
 fn build_clause(where_clauses: String, v: &query::Value) -> String {
     match v {
-        query::Value::Integer(_) | query::Value::Float(_) | query::Value::Boolean(_) => {
+        query::Value::Integer(_)
+        | query::Value::Float(_)
+        | query::Value::Boolean(_)
+        | query::Value::IntegerArray(_)
+        | query::Value::FloatArray(_) => {
             let select = r#"
-            SELECT chunk_id FROM chunk_t 
+            SELECT chunk_id FROM chunk_t
             JOIN column_chunk_numeric_t __stats__ USING(chunk_id)
             JOIN column_t __column__ USING(column_id)
             "#;
 
             format!("{select} WHERE {where_clauses}")
         }
-        query::Value::Text(_) => {
+        query::Value::Text(_) | query::Value::TextArray(_) => {
             let select = r#"
-            SELECT chunk_id FROM chunk_t 
-            JOIN column_chunk_textual_t __stats__ USING(chunk_id) 
+            SELECT chunk_id FROM chunk_t
+            JOIN column_chunk_textual_t __stats__ USING(chunk_id)
             JOIN column_t __column__ USING(column_id)
             "#;
 
@@ -77,7 +97,7 @@ fn build_clause(where_clauses: String, v: &query::Value) -> String {
     }
 }
 
-fn column_table_name_by_value(_v: &query::Value) -> String {
+fn column_table_name() -> String {
     "(__column__.ontology_tag || '.' || __column__.column_name)".into()
 }
 
@@ -94,18 +114,27 @@ impl query::CompileClause for ChunkQueryBuilder {
             query::Op::Eq(v) => {
                 let v = v.into();
                 let p = self.consume_placeholder();
-                let column_name = column_table_name_by_value(&v);
+                let column_name = column_table_name();
 
                 let clause = format!(
                     "{column_name} = {field} AND __stats__.min_value <= {p} AND __stats__.max_value >= {p}"
                 );
                 query::CompiledClause::new(build_clause(clause, &v), vec![v])
             }
-            query::Op::Neq(_) => return Err(query::Error::unsupported_op(field.into())),
+            query::Op::Neq(v) => {
+                let v = v.into();
+                let p = self.consume_placeholder();
+                let column_name = column_table_name();
+
+                let clause = format!(
+                    "{column_name} = {field} AND (__stats__.min_value > {p} OR __stats__.max_value < {p})"
+                );
+                query::CompiledClause::new(build_clause(clause, &v), vec![v])
+            }
             query::Op::Leq(v) => {
                 let v = v.into();
                 let p = self.consume_placeholder();
-                let column_name = column_table_name_by_value(&v);
+                let column_name = column_table_name();
 
                 let clause = format!("{column_name} = {field} AND __stats__.min_value <= {p}");
                 query::CompiledClause::new(build_clause(clause, &v), vec![v])
@@ -113,7 +142,7 @@ impl query::CompileClause for ChunkQueryBuilder {
             query::Op::Geq(v) => {
                 let v = v.into();
                 let p = self.consume_placeholder();
-                let column_name = column_table_name_by_value(&v);
+                let column_name = column_table_name();
 
                 let clause = format!("{column_name} = {field} AND __stats__.max_value >= {p}");
                 query::CompiledClause::new(build_clause(clause, &v), vec![v])
@@ -121,7 +150,7 @@ impl query::CompileClause for ChunkQueryBuilder {
             query::Op::Lt(v) => {
                 let v = v.into();
                 let p = self.consume_placeholder();
-                let column_name = column_table_name_by_value(&v);
+                let column_name = column_table_name();
 
                 let clause = format!("{column_name} = {field} AND __stats__.min_value < {p}");
                 query::CompiledClause::new(build_clause(clause, &v), vec![v])
@@ -129,21 +158,29 @@ impl query::CompileClause for ChunkQueryBuilder {
             query::Op::Gt(v) => {
                 let v = v.into();
                 let p = self.consume_placeholder();
-                let column_name = column_table_name_by_value(&v);
+                let column_name = column_table_name();
 
                 let clause = format!("{column_name} = {field} AND __stats__.max_value > {p}");
                 query::CompiledClause::new(build_clause(clause, &v), vec![v])
             }
 
-            query::Op::Ex => return Err(query::Error::unsupported_op(field.into())),
-            query::Op::Nex => return Err(query::Error::unsupported_op(field.into())),
+            query::Op::Ex => {
+                let col = column_table_name();
+                let clause = format!("{col} = {field}");
+                query::CompiledClause::new(build_clause_union(&clause), vec![])
+            }
+            query::Op::Nex => {
+                let col = column_table_name();
+                let clause = format!("{col} = {field} AND __stats__.has_null = TRUE");
+                query::CompiledClause::new(build_clause_union(&clause), vec![])
+            }
 
             query::Op::Between(range) => {
                 let vmin = range.min.into();
                 let vmax = range.max.into();
                 let pmin = self.consume_placeholder();
                 let pmax = self.consume_placeholder();
-                let column_name = column_table_name_by_value(&vmin);
+                let column_name = column_table_name();
 
                 let clause = format!(
                     "{column_name} = {field} AND __stats__.min_value <= {pmax} AND __stats__.max_value >= {pmin}"
@@ -152,8 +189,92 @@ impl query::CompileClause for ChunkQueryBuilder {
                 query::CompiledClause::new(build_clause(clause, &vmin), vec![vmin, vmax])
             }
 
-            query::Op::In(_) => return Err(query::Error::unsupported_op(field.into())),
-            query::Op::Match(_) => return Err(query::Error::unsupported_op(field.into())),
+            query::Op::In(items) => {
+                let values: Vec<query::Value> = items.into_iter().map(Into::into).collect();
+                if values.is_empty() {
+                    return Ok(query::CompiledClause::empty());
+                }
+
+                // Check if all the values inside array are of same type
+                let first = std::mem::discriminant(&values[0]);
+                if values.iter().any(|v| std::mem::discriminant(v) != first) {
+                    return Err(query::Error::unsupported_op(field.into()));
+                }
+
+                let p = self.consume_placeholder();
+                let column_name = column_table_name();
+
+                let (cast, array_value) = match &values[0] {
+                    query::Value::Integer(_) => {
+                        let arr: Vec<i64> = values
+                            .iter()
+                            .map(|v| match v {
+                                query::Value::Integer(i) => *i,
+                                _ => unreachable!(),
+                            })
+                            .collect();
+                        // float8 because min and max are saved as float8
+                        ("float8", query::Value::IntegerArray(arr))
+                    }
+                    query::Value::Float(_) => {
+                        let arr: Vec<f64> = values
+                            .iter()
+                            .map(|v| match v {
+                                query::Value::Float(f) => *f,
+                                _ => unreachable!(),
+                            })
+                            .collect();
+                        ("float8", query::Value::FloatArray(arr))
+                    }
+                    query::Value::Text(_) => {
+                        let arr: Vec<String> = values
+                            .iter()
+                            .map(|v| match v {
+                                query::Value::Text(t) => t.clone(),
+                                _ => unreachable!(),
+                            })
+                            .collect();
+                        ("text", query::Value::TextArray(arr))
+                    }
+                    query::Value::Boolean(_) => {
+                        let arr: Vec<f64> = values
+                            .iter()
+                            .map(|v| match v {
+                                query::Value::Boolean(b) => {
+                                    if *b {
+                                        1.0
+                                    } else {
+                                        0.0
+                                    }
+                                }
+                                _ => unreachable!(),
+                            })
+                            .collect();
+                        ("float8", query::Value::FloatArray(arr))
+                    }
+                    _ => return Err(query::Error::unsupported_op(field.into())),
+                };
+
+                let clause = format!(
+                    "{column_name} = {field} AND EXISTS (
+                        SELECT 1 FROM UNNEST({p}::{cast}[]) AS v
+                        WHERE __stats__.min_value <= v AND __stats__.max_value >= v
+                    )"
+                );
+
+                query::CompiledClause::new(build_clause(clause, &values[0]), vec![array_value])
+            }
+            query::Op::Match(v) => {
+                let v = v.into();
+                let column_name = column_table_name();
+                // Regex cannot be pruned using [min_value, max_value] stats: even if the pattern
+                // falls lexicographically within the range, the chunk may not contain any matching
+                // value (e.g. range ["apple", "zebra"] tells us nothing about whether "truck.*"
+                // matches any row). All chunks that have the column are kept; DataFusion filters
+                // row-by-row at query execution time.
+                let clause = format!("{column_name} = {field}");
+                query::CompiledClause::new(build_clause(clause, &v), vec![])
+            }
         };
 
         Ok(clause)

--- a/mosaicod/crates/mosaicod-db/src/sql/pg_queries/builders.rs
+++ b/mosaicod/crates/mosaicod-db/src/sql/pg_queries/builders.rs
@@ -191,8 +191,9 @@ impl query::CompileClause for ChunkQueryBuilder {
 
             query::Op::In(items) => {
                 let values: Vec<query::Value> = items.into_iter().map(Into::into).collect();
+
                 if values.is_empty() {
-                    return Ok(query::CompiledClause::empty());
+                    return Err(query::Error::empty_in(field.to_owned()));
                 }
 
                 // Check if all the values inside array are of same type
@@ -266,6 +267,13 @@ impl query::CompileClause for ChunkQueryBuilder {
             }
             query::Op::Match(v) => {
                 let v = v.into();
+
+                if let query::Value::Text(text) = &v
+                    && text.is_empty()
+                {
+                    return Err(query::Error::empty_pattern(field.to_owned()));
+                }
+
                 let column_name = column_table_name();
                 // Regex cannot be pruned using [min_value, max_value] stats: even if the pattern
                 // falls lexicographically within the range, the chunk may not contain any matching

--- a/mosaicod/crates/mosaicod-db/src/sql/pg_queries/compilers.rs
+++ b/mosaicod/crates/mosaicod-db/src/sql/pg_queries/compilers.rs
@@ -175,6 +175,11 @@ mod internal {
                 query::Value::Integer(_) | query::Value::Float(_) => format!("({field})::numeric"),
                 query::Value::Text(_) => field.to_owned(),
                 query::Value::Boolean(_) => format!("({field})::boolean"),
+                query::Value::IntegerArray(_)
+                | query::Value::FloatArray(_)
+                | query::Value::TextArray(_) => {
+                    unreachable!("array values are only used as bound parameters")
+                }
             }
         }
 

--- a/mosaicod/crates/mosaicod-db/src/sql/pg_queries/data_catalog.rs
+++ b/mosaicod/crates/mosaicod-db/src/sql/pg_queries/data_catalog.rs
@@ -177,6 +177,9 @@ pub async fn chunks_from_filters(
             query::Value::Text(v) => r = r.bind(v),
             // Cast boolean value to numeric, since for now there is no custom column for boolean values
             query::Value::Boolean(v) => r = r.bind(if v { 1.0 } else { 0.0 }),
+            query::Value::IntegerArray(v) => r = r.bind(v),
+            query::Value::FloatArray(v) => r = r.bind(v),
+            query::Value::TextArray(v) => r = r.bind(v),
         }
     }
 

--- a/mosaicod/crates/mosaicod-db/src/sql/pg_queries/topic_record.rs
+++ b/mosaicod/crates/mosaicod-db/src/sql/pg_queries/topic_record.rs
@@ -433,6 +433,11 @@ pub async fn topic_from_query_filter(
             query::Value::Float(v) => r = r.bind(v),
             query::Value::Text(v) => r = r.bind(v),
             query::Value::Boolean(v) => r = r.bind(v),
+            query::Value::IntegerArray(_)
+            | query::Value::FloatArray(_)
+            | query::Value::TextArray(_) => {
+                unreachable!("array values are not produced by SQL/JSON query compilers")
+            }
         }
     }
 

--- a/mosaicod/crates/mosaicod-query/src/filter.rs
+++ b/mosaicod/crates/mosaicod-query/src/filter.rs
@@ -66,6 +66,9 @@ pub enum Value {
     Float(Float),
     Text(Text),
     Boolean(bool),
+    IntegerArray(Vec<Integer>),
+    FloatArray(Vec<Float>),
+    TextArray(Vec<Text>),
 }
 
 impl From<&str> for Value {
@@ -133,6 +136,7 @@ impl IsSupportedOp for Value {
             Self::Boolean(_) => false,
             Self::Integer(_) => true,
             Self::Float(_) => true,
+            Self::IntegerArray(_) | Self::FloatArray(_) | Self::TextArray(_) => false,
         }
     }
 

--- a/mosaicod/crates/mosaicod-query/src/timeseries.rs
+++ b/mosaicod/crates/mosaicod-query/src/timeseries.rs
@@ -11,6 +11,7 @@ use datafusion::execution::disk_manager::DiskManagerBuilder;
 use datafusion::execution::memory_pool::FairSpillPool;
 use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
 use datafusion::functions::core::expr_ext::FieldAccessor;
+use datafusion::functions::regex::expr_fn::regexp_like;
 use datafusion::functions_aggregate::expr_fn::{max, min};
 use datafusion::prelude::*;
 use datafusion::scalar::ScalarValue;
@@ -266,7 +267,11 @@ where
                     .collect();
                 Some(unfold_field(&field).in_list(list, false))
             }
-            Op::Match(v) => Some(unfold_field(&field).like(value_to_df_expr(v.into()))),
+            Op::Match(v) => Some(regexp_like(
+                unfold_field(&field),
+                value_to_df_expr(v.into()),
+                None,
+            )),
         };
 
         if let Some(expr) = expr {
@@ -287,6 +292,11 @@ fn value_to_df_expr(v: Value) -> Expr {
         Value::Float(v) => lit(v),
         Value::Text(v) => lit(v),
         Value::Boolean(v) => lit(v),
+        Value::IntegerArray(_) | Value::FloatArray(_) | Value::TextArray(_) => {
+            unreachable!(
+                "array values are only used as bound parameters, not as DataFusion literals"
+            )
+        }
     }
 }
 

--- a/mosaicod/tests/tests/ontology_query.rs
+++ b/mosaicod/tests/tests/ontology_query.rs
@@ -480,10 +480,6 @@ async fn test_ontology_in_unnest_no_false_positives(pool: sqlx::Pool<db::Databas
     server.shutdown().await;
 }
 
-// ---------------------------------------------------------------------------
-// $in on text values
-// ---------------------------------------------------------------------------
-
 #[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
 async fn test_ontology_in_text_values(pool: sqlx::Pool<db::DatabaseType>) {
     let server = common::ServerBuilder::new(common::HOST, pool).build().await;

--- a/mosaicod/tests/tests/ontology_query.rs
+++ b/mosaicod/tests/tests/ontology_query.rs
@@ -295,7 +295,7 @@ async fn test_ontology_in_returns_chunks_overlapping_any_value(pool: sqlx::Pool<
     )
     .await;
 
-    // [5, 103]: 5 is in [1,7] and 103 is in [100,106] → both match
+    // [5, 103]: 5 is in [1,7] and 103 is in [100,106] -> both match
     let items = actions::query(
         &mut client,
         json!({ "ontology": { "mock.value": { "$in": [5, 103] } } }),
@@ -312,7 +312,7 @@ async fn test_ontology_in_returns_chunks_overlapping_any_value(pool: sqlx::Pool<
         "topic_b should match (103 is in range [100,106])"
     );
 
-    // [50]: not in [1,7] and not in [100,106] → no match
+    // [50]: not in [1,7] and not in [100,106] -> no match
     let items = actions::query(
         &mut client,
         json!({ "ontology": { "mock.value": { "$in": [50] } } }),

--- a/mosaicod/tests/tests/ontology_query.rs
+++ b/mosaicod/tests/tests/ontology_query.rs
@@ -1,0 +1,670 @@
+#![allow(unused_crate_dependencies)]
+use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use mosaicod_db as db;
+use serde_json::json;
+use std::sync::Arc;
+use tests::{actions, common};
+
+fn int_batch(ts_start: i64, values: &[i64]) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("timestamp_ns", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+    let timestamps: Vec<i64> = (0..values.len() as i64).map(|i| ts_start + i * 5).collect();
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(timestamps)),
+            Arc::new(Int64Array::from(values.to_vec())),
+        ],
+    )
+    .unwrap()
+}
+
+fn nullable_int_batch(ts_start: i64, values: Vec<Option<i64>>) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("timestamp_ns", DataType::Int64, false),
+        Field::new("value", DataType::Int64, true),
+    ]));
+    let n = values.len();
+    let timestamps: Vec<i64> = (0..n as i64).map(|i| ts_start + i * 5).collect();
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(timestamps)),
+            Arc::new(Int64Array::from(values)),
+        ],
+    )
+    .unwrap()
+}
+
+fn string_batch(ts_start: i64, values: &[&str]) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("timestamp_ns", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+    ]));
+    let timestamps: Vec<i64> = (0..values.len() as i64).map(|i| ts_start + i * 5).collect();
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(timestamps)),
+            Arc::new(StringArray::from(values.to_vec())),
+        ],
+    )
+    .unwrap()
+}
+
+fn no_value_batch(ts_start: i64, count: usize) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("timestamp_ns", DataType::Int64, false),
+        Field::new("sensor_id", DataType::Int64, false),
+    ]));
+    let timestamps: Vec<i64> = (0..count as i64).map(|i| ts_start + i * 5).collect();
+    let ids: Vec<i64> = (0..count as i64).collect();
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(timestamps)),
+            Arc::new(Int64Array::from(ids)),
+        ],
+    )
+    .unwrap()
+}
+
+async fn setup_topics(client: &mut common::Client, seq: &str, topics: Vec<(&str, RecordBatch)>) {
+    actions::sequence_create(client, seq, None).await.unwrap();
+    let (_, session_uuid) = actions::session_create(client, seq).await.unwrap();
+    for (suffix, batch) in topics {
+        let topic_name = format!("{seq}/{suffix}");
+        let uuid = actions::topic_create(client, &session_uuid, &topic_name, None)
+            .await
+            .unwrap();
+        actions::do_put(client, &uuid, &topic_name, vec![batch], false)
+            .await
+            .unwrap();
+    }
+    actions::session_finalize(client, &session_uuid)
+        .await
+        .unwrap();
+}
+
+fn topic_locators(items: &[serde_json::Value]) -> Vec<String> {
+    items
+        .iter()
+        .flat_map(|item| {
+            item["topics"]
+                .as_array()
+                .unwrap_or(&vec![])
+                .iter()
+                .map(|t| t["locator"].as_str().unwrap().to_owned())
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_neq_excludes_range_containing_value(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_neq";
+    // Topic A: value range [1, 7], Topic B: value range [100, 106]
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_batch(10_000, &[1, 2, 3, 4, 5, 6, 7])),
+            (
+                "topic_b",
+                int_batch(20_000, &[100, 101, 102, 103, 104, 105, 106]),
+            ),
+        ],
+    )
+    .await;
+
+    // neq 5: value 5 is inside topic_a's range [1,7] -> excluded; 5 < 100 so topic_b matches
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$neq": 5 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "topic_a should be excluded (value 5 is in range [1,7])"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "topic_b should be included (min=100 > 5)"
+    );
+
+    // neq 50: both ranges entirely exclude 50 (max=7 < 50, min=100 > 50)
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$neq": 50 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "topic_a should be included (max=7 < 50)"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "topic_b should be included (min=100 > 50)"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_exist_returns_topic_with_column(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_ex";
+    // topic_with: has a "value" column; topic_without: has "sensor_id" but no "value"
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_with", int_batch(10_000, &[1, 2, 3])),
+            ("topic_without", no_value_batch(20_000, 3)),
+        ],
+    )
+    .await;
+
+    let items = actions::query(&mut client, json!({ "ontology": { "mock.value": "$ex" } }))
+        .await
+        .unwrap();
+    let locators = topic_locators(&items);
+
+    assert!(
+        locators.contains(&format!("{seq}/topic_with")),
+        "topic_with should be included (has mock.value)"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_without")),
+        "topic_without should be excluded (no mock.value column)"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_exist_works_on_text_column(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_ex_text";
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_with", string_batch(10_000, &["alpha", "beta"])),
+            ("topic_without", int_batch(20_000, &[1, 2])),
+        ],
+    )
+    .await;
+
+    let items = actions::query(&mut client, json!({ "ontology": { "mock.name": "$ex" } }))
+        .await
+        .unwrap();
+    let locators = topic_locators(&items);
+
+    assert!(
+        locators.contains(&format!("{seq}/topic_with")),
+        "topic_with should be included (has mock.name)"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_without")),
+        "topic_without should be excluded (no mock.name column)"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_not_exist_returns_chunks_with_nulls(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_nex";
+    // topic_nonull: "value" column with no nulls -> has_null=FALSE
+    // topic_withnull: "value" column with some nulls -> has_null=TRUE
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_nonull", int_batch(10_000, &[1, 2, 3])),
+            (
+                "topic_withnull",
+                nullable_int_batch(20_000, vec![Some(1), None, Some(3)]),
+            ),
+        ],
+    )
+    .await;
+
+    let items = actions::query(&mut client, json!({ "ontology": { "mock.value": "$nex" } }))
+        .await
+        .unwrap();
+    let locators = topic_locators(&items);
+
+    assert!(
+        !locators.contains(&format!("{seq}/topic_nonull")),
+        "topic_nonull should be excluded (has_null=FALSE, column definitely has non-null values)"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_withnull")),
+        "topic_withnull should be included (has_null=TRUE)"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_in_returns_chunks_overlapping_any_value(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_in";
+    // topic_a: value range [1, 7]; topic_b: value range [100, 106]
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_batch(10_000, &[1, 2, 3, 4, 5, 6, 7])),
+            (
+                "topic_b",
+                int_batch(20_000, &[100, 101, 102, 103, 104, 105, 106]),
+            ),
+        ],
+    )
+    .await;
+
+    // [5, 103]: 5 is in [1,7] and 103 is in [100,106] → both match
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$in": [5, 103] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "topic_a should match (5 is in range [1,7])"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "topic_b should match (103 is in range [100,106])"
+    );
+
+    // [50]: not in [1,7] and not in [100,106] → no match
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$in": [50] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "topic_a should not match (50 not in [1,7])"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "topic_b should not match (50 not in [100,106])"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_in_single_value_acts_like_eq(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_in_single";
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_batch(10_000, &[1, 2, 3])),
+            ("topic_b", int_batch(20_000, &[10, 20, 30])),
+        ],
+    )
+    .await;
+
+    // [2]: in [1,3] but not in [10,30]
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$in": [2] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(locators.contains(&format!("{seq}/topic_a")));
+    assert!(!locators.contains(&format!("{seq}/topic_b")));
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_match_filters_by_regex(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_match";
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            (
+                "topic_truck",
+                string_batch(10_000, &["truck_scania", "truck_volvo"]),
+            ),
+            ("topic_car", string_batch(20_000, &["ferrari", "porsche"])),
+        ],
+    )
+    .await;
+
+    // "^truck" should match only topic_truck
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.name": { "$match": "^truck" } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_truck")),
+        "topic_truck should match '^truck'"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_car")),
+        "topic_car should not match '^truck'"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_match_excludes_topics_without_column(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_match_nocol";
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_with_name", string_batch(10_000, &["truck_scania"])),
+            ("topic_no_name", int_batch(20_000, &[1, 2, 3])),
+        ],
+    )
+    .await;
+
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.name": { "$match": ".*" } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+
+    assert!(locators.contains(&format!("{seq}/topic_with_name")));
+    assert!(!locators.contains(&format!("{seq}/topic_no_name")));
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_in_unnest_no_false_positives(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_in_unnest";
+    // topic_a: [1,7],  topic_b: [100,106]
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_batch(10_000, &[1, 2, 3, 4, 5, 6, 7])),
+            (
+                "topic_b",
+                int_batch(20_000, &[100, 101, 102, 103, 104, 105, 106]),
+            ),
+        ],
+    )
+    .await;
+
+    // [3, 200]: 3 hits topic_a's range, 200 is outside both ranges.
+    // topic_b must NOT be included even though 100 <= 200 and 106 >= 3.
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$in": [3, 200] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "topic_a should match (3 is in [1,7])"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "topic_b must not match: neither 3 nor 200 falls in [100,106]"
+    );
+
+    server.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// $in on text values
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_in_text_values(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_in_text";
+    // topic_vehicles: ["car", "truck", "bus"], topic_animals: ["cat", "dog", "fox"]
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            (
+                "topic_vehicles",
+                string_batch(10_000, &["bus", "car", "truck"]),
+            ),
+            (
+                "topic_animals",
+                string_batch(20_000, &["cat", "dog", "fox"]),
+            ),
+        ],
+    )
+    .await;
+
+    // ["truck", "dog"]: each value hits exactly one topic
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.name": { "$in": ["truck", "dog"] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_vehicles")),
+        "topic_vehicles should match ('truck' in ['bus','car','truck'])"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_animals")),
+        "topic_animals should match ('dog' in ['cat','dog','fox'])"
+    );
+
+    // ["zebra"]: no topic has this value
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.name": { "$in": ["zebra"] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(locators.is_empty(), "no topic should match 'zebra'");
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_neq_boundary_values(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_neq_boundary";
+    // topic_a: [5, 10]  both boundaries are candidates for $neq
+    setup_topics(
+        &mut client,
+        seq,
+        vec![("topic_a", int_batch(10_000, &[5, 6, 7, 8, 9, 10]))],
+    )
+    .await;
+
+    // neq 5: is in [5,10] -> excluded
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$neq": 5 } } }),
+    )
+    .await
+    .unwrap();
+    assert!(
+        topic_locators(&items).is_empty(),
+        "topic_a should be excluded ($neq min=5, p=5 is in range)"
+    );
+
+    // neq 10: is in [5,10] -> excluded
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$neq": 10 } } }),
+    )
+    .await
+    .unwrap();
+    assert!(
+        topic_locators(&items).is_empty(),
+        "topic_a should be excluded ($neq max=10, p=10 is in range)"
+    );
+
+    // neq 4 : range [5,10] -> included
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$neq": 4 } } }),
+    )
+    .await
+    .unwrap();
+    assert!(
+        topic_locators(&items).contains(&format!("{seq}/topic_a")),
+        "topic_a should be included ($neq 4, range [5,10] is entirely above 4)"
+    );
+
+    // neq 11: range [5,10] -> included
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$neq": 11 } } }),
+    )
+    .await
+    .unwrap();
+    assert!(
+        topic_locators(&items).contains(&format!("{seq}/topic_a")),
+        "topic_a should be included ($neq 11, range [5,10] is entirely below 11)"
+    );
+
+    // neq 8: range [5,10] -> excluded
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$neq": 8 } } }),
+    )
+    .await
+    .unwrap();
+    assert!(
+        !topic_locators(&items).contains(&format!("{seq}/topic_a")),
+        "topic_a should not be included ($neq 8, range [5,10])"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_combined_in_and_geq(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_combined";
+    // topic_low:  values [1, 2, 3]
+    // topic_mid:  values [5, 6, 7]
+    // topic_high: values [20, 21, 22]
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_low", int_batch(10_000, &[1, 2, 3])),
+            ("topic_mid", int_batch(20_000, &[5, 6, 7])),
+            ("topic_high", int_batch(30_000, &[20, 21, 22])),
+        ],
+    )
+    .await;
+
+    // $in [2, 6, 21] AND $geq 5: $in selects all three, $geq 5 prunes topic_low (max=3 < 5)
+    let items = actions::query(
+        &mut client,
+        json!({
+            "ontology": {
+                "mock.value": { "$in": [2, 6, 21] },
+                "mock.value": { "$geq": 5 }
+            }
+        }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_low")),
+        "topic_low should be excluded ($geq 5 prunes max=3)"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_mid")),
+        "topic_mid should be included (6 in $in list and max=7 >= 5)"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_high")),
+        "topic_high should be included (21 in $in list and min=20 >= 5)"
+    );
+
+    server.shutdown().await;
+}


### PR DESCRIPTION
- !=: prunes chunks whose range [min, max] contains the target value.

- exist / !exist: uses a UNION across column_chunk_numeric_t and column_chunk_textual_t so both numeric and textual columns are covered.
  exist selects chunks that have the column; !exist` further requires has_null = TRUE.

- in: uses UNNEST($1::float8[]) / UNNEST($1::text[]) with a single array bind parameter instead of N scalar placeholders. UNNEST checks each candidate value independently against [min, max], avoiding the false positives that ANY/IN would produce. Adds IntegerArray / FloatArray / TextArray variants to Value to carry the array as a single bind parameter through CompiledClause. Mixed-type lists are rejected with a structured error instead of panicking. Boolean values are mapped to 1.0 / 0.0 for consistency with how they are stored in numeric stats.

- match: regex pruning on [min, max] is intractable, so all chunks that have the column are included and row-level filtering is left entirely to DataFusion. Also fixes DataFusion's Op::Match from .like() to regexp_like(), aligning it with SqlQueryCompiler and JsonQueryCompiler.

 - Adds integration tests covering: UNNEST, $in on text values, $neq at exact min/max boundaries, and combined $in + $geq filters on the same ontology field.

Close #513 