### PR TITLE
feat(mosaicod): Implement topic_filter_intersect action

### DIFF
--- a/mosaicod/crates/mosaicod-ext/src/arrow_filter.rs
+++ b/mosaicod/crates/mosaicod-ext/src/arrow_filter.rs
@@ -82,10 +82,12 @@ async fn forward_err(
 /// * `batch_stream`: stream of `Result<RecordBatch, ArrowError>` produced upstream.
 /// * `clustering_dt_ns`: inclusive gap threshold in nanoseconds.
 /// * `timestamp_column`: name of the `UInt64` column carrying timestamps.
-/// * `out`: channel for emitted [`Cluster`]s. If the receiver is dropped, the
-///   next send fails, the function returns
-///   [`ClusteringError::ChannelClosed`] without consuming the remainder of
-///   `input`, and any open cluster is discarded.
+/// * `out`: channel for emitted [`Cluster`]s. On any error, the error is sent
+///   as the last item on `out`, then `out` is dropped, closing the channel so
+///   the receiver sees the stream end immediately after the error with no
+///   further items. If the receiver is already dropped when a send is attempted,
+///   the function returns [`ClusteringError::ChannelClosed`] without consuming
+///   the remainder of `input`.
 ///
 pub async fn topic_filter_clusterize<S>(
     mut batch_stream: S,

--- a/mosaicod/crates/mosaicod-grpc-flight/src/endpoint/actions/topic.rs
+++ b/mosaicod/crates/mosaicod-grpc-flight/src/endpoint/actions/topic.rs
@@ -1,6 +1,6 @@
 //! Topic-related actions.
 
-use mosaicod_ext::arrow_filter::{Cluster, ClusteringError};
+use ext::arrow_filter::{Cluster, ClusteringError};
 
 use arrow::error::ArrowError;
 use datafusion::physical_plan::SendableRecordBatchStream;
@@ -8,9 +8,9 @@ use futures::StreamExt;
 use log::{info, trace, warn};
 use mosaicod_core::{
     self as core,
-    types::{self, MetadataBlob},
+    types::{self, MetadataBlob, TopicLocator},
 };
-use mosaicod_ext;
+use mosaicod_ext as ext;
 use mosaicod_facade::{self as facade};
 use mosaicod_grpc_common as grpc_common;
 use mosaicod_marshal::{
@@ -178,6 +178,9 @@ pub async fn query_by_timestamp(
     Ok(result.stream().await?)
 }
 
+type ClusteringResult =
+    std::result::Result<ext::arrow_filter::Cluster, ext::arrow_filter::ClusteringError>;
+
 pub async fn filter_clusterize(
     ctx: &facade::Context,
     locator: String,
@@ -207,14 +210,7 @@ async fn spawn_cluster_stream(
     clustering_dt_ns: u64,
     ontology: Ontology,
     timestamp_range: Option<FilterTimestampRange>,
-) -> grpc_common::Result<
-    ReceiverStream<
-        std::result::Result<
-            mosaicod_ext::arrow_filter::Cluster,
-            mosaicod_ext::arrow_filter::ClusteringError,
-        >,
-    >,
-> {
+) -> grpc_common::Result<ReceiverStream<ClusteringResult>> {
     if ontology.len() > 1 || ontology.is_empty() {
         return Err(core::Error::bad_request(format!(
             "Only 1 filtering condition is allowed, found {}",
@@ -256,28 +252,23 @@ async fn spawn_cluster_stream(
     // The downstream `map` converts each variant into the corresponding Flight
     // payload or [`tonic::Status`], so the client sees errors interleaved with
     // data at the exact position where they happened.
-    let (tx, rx) = mpsc::channel::<
-        std::result::Result<
-            mosaicod_ext::arrow_filter::Cluster,
-            mosaicod_ext::arrow_filter::ClusteringError,
-        >,
-    >(MAX_BUFFER_CHANNEL_SIZE);
+    let (tx, rx) = mpsc::channel::<ClusteringResult>(MAX_BUFFER_CHANNEL_SIZE);
 
     tokio::spawn(async move {
-        let _ = mosaicod_ext::arrow_filter::topic_filter_clusterize(
-            batch_stream,
-            dt_ns,
-            &timestamp_column,
-            tx,
-        )
-        .await;
+        let _ =
+            ext::arrow_filter::topic_filter_clusterize(batch_stream, dt_ns, &timestamp_column, tx)
+                .await;
     });
 
     Ok(ReceiverStream::new(rx))
 }
 
+/// Converts a [`Cluster`] into an [`arrow_flight::Result`] payload.
+///
+/// `F` is a one-shot closure that selects the correct [`ActionResponse`] variant
+/// for the operation being performed, either a clusterize or an intersect result.
 fn cluster_to_flight_result<F>(
-    cluster: mosaicod_ext::arrow_filter::Cluster,
+    cluster: ext::arrow_filter::Cluster,
     action_builder: F,
 ) -> std::result::Result<arrow_flight::Result, tonic::Status>
 where
@@ -302,7 +293,7 @@ where
 
 pub async fn filter_intersect(
     ctx: &facade::Context,
-    topics: Vec<requests::TopicFilterClusterize>,
+    topics: Vec<requests::TopicClusterizeParams>,
     intersect_dt_ns: u64,
 ) -> grpc_common::Result<DoActionStream> {
     info!("filter intersect for {} topics", topics.len());
@@ -313,23 +304,22 @@ pub async fn filter_intersect(
         ))?;
     }
 
+    let locators = topics
+        .iter()
+        .map(|t| {
+            t.locator
+                .parse::<TopicLocator>()
+                .map_err(|_| core::Error::bad_request("invalid topic locator".to_string()))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
     // All topics must belong to the same sequence.
-    let first_seq = topics[0]
-        .locator
-        .split_once('/')
-        .ok_or_else(|| core::Error::bad_request("invalid topic locator".to_string()))?
-        .0
-        .to_owned();
-    for t in &topics[1..] {
-        let seq = t
-            .locator
-            .split_once('/')
-            .ok_or_else(|| core::Error::bad_request("invalid topic locator".to_string()))?
-            .0;
-        if seq != first_seq {
+    let first_seq = &locators[0].sequence;
+    for loc in &locators[1..] {
+        if loc.sequence != *first_seq {
             return Err(core::Error::bad_request(format!(
-                "all topics must belong to sequence {first_seq}, but {} belongs to {seq}",
-                t.locator
+                "all topics must belong to sequence {first_seq}, but {loc} belongs to {}",
+                loc.sequence
             )))?;
         }
     }
@@ -348,12 +338,7 @@ pub async fn filter_intersect(
         receivers.push(rx);
     }
 
-    let (out_tx, out_rx) = mpsc::channel::<
-        std::result::Result<
-            mosaicod_ext::arrow_filter::Cluster,
-            mosaicod_ext::arrow_filter::ClusteringError,
-        >,
-    >(MAX_BUFFER_CHANNEL_SIZE);
+    let (out_tx, out_rx) = mpsc::channel::<ClusteringResult>(MAX_BUFFER_CHANNEL_SIZE);
 
     tokio::spawn(async move {
         let _ = intersect_cluster_streams(receivers, intersect_dt_ns, out_tx).await;
@@ -376,31 +361,12 @@ pub async fn filter_intersect(
 /// A stream error terminates the intersection immediately: the error is
 /// forwarded to the client as the last item and the function returns.
 async fn intersect_cluster_streams(
-    streams: Vec<
-        ReceiverStream<
-            std::result::Result<
-                mosaicod_ext::arrow_filter::Cluster,
-                mosaicod_ext::arrow_filter::ClusteringError,
-            >,
-        >,
-    >,
+    streams: Vec<ReceiverStream<ClusteringResult>>,
     intersect_dt_ns: u64,
-    out: mpsc::Sender<
-        std::result::Result<
-            mosaicod_ext::arrow_filter::Cluster,
-            mosaicod_ext::arrow_filter::ClusteringError,
-        >,
-    >,
-) -> std::result::Result<(), mosaicod_ext::arrow_filter::ClusteringError> {
+    out: mpsc::Sender<ClusteringResult>,
+) -> std::result::Result<(), ext::arrow_filter::ClusteringError> {
     let mut current_cluster: Vec<Cluster> = Vec::new();
-    let mut active_streams: Vec<
-        ReceiverStream<
-            std::result::Result<
-                mosaicod_ext::arrow_filter::Cluster,
-                mosaicod_ext::arrow_filter::ClusteringError,
-            >,
-        >,
-    > = Vec::new();
+    let mut active_streams: Vec<ReceiverStream<ClusteringResult>> = Vec::new();
 
     for mut stream in streams {
         match advance_one(&mut stream).await {
@@ -479,17 +445,10 @@ async fn intersect_cluster_streams(
 
 /// Reads the next item from stream. Returns Some(cluster) on success,
 /// None on natural exhaustion, Err(e) on a stream error.
+#[inline]
 async fn advance_one(
-    stream: &mut ReceiverStream<
-        std::result::Result<
-            mosaicod_ext::arrow_filter::Cluster,
-            mosaicod_ext::arrow_filter::ClusteringError,
-        >,
-    >,
-) -> std::result::Result<
-    Option<mosaicod_ext::arrow_filter::Cluster>,
-    mosaicod_ext::arrow_filter::ClusteringError,
-> {
+    stream: &mut ReceiverStream<ClusteringResult>,
+) -> std::result::Result<Option<ext::arrow_filter::Cluster>, ext::arrow_filter::ClusteringError> {
     match stream.next().await {
         Some(Ok(c)) => Ok(Some(c)),
         Some(Err(e)) => Err(e),

--- a/mosaicod/crates/mosaicod-grpc-flight/src/endpoint/actions/topic.rs
+++ b/mosaicod/crates/mosaicod-grpc-flight/src/endpoint/actions/topic.rs
@@ -1,4 +1,7 @@
 //! Topic-related actions.
+
+use mosaicod_ext::arrow_filter::{Cluster, ClusteringError};
+
 use arrow::error::ArrowError;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::StreamExt;
@@ -12,7 +15,7 @@ use mosaicod_facade::{self as facade};
 use mosaicod_grpc_common as grpc_common;
 use mosaicod_marshal::{
     self as marshal, ActionResponse, ClusterTimestampRange, Ontology, flight::FilterTimestampRange,
-    responses,
+    requests, responses,
 };
 use mosaicod_query as query;
 use tokio::sync::mpsc;
@@ -184,6 +187,41 @@ pub async fn filter_clusterize(
 ) -> grpc_common::Result<DoActionStream> {
     info!("filter clusterize for {}", locator);
 
+    let rx =
+        spawn_cluster_stream(ctx, locator, clustering_dt_ns, ontology, timestamp_range).await?;
+
+    let stream = rx.map(|res| match res {
+        Ok(cluster) => cluster_to_flight_result(cluster, ActionResponse::topic_filter_clusterize),
+        Err(e) => Err(e.to_status()),
+    });
+
+    Ok(Box::pin(stream))
+}
+
+/// Sets up the full pipeline for a single topic: validates input, opens the
+/// filtered RecordBatch stream, spawns the clustering task, and returns the
+/// receiver end of the cluster channel.
+async fn spawn_cluster_stream(
+    ctx: &facade::Context,
+    locator: String,
+    clustering_dt_ns: u64,
+    ontology: Ontology,
+    timestamp_range: Option<FilterTimestampRange>,
+) -> grpc_common::Result<
+    ReceiverStream<
+        std::result::Result<
+            mosaicod_ext::arrow_filter::Cluster,
+            mosaicod_ext::arrow_filter::ClusteringError,
+        >,
+    >,
+> {
+    if ontology.len() > 1 || ontology.is_empty() {
+        return Err(core::Error::bad_request(format!(
+            "Only 1 filtering condition is allowed, found {}",
+            ontology.len()
+        )))?;
+    }
+
     // Validation and conversion to TimestampRange
     let ts: Option<types::TimestampRange> = match timestamp_range.as_ref() {
         Some(ftr) => {
@@ -192,14 +230,6 @@ pub async fn filter_clusterize(
         }
         None => None,
     };
-
-    // Check ontology parameter
-    if ontology.len() > 1 || ontology.is_empty() {
-        return Err(core::Error::bad_request(format!(
-            "Only 1 filtering condition is allowed, found {}",
-            ontology.len()
-        )))?;
-    }
 
     // Check clustering_dt_ns
     let dt_ns = if clustering_dt_ns == 0 {
@@ -243,17 +273,16 @@ pub async fn filter_clusterize(
         .await;
     });
 
-    let stream = ReceiverStream::new(rx).map(|res| match res {
-        Ok(cluster) => cluster_to_flight_result(cluster),
-        Err(e) => Err(e.to_status()),
-    });
-
-    Ok(Box::pin(stream))
+    Ok(ReceiverStream::new(rx))
 }
 
-fn cluster_to_flight_result(
+fn cluster_to_flight_result<F>(
     cluster: mosaicod_ext::arrow_filter::Cluster,
-) -> std::result::Result<arrow_flight::Result, tonic::Status> {
+    action_builder: F,
+) -> std::result::Result<arrow_flight::Result, tonic::Status>
+where
+    F: FnOnce(responses::TopicFilterClusterize) -> ActionResponse,
+{
     let res = responses::TopicFilterClusterize {
         ts: ClusterTimestampRange {
             start_ns: cluster.start_ns,
@@ -262,11 +291,208 @@ fn cluster_to_flight_result(
         id: cluster.id,
     };
 
-    let bytes = ActionResponse::topic_filter_clusterize(res)
+    let bytes = action_builder(res)
         .bytes()
         .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
     let mut payload = bytes.to_vec();
     payload.push(b'\n');
     Ok(arrow_flight::Result::new(payload))
+}
+
+pub async fn filter_intersect(
+    ctx: &facade::Context,
+    topics: Vec<requests::TopicFilterClusterize>,
+    intersect_dt_ns: u64,
+) -> grpc_common::Result<DoActionStream> {
+    info!("filter intersect for {} topics", topics.len());
+
+    if topics.len() < 2 {
+        return Err(core::Error::bad_request(
+            "at least 2 topics are required".to_string(),
+        ))?;
+    }
+
+    // All topics must belong to the same sequence.
+    let first_seq = topics[0]
+        .locator
+        .split_once('/')
+        .ok_or_else(|| core::Error::bad_request("invalid topic locator".to_string()))?
+        .0
+        .to_owned();
+    for t in &topics[1..] {
+        let seq = t
+            .locator
+            .split_once('/')
+            .ok_or_else(|| core::Error::bad_request("invalid topic locator".to_string()))?
+            .0;
+        if seq != first_seq {
+            return Err(core::Error::bad_request(format!(
+                "all topics must belong to sequence {first_seq}, but {} belongs to {seq}",
+                t.locator
+            )))?;
+        }
+    }
+
+    // One clustering task per topic
+    let mut receivers = Vec::with_capacity(topics.len());
+    for tfc in topics {
+        let rx = spawn_cluster_stream(
+            ctx,
+            tfc.locator,
+            tfc.clustering_dt_ns,
+            tfc.ontology,
+            tfc.timestamp_range,
+        )
+        .await?;
+        receivers.push(rx);
+    }
+
+    let (out_tx, out_rx) = mpsc::channel::<
+        std::result::Result<
+            mosaicod_ext::arrow_filter::Cluster,
+            mosaicod_ext::arrow_filter::ClusteringError,
+        >,
+    >(MAX_BUFFER_CHANNEL_SIZE);
+
+    tokio::spawn(async move {
+        let _ = intersect_cluster_streams(receivers, intersect_dt_ns, out_tx).await;
+    });
+
+    let stream = ReceiverStream::new(out_rx).map(|res| match res {
+        Ok(cluster) => cluster_to_flight_result(cluster, ActionResponse::topic_filter_intersect),
+        Err(e) => Err(e.to_status()),
+    });
+
+    Ok(Box::pin(stream))
+}
+
+/// At each step the stream with the smallest end_ns (min_end) is always
+/// advanced. If all active clusters overlap within intersect_dt_ns
+/// (max_start <= min_end + dt) an intersection is emitted before advancing.
+///
+/// Natural exhaustion of any stream stops the algorithm: with fewer streams
+/// than originally requested, intersections are no longer meaningful.
+/// A stream error terminates the intersection immediately: the error is
+/// forwarded to the client as the last item and the function returns.
+async fn intersect_cluster_streams(
+    streams: Vec<
+        ReceiverStream<
+            std::result::Result<
+                mosaicod_ext::arrow_filter::Cluster,
+                mosaicod_ext::arrow_filter::ClusteringError,
+            >,
+        >,
+    >,
+    intersect_dt_ns: u64,
+    out: mpsc::Sender<
+        std::result::Result<
+            mosaicod_ext::arrow_filter::Cluster,
+            mosaicod_ext::arrow_filter::ClusteringError,
+        >,
+    >,
+) -> std::result::Result<(), mosaicod_ext::arrow_filter::ClusteringError> {
+    let mut current_cluster: Vec<Cluster> = Vec::new();
+    let mut active_streams: Vec<
+        ReceiverStream<
+            std::result::Result<
+                mosaicod_ext::arrow_filter::Cluster,
+                mosaicod_ext::arrow_filter::ClusteringError,
+            >,
+        >,
+    > = Vec::new();
+
+    for mut stream in streams {
+        match advance_one(&mut stream).await {
+            Ok(Some(c)) => {
+                current_cluster.push(c);
+                active_streams.push(stream);
+            }
+            Ok(None) => {} // stream immediately empty, skip it
+            Err(e) => {
+                out.send(Err(e))
+                    .await
+                    .map_err(|_| ClusteringError::ChannelClosed)?;
+                return Ok(());
+            }
+        }
+    }
+
+    let mut cluster_id: u64 = 0;
+
+    loop {
+        if current_cluster.is_empty() {
+            break;
+        }
+
+        let mut max_start = u64::MIN;
+        let mut min_end = u64::MAX;
+        let mut idx = 0;
+
+        for (i, c) in current_cluster.iter().enumerate() {
+            if min_end > c.end_ns {
+                min_end = c.end_ns;
+                idx = i;
+            }
+
+            if max_start < c.start_ns {
+                max_start = c.start_ns;
+            }
+        }
+
+        if max_start <= min_end.saturating_add(intersect_dt_ns) {
+            let (start_ns, end_ns) = if max_start <= min_end {
+                (max_start, min_end)
+            } else {
+                // Split intersect_dt_ns symmetrically but round the second half
+                // up (ceiling) so that lo + hi == intersect_dt_ns exactly.
+                // Without this, odd values truncate both halves to the same
+                // floor and produce start_ns > end_ns when gap == intersect_dt_ns.
+                let lo = intersect_dt_ns / 2;
+                let hi = intersect_dt_ns - lo;
+                (max_start.saturating_sub(lo), min_end.saturating_add(hi))
+            };
+            out.send(Ok(Cluster {
+                start_ns,
+                end_ns,
+                id: cluster_id,
+            }))
+            .await
+            .map_err(|_| ClusteringError::ChannelClosed)?;
+            cluster_id += 1;
+        }
+
+        match advance_one(&mut active_streams[idx]).await {
+            Ok(Some(c)) => current_cluster[idx] = c,
+            Ok(None) => break, // empty stream
+            Err(e) => {
+                out.send(Err(e))
+                    .await
+                    .map_err(|_| ClusteringError::ChannelClosed)?;
+                return Ok(());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Reads the next item from stream. Returns Some(cluster) on success,
+/// None on natural exhaustion, Err(e) on a stream error.
+async fn advance_one(
+    stream: &mut ReceiverStream<
+        std::result::Result<
+            mosaicod_ext::arrow_filter::Cluster,
+            mosaicod_ext::arrow_filter::ClusteringError,
+        >,
+    >,
+) -> std::result::Result<
+    Option<mosaicod_ext::arrow_filter::Cluster>,
+    mosaicod_ext::arrow_filter::ClusteringError,
+> {
+    match stream.next().await {
+        Some(Ok(c)) => Ok(Some(c)),
+        Some(Err(e)) => Err(e),
+        None => Ok(None),
+    }
 }

--- a/mosaicod/crates/mosaicod-grpc-flight/src/endpoint/do_action.rs
+++ b/mosaicod/crates/mosaicod-grpc-flight/src/endpoint/do_action.rs
@@ -96,10 +96,10 @@ pub async fn do_action(
         ActionRequest::TopicFilterClusterize(data) => {
             topic::filter_clusterize(
                 ctx,
-                data.locator,
-                data.clustering_dt_ns,
-                data.ontology,
-                data.timestamp_range,
+                data.params.locator,
+                data.params.clustering_dt_ns,
+                data.params.ontology,
+                data.params.timestamp_range,
             )
             .await
         }

--- a/mosaicod/crates/mosaicod-grpc-flight/src/endpoint/do_action.rs
+++ b/mosaicod/crates/mosaicod-grpc-flight/src/endpoint/do_action.rs
@@ -103,6 +103,9 @@ pub async fn do_action(
             )
             .await
         }
+        ActionRequest::TopicFilterIntersect(data) => {
+            topic::filter_intersect(ctx, data.topics, data.intersect_dt_ns).await
+        }
 
         // Query
         ActionRequest::Query(data) => query_action::execute(ctx, data.query).await?.into_stream(),
@@ -152,6 +155,7 @@ fn has_permissions(action: &ActionRequest, perm: &Permission) -> bool {
         ActionRequest::SequenceNotificationList(_) => perm.can_read(),
         ActionRequest::TopicNotificationList(_) => perm.can_read(),
         ActionRequest::TopicFilterClusterize(_) => perm.can_read(),
+        ActionRequest::TopicFilterIntersect(_) => perm.can_read(),
 
         ActionRequest::ApiKeyCreate(_) => perm.can_manage(),
         ActionRequest::ApiKeyStatus(_) => perm.can_manage(),

--- a/mosaicod/crates/mosaicod-marshal/src/actions/core.rs
+++ b/mosaicod/crates/mosaicod-marshal/src/actions/core.rs
@@ -88,6 +88,10 @@ pub enum ActionRequest {
     /// then clusters matching timestamps by a time-gap threshold.
     TopicFilterClusterize(requests::TopicFilterClusterize),
 
+    /// Filters multiple topics by ontology and timestamp range,
+    /// then returns the intersection of their matching timestamps.
+    TopicFilterIntersect(requests::TopicFilterIntersect),
+
     /// Creates a new upload session for the given sequence.
     SessionCreate(requests::ResourceLocator),
 
@@ -128,6 +132,7 @@ impl std::fmt::Display for ActionRequest {
             Self::TopicNotificationList(_) => write!(f, "TopicNotificationList"),
             Self::TopicNotificationPurge(_) => write!(f, "TopicNotificationPurge"),
             Self::TopicFilterClusterize(_) => write!(f, "TopicFilterClusterize"),
+            Self::TopicFilterIntersect(_) => write!(f, "TopicFilterIntersect"),
             Self::SessionCreate(_) => write!(f, "SessionCreate"),
             Self::SessionFinalize(_) => write!(f, "SessionFinalize"),
             Self::SessionDelete(_) => write!(f, "SessionDelete"),
@@ -162,6 +167,7 @@ impl ActionRequest {
             "topic_notification_list" => parse_action_req!(TopicNotificationList, body),
             "topic_notification_purge" => parse_action_req!(TopicNotificationPurge, body),
             "topic_filter_clusterize" => parse_action_req!(TopicFilterClusterize, body),
+            "topic_filter_intersect" => parse_action_req!(TopicFilterIntersect, body),
 
             "session_create" => parse_action_req!(SessionCreate, body),
             "session_finalize" => parse_action_req!(SessionFinalize, body),
@@ -195,6 +201,7 @@ pub enum ActionResponse {
     TopicNotificationPurge(()),
     TopicNotificationList(responses::NotificationList),
     TopicFilterClusterize(responses::TopicFilterClusterize),
+    TopicFilterIntersect(responses::TopicFilterClusterize),
 
     /// Returns the response key associated with the session just created
     SessionCreate(responses::SessionCreate),
@@ -261,6 +268,10 @@ impl ActionResponse {
 
     pub fn topic_filter_clusterize(response: responses::TopicFilterClusterize) -> Self {
         Self::TopicFilterClusterize(response)
+    }
+
+    pub fn topic_filter_intersect(response: responses::TopicFilterClusterize) -> Self {
+        Self::TopicFilterIntersect(response)
     }
 
     pub fn session_create(

--- a/mosaicod/crates/mosaicod-marshal/src/actions/requests.rs
+++ b/mosaicod/crates/mosaicod-marshal/src/actions/requests.rs
@@ -3,6 +3,7 @@ use crate::Format;
 use crate::Ontology;
 use crate::flight::FilterTimestampRange;
 use serde::Deserialize;
+use serde::Serialize;
 
 #[derive(Deserialize, Debug)]
 pub struct Empty {}
@@ -47,12 +48,21 @@ impl TopicCreate {
 
 /// Specialized message used to filter a topic by ontology and timestamp range,
 /// then cluster matching timestamps by a time-gap threshold
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct TopicFilterClusterize {
     pub locator: String,
     pub clustering_dt_ns: u64,
     pub ontology: Ontology,
     pub timestamp_range: Option<FilterTimestampRange>,
+}
+
+/// Receives multiple topic filters (each with its own clustering configuration)
+/// and intersects their clustered timestamp sets, retaining only timestamps
+/// that fall within intersect_dt_ns nanoseconds of each other across all topics
+#[derive(Deserialize, Debug)]
+pub struct TopicFilterIntersect {
+    pub topics: Vec<TopicFilterClusterize>,
+    pub intersect_dt_ns: u64,
 }
 
 // ////////////////////////////////////////////////////////////////////////////

--- a/mosaicod/crates/mosaicod-marshal/src/actions/requests.rs
+++ b/mosaicod/crates/mosaicod-marshal/src/actions/requests.rs
@@ -46,14 +46,22 @@ impl TopicCreate {
     }
 }
 
-/// Specialized message used to filter a topic by ontology and timestamp range,
-/// then cluster matching timestamps by a time-gap threshold
+/// Parameters for filtering a single topic by ontology and timestamp range,
+/// then clustering matching timestamps by a time-gap threshold.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct TopicFilterClusterize {
+pub struct TopicClusterizeParams {
     pub locator: String,
     pub clustering_dt_ns: u64,
     pub ontology: Ontology,
     pub timestamp_range: Option<FilterTimestampRange>,
+}
+
+/// Filters a topic by ontology and timestamp range,
+/// then clusters matching timestamps by a time-gap threshold.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TopicFilterClusterize {
+    #[serde(flatten)]
+    pub params: TopicClusterizeParams,
 }
 
 /// Receives multiple topic filters (each with its own clustering configuration)
@@ -61,7 +69,7 @@ pub struct TopicFilterClusterize {
 /// that fall within intersect_dt_ns nanoseconds of each other across all topics
 #[derive(Deserialize, Debug)]
 pub struct TopicFilterIntersect {
-    pub topics: Vec<TopicFilterClusterize>,
+    pub topics: Vec<TopicClusterizeParams>,
     pub intersect_dt_ns: u64,
 }
 

--- a/mosaicod/tests/src/actions.rs
+++ b/mosaicod/tests/src/actions.rs
@@ -695,6 +695,36 @@ pub async fn topic_filter_clusterize(
     Ok(ret)
 }
 
+pub async fn topic_filter_intersect(
+    client: &mut Client,
+    topics: Vec<mosaicod_marshal::requests::TopicFilterClusterize>,
+    intersect_dt_ns: u64,
+) -> Result<Vec<serde_json::Value>, tonic::Status> {
+    let body = json!({
+        "topics": topics,
+        "intersect_dt_ns": intersect_dt_ns,
+    });
+
+    let action = Action {
+        r#type: "topic_filter_intersect".to_owned(),
+        body: serde_json::to_vec(&body)
+            .map_err(|e| tonic::Status::internal(e.to_string()))?
+            .into(),
+    };
+
+    dbg!(&action);
+    let mut ret: Vec<serde_json::Value> = Vec::new();
+    let mut stream = client.do_action(action).await?.into_inner();
+    while let Some(result) = stream.message().await? {
+        dbg!(&result);
+        let r = ActionResponse::from_body(&result.body);
+        assert_eq!(r.action, "topic_filter_intersect");
+        ret.push(r.response);
+    }
+
+    Ok(ret)
+}
+
 pub async fn query(
     client: &mut Client,
     filter: serde_json::Value,

--- a/mosaicod/tests/src/actions.rs
+++ b/mosaicod/tests/src/actions.rs
@@ -697,7 +697,7 @@ pub async fn topic_filter_clusterize(
 
 pub async fn topic_filter_intersect(
     client: &mut Client,
-    topics: Vec<mosaicod_marshal::requests::TopicFilterClusterize>,
+    topics: Vec<mosaicod_marshal::requests::TopicClusterizeParams>,
     intersect_dt_ns: u64,
 ) -> Result<Vec<serde_json::Value>, tonic::Status> {
     let body = json!({

--- a/mosaicod/tests/tests/topic.rs
+++ b/mosaicod/tests/tests/topic.rs
@@ -984,13 +984,13 @@ async fn test_topic_filter_intersect_no_intersection(pool: sqlx::Pool<db::Databa
     .await;
 
     let topics = vec![
-        mosaicod_marshal::requests::TopicFilterClusterize {
+        mosaicod_marshal::requests::TopicClusterizeParams {
             locator: t1.to_owned(),
             clustering_dt_ns: 100,
             ontology: ontology_value_gt_5(),
             timestamp_range: None,
         },
-        mosaicod_marshal::requests::TopicFilterClusterize {
+        mosaicod_marshal::requests::TopicClusterizeParams {
             locator: t2.to_owned(),
             clustering_dt_ns: 100,
             ontology: ontology_value_lt_3(),
@@ -1037,13 +1037,13 @@ async fn test_topic_filter_intersect_multiple(pool: sqlx::Pool<db::DatabaseType>
     .await;
 
     let topics = vec![
-        mosaicod_marshal::requests::TopicFilterClusterize {
+        mosaicod_marshal::requests::TopicClusterizeParams {
             locator: t1.to_owned(),
             clustering_dt_ns: 50,
             ontology: ontology_value_gt_5(),
             timestamp_range: None,
         },
-        mosaicod_marshal::requests::TopicFilterClusterize {
+        mosaicod_marshal::requests::TopicClusterizeParams {
             locator: t2.to_owned(),
             clustering_dt_ns: 50,
             ontology: ontology_value_lt_3(),
@@ -1106,19 +1106,19 @@ async fn test_topic_filter_intersect_three_topics(pool: sqlx::Pool<db::DatabaseT
     .await;
 
     let topics = vec![
-        mosaicod_marshal::requests::TopicFilterClusterize {
+        mosaicod_marshal::requests::TopicClusterizeParams {
             locator: t1.to_owned(),
             clustering_dt_ns: 150,
             ontology: ontology_value_gt_5(),
             timestamp_range: None,
         },
-        mosaicod_marshal::requests::TopicFilterClusterize {
+        mosaicod_marshal::requests::TopicClusterizeParams {
             locator: t2.to_owned(),
             clustering_dt_ns: 100,
             ontology: ontology_value_lt_3(),
             timestamp_range: None,
         },
-        mosaicod_marshal::requests::TopicFilterClusterize {
+        mosaicod_marshal::requests::TopicClusterizeParams {
             locator: t3.to_owned(),
             clustering_dt_ns: 100,
             ontology: ontology_value_gt_5(),
@@ -1167,13 +1167,13 @@ async fn test_topic_filter_intersect_within_tolerance(pool: sqlx::Pool<db::Datab
     .await;
 
     let topics = vec![
-        mosaicod_marshal::requests::TopicFilterClusterize {
+        mosaicod_marshal::requests::TopicClusterizeParams {
             locator: t1.to_owned(),
             clustering_dt_ns: 50,
             ontology: ontology_value_gt_5(),
             timestamp_range: None,
         },
-        mosaicod_marshal::requests::TopicFilterClusterize {
+        mosaicod_marshal::requests::TopicClusterizeParams {
             locator: t2.to_owned(),
             clustering_dt_ns: 50,
             ontology: ontology_value_lt_3(),
@@ -1220,13 +1220,13 @@ async fn test_topic_filter_intersect_different_sequences(pool: sqlx::Pool<db::Da
     .await;
 
     let topics = vec![
-        mosaicod_marshal::requests::TopicFilterClusterize {
+        mosaicod_marshal::requests::TopicClusterizeParams {
             locator: t1.to_owned(),
             clustering_dt_ns: 50,
             ontology: ontology_value_gt_5(),
             timestamp_range: None,
         },
-        mosaicod_marshal::requests::TopicFilterClusterize {
+        mosaicod_marshal::requests::TopicClusterizeParams {
             locator: t2.to_owned(),
             clustering_dt_ns: 50,
             ontology: ontology_value_lt_3(),

--- a/mosaicod/tests/tests/topic.rs
+++ b/mosaicod/tests/tests/topic.rs
@@ -571,9 +571,37 @@ async fn setup_topic_with_batches(
         .unwrap();
 }
 
-fn ontology_accel_x_gt_5() -> Ontology {
+async fn setup_topic_with_batches_in_existing_seq(
+    client: &mut common::Client,
+    sequence_name: &str,
+    topic_name: &str,
+    batches: Vec<arrow::array::RecordBatch>,
+) {
+    let (_, session_uuid) = actions::session_create(client, sequence_name)
+        .await
+        .unwrap();
+    let topic_uuid = actions::topic_create(client, &session_uuid, topic_name, None)
+        .await
+        .unwrap();
+
+    actions::do_put(client, &topic_uuid, topic_name, batches, false)
+        .await
+        .unwrap();
+    actions::session_finalize(client, &session_uuid)
+        .await
+        .unwrap();
+}
+
+fn ontology_value_gt_5() -> Ontology {
     serde_json::from_value(json!({
         "mock.value": { "$gt": 5 }
+    }))
+    .unwrap()
+}
+
+fn ontology_value_lt_3() -> Ontology {
+    serde_json::from_value(json!({
+        "mock.value": { "$lt": 3 }
     }))
     .unwrap()
 }
@@ -594,15 +622,10 @@ async fn test_topic_filter_clusterize_three_clusters(pool: sqlx::Pool<db::Databa
 
     setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
 
-    let clusters = actions::topic_filter_clusterize(
-        &mut client,
-        topic_name,
-        50,
-        ontology_accel_x_gt_5(),
-        None,
-    )
-    .await
-    .unwrap();
+    let clusters =
+        actions::topic_filter_clusterize(&mut client, topic_name, 50, ontology_value_gt_5(), None)
+            .await
+            .unwrap();
 
     assert_eq!(clusters.len(), 3, "expected 3 clusters, got: {clusters:?}");
 
@@ -639,7 +662,7 @@ async fn test_topic_filter_clusterize_single_cluster_via_gap(pool: sqlx::Pool<db
         &mut client,
         topic_name,
         100, // dt_ns >> max gap → un cluster
-        ontology_accel_x_gt_5(),
+        ontology_value_gt_5(),
         None,
     )
     .await
@@ -671,7 +694,7 @@ async fn test_topic_filter_clusterize_dt_zero_returns_full_range(
     setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
 
     let clusters =
-        actions::topic_filter_clusterize(&mut client, topic_name, 0, ontology_accel_x_gt_5(), None)
+        actions::topic_filter_clusterize(&mut client, topic_name, 0, ontology_value_gt_5(), None)
             .await
             .unwrap();
 
@@ -700,15 +723,10 @@ async fn test_topic_filter_clusterize_ontology_actually_filters(
 
     setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
 
-    let clusters = actions::topic_filter_clusterize(
-        &mut client,
-        topic_name,
-        50,
-        ontology_accel_x_gt_5(),
-        None,
-    )
-    .await
-    .unwrap();
+    let clusters =
+        actions::topic_filter_clusterize(&mut client, topic_name, 50, ontology_value_gt_5(), None)
+            .await
+            .unwrap();
 
     assert_eq!(clusters.len(), 2, "got: {clusters:?}");
     assert_eq!(clusters[0]["ts"]["start_ns"].as_u64().unwrap(), 100);
@@ -735,15 +753,10 @@ async fn test_topic_filter_clusterize_empty_result(pool: sqlx::Pool<db::Database
 
     setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
 
-    let clusters = actions::topic_filter_clusterize(
-        &mut client,
-        topic_name,
-        50,
-        ontology_accel_x_gt_5(),
-        None,
-    )
-    .await
-    .unwrap();
+    let clusters =
+        actions::topic_filter_clusterize(&mut client, topic_name, 50, ontology_value_gt_5(), None)
+            .await
+            .unwrap();
 
     assert!(
         clusters.is_empty(),
@@ -778,7 +791,7 @@ async fn test_topic_filter_clusterize_with_time_range(pool: sqlx::Pool<db::Datab
         &mut client,
         topic_name,
         100,
-        ontology_accel_x_gt_5(),
+        ontology_value_gt_5(),
         Some(ts_range),
     )
     .await
@@ -807,15 +820,10 @@ async fn test_topic_filter_clusterize_single_row(pool: sqlx::Pool<db::DatabaseTy
 
     setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
 
-    let clusters = actions::topic_filter_clusterize(
-        &mut client,
-        topic_name,
-        50,
-        ontology_accel_x_gt_5(),
-        None,
-    )
-    .await
-    .unwrap();
+    let clusters =
+        actions::topic_filter_clusterize(&mut client, topic_name, 50, ontology_value_gt_5(), None)
+            .await
+            .unwrap();
 
     assert_eq!(clusters.len(), 1);
     assert_eq!(clusters[0]["ts"]["start_ns"].as_u64().unwrap(), 200);
@@ -840,15 +848,10 @@ async fn test_topic_filter_clusterize_across_batches(pool: sqlx::Pool<db::Databa
 
     setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![b1, b2, b3]).await;
 
-    let clusters = actions::topic_filter_clusterize(
-        &mut client,
-        topic_name,
-        50,
-        ontology_accel_x_gt_5(),
-        None,
-    )
-    .await
-    .unwrap();
+    let clusters =
+        actions::topic_filter_clusterize(&mut client, topic_name, 50, ontology_value_gt_5(), None)
+            .await
+            .unwrap();
 
     assert_eq!(clusters.len(), 2, "got: {clusters:?}");
     assert_eq!(clusters[0]["ts"]["start_ns"].as_u64().unwrap(), 100);
@@ -875,15 +878,10 @@ async fn test_topic_filter_clusterize_gap_equals_dt(pool: sqlx::Pool<db::Databas
 
     setup_topic_with_batches(&mut client, sequence_name, topic_name, vec![batch]).await;
 
-    let clusters = actions::topic_filter_clusterize(
-        &mut client,
-        topic_name,
-        50,
-        ontology_accel_x_gt_5(),
-        None,
-    )
-    .await
-    .unwrap();
+    let clusters =
+        actions::topic_filter_clusterize(&mut client, topic_name, 50, ontology_value_gt_5(), None)
+            .await
+            .unwrap();
 
     assert_eq!(clusters.len(), 1, "got: {clusters:?}");
 
@@ -954,4 +952,292 @@ async fn test_topic_filter_clusterize_more_ontology(pool: sqlx::Pool<db::Databas
 
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().code(), tonic::Code::InvalidArgument);
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_topic_filter_intersect_no_intersection(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_no_intersect";
+
+    // Topic 1: cluster [100, 150]
+    let t1 = &format!("{seq}/topic_1");
+    setup_topic_with_batches(
+        &mut client,
+        seq,
+        t1,
+        vec![clustering_test_batch(&[100, 150], &[6, 7])],
+    )
+    .await;
+
+    // Topic 2: cluster [300, 400]
+    let t2 = &format!("{seq}/topic_2");
+    setup_topic_with_batches_in_existing_seq(
+        &mut client,
+        seq,
+        t2,
+        vec![clustering_test_batch(&[300, 400], &[1, 1])],
+    )
+    .await;
+
+    let topics = vec![
+        mosaicod_marshal::requests::TopicFilterClusterize {
+            locator: t1.to_owned(),
+            clustering_dt_ns: 100,
+            ontology: ontology_value_gt_5(),
+            timestamp_range: None,
+        },
+        mosaicod_marshal::requests::TopicFilterClusterize {
+            locator: t2.to_owned(),
+            clustering_dt_ns: 100,
+            ontology: ontology_value_lt_3(),
+            timestamp_range: None,
+        },
+    ];
+
+    let items = actions::topic_filter_intersect(&mut client, topics, 10)
+        .await
+        .unwrap();
+
+    assert_eq!(items.len(), 0);
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_topic_filter_intersect_multiple(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_multi";
+
+    // Topic 1: clusters [100,110] and [500,510]
+    let t1 = &format!("{seq}/topic_1");
+    setup_topic_with_batches(
+        &mut client,
+        seq,
+        t1,
+        vec![clustering_test_batch(&[100, 110, 500, 510], &[6, 7, 8, 9])],
+    )
+    .await;
+
+    // Topic 2: clusters [105,115] and [495,505]
+    let t2 = &format!("{seq}/topic_2");
+    setup_topic_with_batches_in_existing_seq(
+        &mut client,
+        seq,
+        t2,
+        vec![clustering_test_batch(&[105, 115, 495, 505], &[1, 2, 1, 2])],
+    )
+    .await;
+
+    let topics = vec![
+        mosaicod_marshal::requests::TopicFilterClusterize {
+            locator: t1.to_owned(),
+            clustering_dt_ns: 50,
+            ontology: ontology_value_gt_5(),
+            timestamp_range: None,
+        },
+        mosaicod_marshal::requests::TopicFilterClusterize {
+            locator: t2.to_owned(),
+            clustering_dt_ns: 50,
+            ontology: ontology_value_lt_3(),
+            timestamp_range: None,
+        },
+    ];
+
+    let items = actions::topic_filter_intersect(&mut client, topics, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(items.len(), 2, "got: {items:?}");
+
+    assert_eq!(items[0]["ts"]["start_ns"].as_u64().unwrap(), 105);
+    assert_eq!(items[0]["ts"]["end_ns"].as_u64().unwrap(), 110);
+
+    assert_eq!(items[1]["ts"]["start_ns"].as_u64().unwrap(), 500);
+    assert_eq!(items[1]["ts"]["end_ns"].as_u64().unwrap(), 505);
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_topic_filter_intersect_three_topics(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_three";
+
+    // Topic 1: cluster [100, 200]
+    let t1 = &format!("{seq}/topic_1");
+    setup_topic_with_batches(
+        &mut client,
+        seq,
+        t1,
+        vec![clustering_test_batch(&[100, 200], &[6, 7])],
+    )
+    .await;
+
+    // Topic 2: cluster [120, 180]
+    let t2 = &format!("{seq}/topic_2");
+    setup_topic_with_batches_in_existing_seq(
+        &mut client,
+        seq,
+        t2,
+        vec![clustering_test_batch(&[120, 180], &[1, 2])],
+    )
+    .await;
+
+    // Topic 3: cluster [130, 170]
+    let t3 = &format!("{seq}/topic_3");
+    setup_topic_with_batches_in_existing_seq(
+        &mut client,
+        seq,
+        t3,
+        vec![clustering_test_batch(&[130, 170], &[6, 7])],
+    )
+    .await;
+
+    let topics = vec![
+        mosaicod_marshal::requests::TopicFilterClusterize {
+            locator: t1.to_owned(),
+            clustering_dt_ns: 150,
+            ontology: ontology_value_gt_5(),
+            timestamp_range: None,
+        },
+        mosaicod_marshal::requests::TopicFilterClusterize {
+            locator: t2.to_owned(),
+            clustering_dt_ns: 100,
+            ontology: ontology_value_lt_3(),
+            timestamp_range: None,
+        },
+        mosaicod_marshal::requests::TopicFilterClusterize {
+            locator: t3.to_owned(),
+            clustering_dt_ns: 100,
+            ontology: ontology_value_gt_5(),
+            timestamp_range: None,
+        },
+    ];
+
+    let items = actions::topic_filter_intersect(&mut client, topics, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(items.len(), 1, "got: {items:?}");
+    assert_eq!(items[0]["ts"]["start_ns"].as_u64().unwrap(), 130);
+    assert_eq!(items[0]["ts"]["end_ns"].as_u64().unwrap(), 170);
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_topic_filter_intersect_within_tolerance(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_tolerance";
+
+    // Topic 1: cluster [100, 140]
+    let t1 = &format!("{seq}/topic_1");
+    setup_topic_with_batches(
+        &mut client,
+        seq,
+        t1,
+        vec![clustering_test_batch(&[100, 140], &[6, 7])],
+    )
+    .await;
+
+    // Topic 2: cluster [155, 200]
+    let t2 = &format!("{seq}/topic_2");
+    setup_topic_with_batches_in_existing_seq(
+        &mut client,
+        seq,
+        t2,
+        vec![clustering_test_batch(&[155, 200], &[1, 2])],
+    )
+    .await;
+
+    let topics = vec![
+        mosaicod_marshal::requests::TopicFilterClusterize {
+            locator: t1.to_owned(),
+            clustering_dt_ns: 50,
+            ontology: ontology_value_gt_5(),
+            timestamp_range: None,
+        },
+        mosaicod_marshal::requests::TopicFilterClusterize {
+            locator: t2.to_owned(),
+            clustering_dt_ns: 50,
+            ontology: ontology_value_lt_3(),
+            timestamp_range: None,
+        },
+    ];
+
+    // intersect_dt_ns=20: gap 15 < 20, within tolerance.
+    // Tolerance interval: [155 - 20/2, 140 + 20/2] = [145, 150]
+    let items = actions::topic_filter_intersect(&mut client, topics, 20)
+        .await
+        .unwrap();
+
+    assert_eq!(items.len(), 1, "got: {items:?}");
+    assert_eq!(items[0]["ts"]["start_ns"].as_u64().unwrap(), 145);
+    assert_eq!(items[0]["ts"]["end_ns"].as_u64().unwrap(), 150);
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_topic_filter_intersect_different_sequences(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let t1 = "my_seq_1/topic";
+    setup_topic_with_batches(
+        &mut client,
+        "my_seq_1",
+        t1,
+        vec![clustering_test_batch(&[100], &[6])],
+    )
+    .await;
+
+    let t2 = "my_seq_2/topic";
+    setup_topic_with_batches(
+        &mut client,
+        "my_seq_2",
+        t2,
+        vec![clustering_test_batch(&[100], &[1])],
+    )
+    .await;
+
+    let topics = vec![
+        mosaicod_marshal::requests::TopicFilterClusterize {
+            locator: t1.to_owned(),
+            clustering_dt_ns: 50,
+            ontology: ontology_value_gt_5(),
+            timestamp_range: None,
+        },
+        mosaicod_marshal::requests::TopicFilterClusterize {
+            locator: t2.to_owned(),
+            clustering_dt_ns: 50,
+            ontology: ontology_value_lt_3(),
+            timestamp_range: None,
+        },
+    ];
+
+    let res = actions::topic_filter_intersect(&mut client, topics, 0).await;
+
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().code(), tonic::Code::InvalidArgument);
+
+    server.shutdown().await;
 }


### PR DESCRIPTION
Implement topic_filter_intersect action to compute the intersection of clustered timestamp streams across multiple topics belonging to the same sequence.

Close #557 
