### PR TITLE
feat(mosaicod): Enable complex column types queries

### DIFF
--- a/mosaicod/Cargo.lock
+++ b/mosaicod/Cargo.lock
@@ -119,9 +119,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrow"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -165,7 +165,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
 dependencies = [
  "bytes",
  "half",
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca025bd0f38eeecb57c2153c0123b960494138e6a957bbda10da2b25415209fe"
+checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -271,15 +271,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ead0914e4861a531be48fe05858265cf854a4880b9ed12618b1d08cba9bebc8"
+checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
+ "arrow-ord",
  "arrow-schema",
+ "arrow-select",
  "chrono",
  "half",
  "indexmap",
@@ -295,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -308,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -321,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
  "serde_core",
  "serde_json",
@@ -331,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -345,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -865,14 +866,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93db0e623840612f7f2cd757f7e8a8922064192363732c88692e0870016e141b"
+checksum = "997a31e15872606a49478e670c58302094c97cb96abb0a7d60720f8e92170040"
 dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
- "bytes",
  "bzip2",
  "chrono",
  "datafusion-catalog",
@@ -902,14 +902,13 @@ dependencies = [
  "datafusion-sql",
  "flate2",
  "futures",
+ "indexmap",
  "itertools",
  "liblzma",
  "log",
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.2",
- "regex",
  "sqlparser",
  "tempfile",
  "tokio",
@@ -920,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
+checksum = "f7dd61161508f8f5fa1107774ea687bd753c22d83a32eebf963549f89de14139"
 dependencies = [
  "arrow",
  "async-trait",
@@ -945,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
+checksum = "897c70f871277f9ce99aa38347be0d679bbe3e617156c4d2a8378cec8a2a0891"
 dependencies = [
  "arrow",
  "async-trait",
@@ -968,34 +967,35 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d72a11ca44a95e1081870d3abb80c717496e8a7acb467a1d3e932bb636af5cc2"
+checksum = "121c9ded5d87d9172319e006f2afdb9928d72dbacd6a90a458d8acb1e3b43a65"
 dependencies = [
- "ahash",
  "arrow",
  "arrow-ipc",
+ "arrow-schema",
  "chrono",
+ "foldhash 0.2.0",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "itertools",
  "libc",
  "log",
  "object_store",
  "parquet",
- "paste",
  "recursive",
  "sqlparser",
  "tokio",
+ "uuid",
  "web-time",
 ]
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f4afaed29670ec4fd6053643adc749fe3f4bc9d1ce1b8c5679b22c67d12def"
+checksum = "981b9dae74f78ee3d9f714fb49b01919eab975461b56149510c3ba9ea11287d1"
 dependencies = [
  "futures",
  "log",
@@ -1004,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9fb386e1691355355a96419978a0022b7947b44d4a24a6ea99f00b6b485cbb6"
+checksum = "ffd7d295b2ec7c00d8a56562f41ed41062cf0af75549ed891c12a0a09eddfefe"
 dependencies = [
  "arrow",
  "async-compression",
@@ -1030,6 +1030,7 @@ dependencies = [
  "liblzma",
  "log",
  "object_store",
+ "parking_lot",
  "rand 0.9.2",
  "tokio",
  "tokio-util",
@@ -1039,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa6c52cfed0734c5f93754d1c0175f558175248bf686c944fb05c373e5fc096"
+checksum = "552b0b3f342f7ec41b3fbd70f6339dc82a30cfd0349e7f280e7852528085349f"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1063,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503f29e0582c1fc189578d665ff57d9300da1f80c282777d7eb67bb79fb8cdca"
+checksum = "68850aa426b897e879c8b87e512ea8124f1d0a2869a4e51808ddaaddf1bc0ada"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1086,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33804749abc8d0c8cb7473228483cb8070e524c6f6086ee1b85a64debe2b3d2"
+checksum = "402f93242ae08ef99139ee2c528a49d087efe88d5c7b2c3ff5480855a40ce54f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1103,16 +1104,15 @@ dependencies = [
  "datafusion-session",
  "futures",
  "object_store",
- "serde_json",
  "tokio",
  "tokio-stream",
 ]
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a8e0365e0e08e8ff94d912f0ababcf9065a1a304018ba90b1fc83c855b4997"
+checksum = "ffd2499c1bee0eeccf6a57156105700eeeb17bc701899ac719183c4e74231450"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1122,6 +1122,7 @@ dependencies = [
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-functions",
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-adapter",
@@ -1140,20 +1141,19 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
+checksum = "cb9e7e5d11130c48c8bd4e80c79a9772dd28ce6dc330baca9246205d245b9e2e"
 
 [[package]]
 name = "datafusion-execution"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03c7fbdaefcca4ef6ffe425a5fc2325763bfb426599bb0bf4536466efabe709"
+checksum = "37a8643ab852eb68864e1b72ae789e8066282dce48eea6347ffb0aee33d1ccc0"
 dependencies = [
  "arrow",
  "arrow-buffer",
  "async-trait",
- "chrono",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
@@ -1169,11 +1169,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574b9b6977fedbd2a611cbff12e5caf90f31640ad9dc5870f152836d94bad0dd"
+checksum = "6932f4d71eed9c8d9341476a2b845aadfabde5495d08dbcd8fc23881f49fa7a0"
 dependencies = [
  "arrow",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -1184,7 +1185,6 @@ dependencies = [
  "datafusion-physical-expr-common",
  "indexmap",
  "itertools",
- "paste",
  "recursive",
  "serde_json",
  "sqlparser",
@@ -1192,22 +1192,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
+checksum = "0225491839a31b1f7d2cb8092c2d50792e2fe1c1724e4e6d08e011f5feaf4ed2"
 dependencies = [
  "arrow",
  "datafusion-common",
  "indexmap",
  "itertools",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
+checksum = "14872c47bfc3d21e53ec82f57074e6987a15941c1e2f43cde4ac6ae2746634e3"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1220,6 +1219,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-macros",
+ "datafusion-physical-expr-common",
  "hex",
  "itertools",
  "log",
@@ -1227,17 +1227,15 @@ dependencies = [
  "num-traits",
  "rand 0.9.2",
  "regex",
- "unicode-segmentation",
  "uuid",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
+checksum = "75a2ca14e1b609be21e657e2d3130b2f446456b08393b377bb721a33952d2e09"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -1247,19 +1245,18 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
+ "foldhash 0.2.0",
  "half",
  "log",
  "num-traits",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b511250349407db7c43832ab2de63f5557b19a20dfd236b39ca2c04468b50d47"
+checksum = "1ece74ba09092d2ef9c9b54a38445450aea292a1f8b04faf531936b723a24b3c"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -1268,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
+checksum = "3f3e3f9ee8ca59bf70518802107de6f1b88a9509efdc629fadc5de9d6b2d5ef5"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1284,34 +1281,34 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-macros",
  "datafusion-physical-expr-common",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itertools",
  "itoa",
  "log",
- "paste",
+ "memchr",
 ]
 
 [[package]]
 name = "datafusion-functions-table"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
+checksum = "89161dffc22cf2b50f9f4b1bee83b5221d3b4ed7c2e37fd7aa2b22a5297b3a26"
 dependencies = [
  "arrow",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-physical-expr",
  "datafusion-physical-plan",
  "parking_lot",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e88ec9d57c9b685d02f58bfee7be62d72610430ddcedb82a08e5d9925dbfb6"
+checksum = "d7339345b226b3874037708bf5023ba1c2de705128f8457a095aae5ae9cb9c78"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1322,14 +1319,13 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8307bb93519b1a91913723a1130cfafeee3f72200d870d88e91a6fc5470ede5c"
+checksum = "fa84836dc2392df6f43d6a29d37fb56a8ebdc8b3f4e10ae8dc15861fd20278fb"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1337,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
+checksum = "587164e03ad68732aa9e7bfe5686e3f25970d4c64fd4bd80790749840892dae5"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -1348,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e929015451a67f77d9d8b727b2bf3a40c4445fdef6cdc53281d7d97c76888ace"
+checksum = "77f20e8cf9e8654d92f4c16b24c487353ee5bf153ffc12d5772cd399ab8cd281"
 dependencies = [
  "arrow",
  "chrono",
@@ -1368,11 +1364,10 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b1e68aba7a4b350401cfdf25a3d6f989ad898a7410164afe9ca52080244cb59"
+checksum = "f015a4a82f6f7ff7e1d8d4bf3870a936752fa38b17705dfcc14adef95aa8922c"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -1380,11 +1375,10 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "itertools",
  "parking_lot",
- "paste",
  "petgraph",
  "recursive",
  "tokio",
@@ -1392,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
+checksum = "51e6ffff8acdfe54e0ea15ccf38115c4a9184433b0439f42907637928d00a235"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1407,26 +1401,26 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04b45ea8ad3ac2d78f2ea2a76053e06591c9629c7a603eda16c10649ecf4362"
+checksum = "7967a3e171c6a4bf09474b3f7a14f1a3db13ed1714ba12156f33fcce2bba54e8"
 dependencies = [
- "ahash",
  "arrow",
  "chrono",
  "datafusion-common",
  "datafusion-expr-common",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "itertools",
  "parking_lot",
+ "pin-project",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
+checksum = "59ff803e2a96054cb6d83f35f9e60fd4f42eac515e1932bd1b2dbc91d5fcbf36"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1443,12 +1437,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edc023675791af9d5fb4cc4c24abf5f7bd3bd4dcf9e5bd90ea1eff6976dcc79"
+checksum = "776ee54d47d15bdb126452f9ca17b03761e3b004682914beaedd3f86eb507fbc"
 dependencies = [
- "ahash",
  "arrow",
+ "arrow-data",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "async-trait",
@@ -1463,7 +1458,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "futures",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "itertools",
  "log",
@@ -1475,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
+checksum = "d5fb9e5774660aa69c3ba93c610f175f75b65cb8c3776edb3626de8f3a4f4ee3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1486,15 +1481,14 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "itertools",
  "log",
 ]
 
 [[package]]
 name = "datafusion-session"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5412111aa48e2424ba926112e192f7a6b7e4ccb450145d25ce5ede9f19dc491e"
+checksum = "15ce715fa2a61f4623cc234bcc14a3ef6a91f189128d5b14b468a6a17cdfc417"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -1506,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
+checksum = "6094ad36a3ed6d7ac87b20b479b2d0b118250f66cf997603829fdc65b44a7099"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -1910,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2244,12 +2238,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2406,9 +2400,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "liblzma"
@@ -2566,13 +2560,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3003,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -3021,7 +3015,7 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "lz4_flex",
  "num-bigint",
  "num-integer",
@@ -3834,12 +3828,12 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3863,9 +3857,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
  "recursive",
@@ -4288,9 +4282,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4303,9 +4297,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4567,12 +4561,6 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/mosaicod/Cargo.toml
+++ b/mosaicod/Cargo.toml
@@ -33,7 +33,7 @@ arrow-cast = "58.1.0"
 arrow-flight = "58.1.0"
 arrow-schema = "58.1.0"
 parquet = "58.1.0"
-datafusion = { version = "53.1.0", default-features = false, features = ["compression", "parquet", "sql", "recursive_protection"] }
+datafusion = { version = "54.0.0", default-features = false, features = ["compression", "parquet", "sql", "recursive_protection", "nested_expressions"] }
 tonic = { version = "0.14.6", features = ["tls-ring", "gzip"] }
 object_store = { version = "0.13.2", features = ["aws", "fs"] }
 

--- a/mosaicod/crates/mosaicod-core/src/types/chunk.rs
+++ b/mosaicod/crates/mosaicod-core/src/types/chunk.rs
@@ -22,14 +22,13 @@ pub enum Stats {
     Numeric(NumericStats),
     Textual(TextualStats),
     Unsupported,
+    List(NumericStats),
+    ListTextual(TextualStats),
 }
 
 impl Stats {
     pub fn is_unsupported(&self) -> bool {
-        if let Stats::Unsupported = self {
-            return true;
-        }
-        false
+        matches!(self, Stats::Unsupported)
     }
 }
 

--- a/mosaicod/crates/mosaicod-core/src/types/chunk.rs
+++ b/mosaicod/crates/mosaicod-core/src/types/chunk.rs
@@ -22,7 +22,7 @@ pub enum Stats {
     Numeric(NumericStats),
     Textual(TextualStats),
     Unsupported,
-    List(NumericStats),
+    ListNumeric(NumericStats),
     ListTextual(TextualStats),
 }
 

--- a/mosaicod/crates/mosaicod-db/src/sql/pg_queries/builders.rs
+++ b/mosaicod/crates/mosaicod-db/src/sql/pg_queries/builders.rs
@@ -291,7 +291,14 @@ impl query::CompileClause for ChunkQueryBuilder {
 
 impl query::OntologyFieldFmt for ChunkQueryBuilder {
     fn ontology_column_fmt(&self, subfield: &query::OntologyField) -> String {
-        format!("'{}'", subfield.value())
+        // Strip the index specifier ([?], [!], [n]) for column name search in column_t.
+        let parsed = subfield.parsed_field();
+        let field_path = if parsed.prefix.is_empty() {
+            parsed.field.clone()
+        } else {
+            format!("{}.{}", parsed.prefix.join("."), parsed.field)
+        };
+        format!("'{}.{}'", subfield.ontology_tag(), field_path)
     }
 }
 

--- a/mosaicod/crates/mosaicod-db/src/sql/pg_queries/builders.rs
+++ b/mosaicod/crates/mosaicod-db/src/sql/pg_queries/builders.rs
@@ -292,7 +292,7 @@ impl query::CompileClause for ChunkQueryBuilder {
 impl query::OntologyFieldFmt for ChunkQueryBuilder {
     fn ontology_column_fmt(&self, subfield: &query::OntologyField) -> String {
         // Strip the index specifier ([?], [!], [n]) for column name search in column_t.
-        let parsed = subfield.parsed_field();
+        let parsed = subfield.field_path();
         let field_path = if parsed.prefix.is_empty() {
             parsed.field.clone()
         } else {

--- a/mosaicod/crates/mosaicod-db/src/sql/pg_queries/builders.rs
+++ b/mosaicod/crates/mosaicod-db/src/sql/pg_queries/builders.rs
@@ -291,14 +291,7 @@ impl query::CompileClause for ChunkQueryBuilder {
 
 impl query::OntologyFieldFmt for ChunkQueryBuilder {
     fn ontology_column_fmt(&self, subfield: &query::OntologyField) -> String {
-        // Strip the index specifier ([?], [!], [n]) for column name search in column_t.
-        let parsed = subfield.field_path();
-        let field_path = if parsed.prefix.is_empty() {
-            parsed.field.clone()
-        } else {
-            format!("{}.{}", parsed.prefix.join("."), parsed.field)
-        };
-        format!("'{}.{}'", subfield.ontology_tag(), field_path)
+        format!("'{}'", subfield.field_str())
     }
 }
 

--- a/mosaicod/crates/mosaicod-ext/src/arrow.rs
+++ b/mosaicod/crates/mosaicod-ext/src/arrow.rs
@@ -1,4 +1,6 @@
-use arrow::array::{ArrayRef, AsArray, RecordBatch, StructArray};
+use arrow::array::{
+    ArrayRef, AsArray, FixedSizeListArray, LargeListArray, ListArray, RecordBatch, StructArray,
+};
 use arrow::datatypes::{DataType, Field, FieldRef, Schema, SchemaRef};
 use mosaicod_core::{self as core, params, types};
 use parquet::arrow::async_reader::{AsyncFileReader, ParquetObjectReader};
@@ -298,8 +300,39 @@ pub fn stats_from_arrow_field(field: &Field) -> types::Stats {
     match field.data_type() {
         dt if is_numeric(dt) => Stats::Numeric(NumericStats::new()),
         dt if is_textual(dt) => Stats::Textual(TextualStats::new()),
+        DataType::List(elem) | DataType::LargeList(elem) => {
+            if is_textual(elem.data_type()) {
+                Stats::ListTextual(TextualStats::new())
+            } else {
+                Stats::List(NumericStats::new())
+            }
+        }
+        // Do we need to handle the fixed size?
+        DataType::FixedSizeList(elem, _) => {
+            if is_textual(elem.data_type()) {
+                Stats::ListTextual(TextualStats::new())
+            } else {
+                Stats::List(NumericStats::new())
+            }
+        }
         _ => Stats::Unsupported,
     }
+}
+
+/// Extracts the flattened child values array from a list array.
+/// Returns None if the array is not a recognized list type.
+fn list_child_values(array: &ArrayRef) -> Option<ArrayRef> {
+    use arrow::array::Array;
+    if let Some(a) = array.as_any().downcast_ref::<ListArray>() {
+        return Some(a.values().clone());
+    }
+    if let Some(a) = array.as_any().downcast_ref::<LargeListArray>() {
+        return Some(a.values().clone());
+    }
+    if let Some(a) = array.as_any().downcast_ref::<FixedSizeListArray>() {
+        return Some(a.values().clone());
+    }
+    None
 }
 
 /// Inspects an array and updates the provided statistics using SIMD-optimized Arrow compute kernels.
@@ -337,6 +370,31 @@ pub fn stats_inspect_array(stats: &mut types::Stats, array: &ArrayRef) -> Result
             // Check for nulls (O(1))
             let has_null = string_array.null_count() > 0;
 
+            stats.merge(min_val, max_val, has_null);
+        }
+        Stats::List(stats) => {
+            let flatten_list = list_child_values(array).ok_or_else(|| {
+                arrow::error::ArrowError::CastError("expected list array".to_string())
+            })?;
+
+            let narray = cast_array_to_numeric(&flatten_list)?;
+            let primitive = narray.as_primitive::<arrow::datatypes::Float64Type>();
+            let min_val = compute::min(primitive);
+            let max_val = compute::max(primitive);
+            let has_null = primitive.null_count() > 0;
+            let has_nan = primitive.values().iter().any(|v| v.is_nan());
+            stats.merge(min_val, max_val, has_null, has_nan);
+        }
+        Stats::ListTextual(stats) => {
+            let flatten_list = list_child_values(array).ok_or_else(|| {
+                arrow::error::ArrowError::CastError("expected list array".to_string())
+            })?;
+
+            let sarray = cast_array_to_textual(&flatten_list)?;
+            let string_array = sarray.as_string::<i32>();
+            let min_val = compute::min_string(string_array);
+            let max_val = compute::max_string(string_array);
+            let has_null = string_array.null_count() > 0;
             stats.merge(min_val, max_val, has_null);
         }
         Stats::Unsupported => { /* do nothing */ }

--- a/mosaicod/crates/mosaicod-ext/src/arrow.rs
+++ b/mosaicod/crates/mosaicod-ext/src/arrow.rs
@@ -304,15 +304,14 @@ pub fn stats_from_arrow_field(field: &Field) -> types::Stats {
             if is_textual(elem.data_type()) {
                 Stats::ListTextual(TextualStats::new())
             } else {
-                Stats::List(NumericStats::new())
+                Stats::ListNumeric(NumericStats::new())
             }
         }
-        // Do we need to handle the fixed size?
         DataType::FixedSizeList(elem, _) => {
             if is_textual(elem.data_type()) {
                 Stats::ListTextual(TextualStats::new())
             } else {
-                Stats::List(NumericStats::new())
+                Stats::ListNumeric(NumericStats::new())
             }
         }
         _ => Stats::Unsupported,
@@ -321,7 +320,7 @@ pub fn stats_from_arrow_field(field: &Field) -> types::Stats {
 
 /// Extracts the flattened child values array from a list array.
 /// Returns None if the array is not a recognized list type.
-fn list_child_values(array: &ArrayRef) -> Option<ArrayRef> {
+fn list_child_values_from_array(array: &ArrayRef) -> Option<ArrayRef> {
     use arrow::array::Array;
     if let Some(a) = array.as_any().downcast_ref::<ListArray>() {
         return Some(a.values().clone());
@@ -372,8 +371,8 @@ pub fn stats_inspect_array(stats: &mut types::Stats, array: &ArrayRef) -> Result
 
             stats.merge(min_val, max_val, has_null);
         }
-        Stats::List(stats) => {
-            let flatten_list = list_child_values(array).ok_or_else(|| {
+        Stats::ListNumeric(stats) => {
+            let flatten_list = list_child_values_from_array(array).ok_or_else(|| {
                 arrow::error::ArrowError::CastError("expected list array".to_string())
             })?;
 
@@ -386,7 +385,7 @@ pub fn stats_inspect_array(stats: &mut types::Stats, array: &ArrayRef) -> Result
             stats.merge(min_val, max_val, has_null, has_nan);
         }
         Stats::ListTextual(stats) => {
-            let flatten_list = list_child_values(array).ok_or_else(|| {
+            let flatten_list = list_child_values_from_array(array).ok_or_else(|| {
                 arrow::error::ArrowError::CastError("expected list array".to_string())
             })?;
 

--- a/mosaicod/crates/mosaicod-facade/src/chunk.rs
+++ b/mosaicod/crates/mosaicod-facade/src/chunk.rs
@@ -70,7 +70,7 @@ impl<'a> Chunk<'a> {
                         stats.has_nan,
                     ));
                 }
-                types::Stats::List(stats) => {
+                types::Stats::ListNumeric(stats) => {
                     numeric_batch.push(db::ColumnChunkNumericRecord::new(
                         column.column_id,
                         self.chunk.chunk_id,

--- a/mosaicod/crates/mosaicod-facade/src/chunk.rs
+++ b/mosaicod/crates/mosaicod-facade/src/chunk.rs
@@ -70,6 +70,26 @@ impl<'a> Chunk<'a> {
                         stats.has_nan,
                     ));
                 }
+                types::Stats::List(stats) => {
+                    numeric_batch.push(db::ColumnChunkNumericRecord::new(
+                        column.column_id,
+                        self.chunk.chunk_id,
+                        stats.min,
+                        stats.max,
+                        stats.has_null,
+                        stats.has_nan,
+                    ));
+                }
+                types::Stats::ListTextual(stats) => {
+                    let (min, max, has_null) = stats.into_owned();
+                    textual_batch.push(db::ColumnChunkTextualRecord::try_new(
+                        column.column_id,
+                        self.chunk.chunk_id,
+                        min,
+                        max,
+                        has_null,
+                    )?);
+                }
                 types::Stats::Unsupported => {}
             }
         }

--- a/mosaicod/crates/mosaicod-query/src/filter.rs
+++ b/mosaicod/crates/mosaicod-query/src/filter.rs
@@ -367,6 +367,12 @@ impl OntologyField {
     pub fn value(&self) -> String {
         self.to_string()
     }
+
+    pub fn field_str(&self) -> String {
+        let mut parts = vec![self.tag.as_str()];
+        parts.extend(self.field_path.field_segments());
+        parts.join(".")
+    }
 }
 
 impl std::fmt::Display for OntologyField {

--- a/mosaicod/crates/mosaicod-query/src/filter.rs
+++ b/mosaicod/crates/mosaicod-query/src/filter.rs
@@ -24,7 +24,7 @@
 //!
 
 use mosaicod_core::types;
-use std::{borrow::Borrow, collections::HashMap, collections::hash_map::Entry};
+use std::{collections::HashMap, collections::hash_map::Entry};
 
 /// Floating point value type alias
 pub type Float = f64;
@@ -218,7 +218,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum IndexSpecifier {
     /// Access the element at a specific position: [0], [42].
     At(usize),
@@ -226,6 +226,16 @@ pub enum IndexSpecifier {
     Any,
     /// Every element must satisfy the predicate: [!].
     All,
+}
+
+impl std::fmt::Display for IndexSpecifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IndexSpecifier::At(n) => write!(f, "[{n}]"),
+            IndexSpecifier::Any => write!(f, "[?]"),
+            IndexSpecifier::All => write!(f, "[!]"),
+        }
+    }
 }
 
 /// The structured representation of an ontology field path after parsing.
@@ -240,14 +250,37 @@ pub enum IndexSpecifier {
 /// - "x[30]"                 prefix: [],                field: "x",    specifier: Some(At(30))
 /// - "acceleration.x"        prefix: ["acceleration"],  field: "x",    specifier: None
 /// - "acceleration.x[!]"     prefix: ["acceleration"],  field: "x",    specifier: Some(All)
-#[derive(Debug, Clone)]
-pub struct ParsedField {
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OntologyFieldPath {
     /// Plain struct navigation segments before the leaf field.
     pub prefix: Vec<String>,
     /// The leaf field name.
     pub field: String,
     /// Index specifier for list access, if the leaf field is a list column.
     pub specifier: Option<IndexSpecifier>,
+}
+
+impl OntologyFieldPath {
+    /// Returns an iterator over all dot-path segments in order: prefix segments first, then the leaf field name.
+    pub fn field_segments(&self) -> impl Iterator<Item = &str> {
+        self.prefix
+            .iter()
+            .map(|s| s.as_str())
+            .chain(std::iter::once(self.field.as_str()))
+    }
+}
+
+impl std::fmt::Display for OntologyFieldPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for seg in &self.prefix {
+            write!(f, "{seg}.")?;
+        }
+        write!(f, "{}", self.field)?;
+        if let Some(spec) = &self.specifier {
+            write!(f, "{spec}")?;
+        }
+        Ok(())
+    }
 }
 
 /// Parses a single dot-path segment, splitting the field name from its optional
@@ -271,11 +304,10 @@ fn parse_segment(s: &str) -> Result<(String, Option<IndexSpecifier>), ()> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct OntologyField {
-    value: String,
-    tag_offset: usize,
-    parsed_field: ParsedField,
+    tag: String,
+    field_path: OntologyFieldPath,
 }
 
 impl OntologyField {
@@ -283,6 +315,7 @@ impl OntologyField {
         let ontology_tag = v.split(".").next().ok_or_else(|| super::Error::BadField {
             field: v.to_string(),
         })?;
+        let tag = ontology_tag.to_owned();
         let len = ontology_tag.len();
 
         // Validate that only the last segment may carry an index specifier.
@@ -309,60 +342,36 @@ impl OntologyField {
             }
         }
 
-        let parsed_field = ParsedField {
-            prefix,
-            field: leaf_name,
-            specifier: leaf_specifier,
-        };
-
         Ok(Self {
-            value: v,
-            tag_offset: len,
-            parsed_field,
+            tag,
+            field_path: OntologyFieldPath {
+                prefix,
+                field: leaf_name,
+                specifier: leaf_specifier,
+            },
         })
     }
 
     pub fn ontology_tag(&self) -> &str {
-        &self.value[..self.tag_offset]
+        &self.tag
     }
 
-    pub fn field(&self) -> &str {
-        // +1 to remove the dot
-        &self.value[(self.tag_offset + 1)..]
+    pub fn field_path(&self) -> &OntologyFieldPath {
+        &self.field_path
     }
 
-    pub fn parsed_field(&self) -> &ParsedField {
-        &self.parsed_field
+    pub fn field(&self) -> String {
+        self.field_path.to_string()
     }
 
-    pub fn value(&self) -> &str {
-        &self.value
-    }
-}
-
-impl PartialEq for OntologyField {
-    fn eq(&self, other: &Self) -> bool {
-        self.value == other.value
+    pub fn value(&self) -> String {
+        self.to_string()
     }
 }
 
-impl PartialEq<str> for OntologyField {
-    fn eq(&self, other: &str) -> bool {
-        self.value == other
-    }
-}
-
-impl Borrow<str> for OntologyField {
-    fn borrow(&self) -> &str {
-        &self.value
-    }
-}
-
-impl Eq for OntologyField {}
-
-impl std::hash::Hash for OntologyField {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.value.hash(state);
+impl std::fmt::Display for OntologyField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.tag, self.field_path)
     }
 }
 
@@ -477,7 +486,7 @@ impl OntologyFilter {
     }
 
     /// Retrieves the operation associated with a specific metadata field.
-    pub fn get_op(&self, field: &str) -> Option<&Op<Value>> {
+    pub fn get_op(&self, field: &OntologyField) -> Option<&Op<Value>> {
         self.ontology.get(field)
     }
 

--- a/mosaicod/crates/mosaicod-query/src/filter.rs
+++ b/mosaicod/crates/mosaicod-query/src/filter.rs
@@ -218,10 +218,64 @@ where
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum IndexSpecifier {
+    /// Access the element at a specific position: [0], [42].
+    At(usize),
+    /// At least one element must satisfy the predicate: [?].
+    Any,
+    /// Every element must satisfy the predicate: [!].
+    All,
+}
+
+/// The structured representation of an ontology field path after parsing.
+///
+/// Index specifiers are only supported on the leaf (last) segment of the path.
+/// A field path always follows this shape:
+///   <prefix>.<leaf>[specifier]
+///
+/// Examples:
+/// - "x"                     prefix: [],                field: "x",    specifier: None
+/// - "x[?]"                  prefix: [],                field: "x",    specifier: Some(Any)
+/// - "x[30]"                 prefix: [],                field: "x",    specifier: Some(At(30))
+/// - "acceleration.x"        prefix: ["acceleration"],  field: "x",    specifier: None
+/// - "acceleration.x[!]"     prefix: ["acceleration"],  field: "x",    specifier: Some(All)
+#[derive(Debug, Clone)]
+pub struct ParsedField {
+    /// Plain struct navigation segments before the leaf field.
+    pub prefix: Vec<String>,
+    /// The leaf field name.
+    pub field: String,
+    /// Index specifier for list access, if the leaf field is a list column.
+    pub specifier: Option<IndexSpecifier>,
+}
+
+/// Parses a single dot-path segment, splitting the field name from its optional
+/// index specifier (e.g. "x[?]" -> name "x", specifier Any).
+fn parse_segment(s: &str) -> Result<(String, Option<IndexSpecifier>), ()> {
+    match s.find('[') {
+        None => Ok((s.to_owned(), None)),
+        Some(pos) => {
+            let name = s[..pos].to_owned();
+            let content = s[pos..]
+                .strip_prefix('[')
+                .and_then(|r| r.strip_suffix(']'))
+                .ok_or(())?;
+            let specifier = match content {
+                "?" => IndexSpecifier::Any,
+                "!" => IndexSpecifier::All,
+                n => IndexSpecifier::At(n.parse::<usize>().map_err(|_| ())?),
+            };
+            Ok((name, Some(specifier)))
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct OntologyField {
     value: String,
     tag_offset: usize,
+    parsed_field: ParsedField,
 }
 
 impl OntologyField {
@@ -231,9 +285,40 @@ impl OntologyField {
         })?;
         let len = ontology_tag.len();
 
+        // Validate that only the last segment may carry an index specifier.
+        let field_part = &v[(len + 1)..];
+        let segments: Vec<&str> = field_part.split('.').collect();
+
+        let mut prefix = Vec::with_capacity(segments.len().saturating_sub(1));
+        let mut leaf_name = String::new();
+        let mut leaf_specifier = None;
+
+        for (i, segment) in segments.iter().enumerate() {
+            let (parsed_name, specifier) =
+                parse_segment(segment).map_err(|_| super::Error::BadField { field: v.clone() })?;
+
+            if i != segments.len() - 1 {
+                // if the specifier is not on the last segment (x.y[].z).
+                if specifier.is_some() {
+                    return Err(super::Error::BadField { field: v });
+                }
+                prefix.push(parsed_name);
+            } else {
+                leaf_name = parsed_name;
+                leaf_specifier = specifier;
+            }
+        }
+
+        let parsed_field = ParsedField {
+            prefix,
+            field: leaf_name,
+            specifier: leaf_specifier,
+        };
+
         Ok(Self {
             value: v,
             tag_offset: len,
+            parsed_field,
         })
     }
 
@@ -244,6 +329,10 @@ impl OntologyField {
     pub fn field(&self) -> &str {
         // +1 to remove the dot
         &self.value[(self.tag_offset + 1)..]
+    }
+
+    pub fn parsed_field(&self) -> &ParsedField {
+        &self.parsed_field
     }
 
     pub fn value(&self) -> &str {

--- a/mosaicod/crates/mosaicod-query/src/filter.rs
+++ b/mosaicod/crates/mosaicod-query/src/filter.rs
@@ -223,7 +223,7 @@ pub enum IndexSpecifier {
     /// Access the element at a specific position: [0], [42].
     At(usize),
     /// At least one element must satisfy the predicate: [?].
-    Any,
+    AtLeastOne,
     /// Every element must satisfy the predicate: [!].
     All,
 }
@@ -232,7 +232,7 @@ impl std::fmt::Display for IndexSpecifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             IndexSpecifier::At(n) => write!(f, "[{n}]"),
-            IndexSpecifier::Any => write!(f, "[?]"),
+            IndexSpecifier::AtLeastOne => write!(f, "[?]"),
             IndexSpecifier::All => write!(f, "[!]"),
         }
     }
@@ -246,7 +246,7 @@ impl std::fmt::Display for IndexSpecifier {
 ///
 /// Examples:
 /// - "x"                     prefix: [],                field: "x",    specifier: None
-/// - "x[?]"                  prefix: [],                field: "x",    specifier: Some(Any)
+/// - "x[?]"                  prefix: [],                field: "x",    specifier: Some(AtLeastOne)
 /// - "x[30]"                 prefix: [],                field: "x",    specifier: Some(At(30))
 /// - "acceleration.x"        prefix: ["acceleration"],  field: "x",    specifier: None
 /// - "acceleration.x[!]"     prefix: ["acceleration"],  field: "x",    specifier: Some(All)
@@ -295,7 +295,7 @@ fn parse_segment(s: &str) -> Result<(String, Option<IndexSpecifier>), ()> {
                 .and_then(|r| r.strip_suffix(']'))
                 .ok_or(())?;
             let specifier = match content {
-                "?" => IndexSpecifier::Any,
+                "?" => IndexSpecifier::AtLeastOne,
                 "!" => IndexSpecifier::All,
                 n => IndexSpecifier::At(n.parse::<usize>().map_err(|_| ())?),
             };

--- a/mosaicod/crates/mosaicod-query/src/timeseries.rs
+++ b/mosaicod/crates/mosaicod-query/src/timeseries.rs
@@ -4,7 +4,7 @@
 //!
 //! The engine integrates directly with the configured [`store::Store`] to resolve
 //! paths and access data sources like Parquet files efficiently.
-use super::{Error, OntologyExprGroup, OntologyField, Op, Value};
+use super::{Error, IndexSpecifier, OntologyExprGroup, OntologyField, Op, Value};
 use arrow::datatypes::{Schema, SchemaRef};
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::execution::disk_manager::DiskManagerBuilder;
@@ -13,6 +13,10 @@ use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
 use datafusion::functions::core::expr_ext::FieldAccessor;
 use datafusion::functions::regex::expr_fn::regexp_like;
 use datafusion::functions_aggregate::expr_fn::{max, min};
+use datafusion::functions_nested::expr_fn::{
+    array_distinct, array_element, array_has, array_has_any, array_intersect, array_max, array_min,
+    cardinality, make_array,
+};
 use datafusion::prelude::*;
 use datafusion::scalar::ScalarValue;
 use log::trace;
@@ -155,6 +159,14 @@ impl TimeseriesResult {
         let expr = expr_group_to_df_expr(filter);
 
         let data_frame = if let Some(expr) = expr {
+            // Resolve LambdaVariable.field for any higher-order functions (e.g.
+            // array_any_match). The programmatic df.filter() path does not run
+            // the SQL analyzer, so lambda variable types must be resolved
+            // manually using the current schema before handing the expression
+            // to the DataFrame API.
+            let expr = expr
+                .resolve_lambda_variables(self.data_frame.schema())?
+                .data;
             trace!("filter expression: {}", expr);
             self.data_frame.filter(expr)?
         } else {
@@ -227,13 +239,131 @@ fn scalar_value_to_timestamp(value: ScalarValue) -> Option<types::Timestamp> {
 }
 
 fn unfold_field(field: &OntologyField) -> Expr {
-    let mut fields = field.field().split(".");
-    // By construction fields needs to have at least a value
-    let mut col = col(fields.next().unwrap());
-    for s in fields {
-        col = col.field(s);
+    let parsed = field.parsed_field();
+    let mut all = parsed
+        .prefix
+        .iter()
+        .map(|s| s.as_str())
+        .chain(std::iter::once(parsed.field.as_str()));
+    let mut expr = col(all.next().unwrap());
+    for seg in all {
+        expr = expr.field(seg);
     }
-    col
+    expr
+}
+
+/// Applies a scalar (non-array) operator to a DataFusion expression.
+fn scalar_op_to_df_expr<V: Into<Value>>(expr: Expr, op: Op<V>) -> Option<Expr> {
+    match op {
+        Op::Eq(v) => Some(expr.eq(value_to_df_expr(v.into()))),
+        Op::Neq(v) => Some(expr.not_eq(value_to_df_expr(v.into()))),
+        Op::Leq(v) => Some(expr.lt_eq(value_to_df_expr(v.into()))),
+        Op::Geq(v) => Some(expr.gt_eq(value_to_df_expr(v.into()))),
+        Op::Lt(v) => Some(expr.lt(value_to_df_expr(v.into()))),
+        Op::Gt(v) => Some(expr.gt(value_to_df_expr(v.into()))),
+        Op::Ex => None,
+        Op::Nex => None,
+        Op::Between(range) => {
+            let vmin = value_to_df_expr(range.min.into());
+            let vmax = value_to_df_expr(range.max.into());
+            Some(expr.clone().gt_eq(vmin).and(expr.lt_eq(vmax)))
+        }
+        Op::In(items) => {
+            let list = items
+                .into_iter()
+                .map(|v| value_to_df_expr(v.into()))
+                .collect();
+            Some(expr.in_list(list, false))
+        }
+        Op::Match(v) => Some(regexp_like(expr, value_to_df_expr(v.into()), None)),
+    }
+}
+
+/// Builds the DataFusion expression for [?], at least one element satisfies the predicate.
+fn any_op_to_df_expr<V: Into<Value>>(arr: Expr, op: Op<V>) -> Option<Expr> {
+    match op {
+        Op::Eq(v) => Some(array_has(arr, value_to_df_expr(v.into()))),
+        Op::Neq(v) => {
+            let v = value_to_df_expr(v.into());
+            let res = cardinality(array_remove_all(arr, v));
+            Some(res.gt(lit(0)))
+        }
+        Op::Gt(v) => Some(array_max(arr).gt(value_to_df_expr(v.into()))),
+        Op::Geq(v) => Some(array_max(arr).gt_eq(value_to_df_expr(v.into()))),
+        Op::Lt(v) => Some(array_min(arr).lt(value_to_df_expr(v.into()))),
+        Op::Leq(v) => Some(array_min(arr).lt_eq(value_to_df_expr(v.into()))),
+        Op::Between(range) => {
+            let vmin = value_to_df_expr(range.min.into());
+            let vmax = value_to_df_expr(range.max.into());
+            let x = lambda_var("x");
+            let body = x.clone().gt_eq(vmin).and(x.lt_eq(vmax));
+            Some(array_any_match(arr, lambda(["x"], body)))
+        }
+        Op::In(items) => {
+            let set = make_array(
+                items
+                    .into_iter()
+                    .map(|v| value_to_df_expr(v.into()))
+                    .collect(),
+            );
+            Some(array_has_any(arr, set))
+        }
+        Op::Match(v) => {
+            let x = lambda_var("x");
+            let body = regexp_like(x, value_to_df_expr(v.into()), None);
+            Some(array_any_match(arr, lambda(["x"], body)))
+        }
+        Op::Ex => None,
+        Op::Nex => None,
+    }
+}
+
+/// Builds the DataFusion expression for [!], every element satisfies the predicate.
+fn all_op_to_df_expr<V: Into<Value>>(arr: Expr, op: Op<V>) -> Option<Expr> {
+    match op {
+        Op::Eq(v) => {
+            let v = value_to_df_expr(v.into());
+            Some(
+                array_min(arr.clone())
+                    .eq(v.clone())
+                    .and(array_max(arr).eq(v)),
+            )
+        }
+        Op::Neq(v) => Some(array_has(arr, value_to_df_expr(v.into())).not()),
+        Op::Gt(v) => Some(array_min(arr).gt(value_to_df_expr(v.into()))),
+        Op::Geq(v) => Some(array_min(arr).gt_eq(value_to_df_expr(v.into()))),
+        Op::Lt(v) => Some(array_max(arr).lt(value_to_df_expr(v.into()))),
+        Op::Leq(v) => Some(array_max(arr).lt_eq(value_to_df_expr(v.into()))),
+        Op::Between(range) => {
+            let vmin = value_to_df_expr(range.min.into());
+            let vmax = value_to_df_expr(range.max.into());
+            Some(
+                array_min(arr.clone())
+                    .gt_eq(vmin)
+                    .and(array_max(arr).lt_eq(vmax)),
+            )
+        }
+        Op::In(items) => {
+            let set = make_array(
+                items
+                    .into_iter()
+                    .map(|v| value_to_df_expr(v.into()))
+                    .collect(),
+            );
+            let distinct_count = cardinality(array_distinct(arr.clone()));
+            let intersect_count = cardinality(array_intersect(arr, set));
+            Some(distinct_count.eq(intersect_count))
+        }
+
+        Op::Match(v) => {
+            // all elements match <-> no element fails to match
+            let x = lambda_var("x");
+            let body = not(regexp_like(x, value_to_df_expr(v.into()), None));
+            Some(not(array_any_match(arr, lambda(["x"], body))))
+        }
+        Op::Ex => None,
+        Op::Nex => None,
+    }
 }
 
 fn expr_group_to_df_expr<V>(filter: OntologyExprGroup<V>) -> Option<Expr>
@@ -244,34 +374,17 @@ where
 
     for expr in filter.into_iter() {
         let (field, op) = expr.into_parts();
-        let expr = match op {
-            Op::Eq(v) => Some(unfold_field(&field).eq(value_to_df_expr(v.into()))),
-            Op::Neq(v) => Some(unfold_field(&field).not_eq(value_to_df_expr(v.into()))),
-            Op::Leq(v) => Some(unfold_field(&field).lt_eq(value_to_df_expr(v.into()))),
-            Op::Geq(v) => Some(unfold_field(&field).gt_eq(value_to_df_expr(v.into()))),
-            Op::Lt(v) => Some(unfold_field(&field).lt(value_to_df_expr(v.into()))),
-            Op::Gt(v) => Some(unfold_field(&field).gt(value_to_df_expr(v.into()))),
-            Op::Ex => None,  // no-op
-            Op::Nex => None, // no-op
-            Op::Between(range) => {
-                let vmin: Value = range.min.into();
-                let vmax: Value = range.max.into();
-                let emin = unfold_field(&field).lt_eq(value_to_df_expr(vmax));
-                let emax = unfold_field(&field).gt_eq(value_to_df_expr(vmin));
-                Some(emin.and(emax))
+        let parsed = field.parsed_field();
+        let arr = unfold_field(&field);
+
+        let expr = match parsed.specifier {
+            None => scalar_op_to_df_expr(arr, op),
+            Some(IndexSpecifier::At(i)) => {
+                // DataFusion array_element uses 1-indexing
+                scalar_op_to_df_expr(array_element(arr, lit(i as i64 + 1)), op)
             }
-            Op::In(items) => {
-                let list = items
-                    .into_iter()
-                    .map(|v| value_to_df_expr(v.into()))
-                    .collect();
-                Some(unfold_field(&field).in_list(list, false))
-            }
-            Op::Match(v) => Some(regexp_like(
-                unfold_field(&field),
-                value_to_df_expr(v.into()),
-                None,
-            )),
+            Some(IndexSpecifier::Any) => any_op_to_df_expr(arr, op),
+            Some(IndexSpecifier::All) => all_op_to_df_expr(arr, op),
         };
 
         if let Some(expr) = expr {

--- a/mosaicod/crates/mosaicod-query/src/timeseries.rs
+++ b/mosaicod/crates/mosaicod-query/src/timeseries.rs
@@ -382,7 +382,7 @@ where
                 // DataFusion array_element uses 1-indexing
                 scalar_op_to_df_expr(array_element(arr, lit(i as i64 + 1)), op)
             }
-            Some(IndexSpecifier::Any) => any_op_to_df_expr(arr, op),
+            Some(IndexSpecifier::AtLeastOne) => any_op_to_df_expr(arr, op),
             Some(IndexSpecifier::All) => all_op_to_df_expr(arr, op),
         };
 

--- a/mosaicod/crates/mosaicod-query/src/timeseries.rs
+++ b/mosaicod/crates/mosaicod-query/src/timeseries.rs
@@ -238,14 +238,13 @@ fn scalar_value_to_timestamp(value: ScalarValue) -> Option<types::Timestamp> {
     }
 }
 
+/// Converts an [`OntologyField`] dot-path into a nested DataFusion [`Expr`].
+/// Each segment becomes a `.field()` access on the previous one, e.g.
+/// `"acceleration.x"` -> `col("acceleration").field("x")`.
 fn unfold_field(field: &OntologyField) -> Expr {
-    let parsed = field.parsed_field();
-    let mut all = parsed
-        .prefix
-        .iter()
-        .map(|s| s.as_str())
-        .chain(std::iter::once(parsed.field.as_str()));
-    let mut expr = col(all.next().unwrap());
+    let parsed = field.field_path();
+    let mut all = parsed.field_segments();
+    let mut expr = col(all.next().expect("field has at least one segment"));
     for seg in all {
         expr = expr.field(seg);
     }
@@ -374,7 +373,7 @@ where
 
     for expr in filter.into_iter() {
         let (field, op) = expr.into_parts();
-        let parsed = field.parsed_field();
+        let parsed = field.field_path();
         let arr = unfold_field(&field);
 
         let expr = match parsed.specifier {

--- a/mosaicod/tests/tests/ontology_query.rs
+++ b/mosaicod/tests/tests/ontology_query.rs
@@ -1,10 +1,98 @@
 #![allow(unused_crate_dependencies)]
-use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::array::{
+    Int64Array, Int64Builder, ListBuilder, RecordBatch, StringArray, StringBuilder,
+};
 use arrow::datatypes::{DataType, Field, Schema};
 use mosaicod_db as db;
 use serde_json::json;
 use std::sync::Arc;
 use tests::{actions, common};
+
+use arrow::array::ArrayRef;
+
+fn int_list_batch(ts_start: i64, values: &[i64], list_test: &[Vec<i64>]) -> RecordBatch {
+    assert_eq!(
+        values.len(),
+        list_test.len(),
+        "values and test_list must have the same length"
+    );
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("timestamp_ns", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+        Field::new(
+            "list_test",
+            DataType::List(Arc::new(Field::new("item", DataType::Int64, false))),
+            false,
+        ),
+    ]));
+
+    let timestamps: Vec<i64> = (0..values.len() as i64).map(|i| ts_start + i * 5).collect();
+
+    let mut list_builder = ListBuilder::new(Int64Builder::new()).with_field(Field::new(
+        "item",
+        DataType::Int64,
+        false,
+    ));
+
+    for row in list_test {
+        for &val in row {
+            list_builder.values().append_value(val);
+        }
+        list_builder.append(true);
+    }
+    let list_array = list_builder.finish();
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(timestamps)) as ArrayRef,
+            Arc::new(Int64Array::from(values.to_vec())) as ArrayRef,
+            Arc::new(list_array) as ArrayRef,
+        ],
+    )
+    .unwrap()
+}
+
+fn string_list_batch(ts_start: i64, values: &[i64], list_test: &[Vec<&str>]) -> RecordBatch {
+    assert_eq!(values.len(), list_test.len());
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("timestamp_ns", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+        Field::new(
+            "list_test",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, false))),
+            false,
+        ),
+    ]));
+
+    let timestamps: Vec<i64> = (0..values.len() as i64).map(|i| ts_start + i * 5).collect();
+
+    let mut list_builder = ListBuilder::new(StringBuilder::new()).with_field(Field::new(
+        "item",
+        DataType::Utf8,
+        false,
+    ));
+
+    for row in list_test {
+        for &val in row {
+            list_builder.values().append_value(val);
+        }
+        list_builder.append(true);
+    }
+    let list_array = list_builder.finish();
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(timestamps)) as ArrayRef,
+            Arc::new(Int64Array::from(values.to_vec())) as ArrayRef,
+            Arc::new(list_array) as ArrayRef,
+        ],
+    )
+    .unwrap()
+}
 
 fn int_batch(ts_start: i64, values: &[i64]) -> RecordBatch {
     let schema = Arc::new(Schema::new(vec![
@@ -660,6 +748,1049 @@ async fn test_ontology_combined_in_and_geq(pool: sqlx::Pool<db::DatabaseType>) {
     assert!(
         locators.contains(&format!("{seq}/topic_high")),
         "topic_high should be included (21 in $in list and min=20 >= 5)"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_any_eq(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_eq";
+
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            (
+                "topic_a",
+                int_list_batch(
+                    10_000,
+                    &[1, 2, 3],
+                    &[vec![1, 2, 3], vec![3, 4, 5], vec![6, 7, 8]],
+                ),
+            ),
+            ("topic_b", int_batch(20_000, &[100, 101, 102])),
+        ],
+    )
+    .await;
+
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$eq": 5 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "topic_a should be included (value 5 appears in one of its lists)"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "topic_b should be excluded (no list_test column)"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_any_neq(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_any_neq";
+    // topic_a: [5,5,5] — every element equals 5, so no element != 5
+    // topic_b: [1,2,3] — all elements != 5 (max=3 < 5, so DB also passes it through)
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_list_batch(10_000, &[1], &[vec![5, 5, 5]])),
+            ("topic_b", int_list_batch(20_000, &[2], &[vec![1, 2, 3]])),
+        ],
+    )
+    .await;
+
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$neq": 5 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "topic_a should be excluded (all elements are 5, none != 5)"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "topic_b should be included (elements [1,2,3] all satisfy != 5)"
+    );
+
+    // [5,5,5] has no element equal to 3 -> all elements satisfy != 3 -> at least one does
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$neq": 3 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "topic_a should be included (elements [5,5,5] all satisfy != 3)"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_any_ordering(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_any_ord";
+    // topic_a elements: [1, 2, 3] (min=1, max=3)
+    // topic_b elements: [10, 20, 30] (min=10, max=30)
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_list_batch(10_000, &[1], &[vec![1, 2, 3]])),
+            ("topic_b", int_list_batch(20_000, &[2], &[vec![10, 20, 30]])),
+        ],
+    )
+    .await;
+
+    macro_rules! query_locs {
+        ($client:expr, $op:literal, $val:expr) => {{
+            let items = actions::query(
+                $client,
+                json!({ "ontology": { "mock.list_test[?]": { $op: $val } } }),
+            )
+            .await
+            .unwrap();
+            topic_locators(&items)
+        }};
+    }
+
+    // $gt v: any element > v — DataFusion: array_max(arr) > v
+    let locs = query_locs!(&mut client, "$gt", 25);
+    assert!(
+        !locs.contains(&format!("{seq}/topic_a")),
+        "$gt 25: max(a)=3, excluded"
+    );
+    assert!(
+        locs.contains(&format!("{seq}/topic_b")),
+        "$gt 25: max(b)=30 > 25, included"
+    );
+
+    let locs = query_locs!(&mut client, "$gt", 30);
+    assert!(
+        !locs.contains(&format!("{seq}/topic_a")),
+        "$gt 30: excluded"
+    );
+    assert!(
+        !locs.contains(&format!("{seq}/topic_b")),
+        "$gt 30: max(b)=30 not > 30, excluded"
+    );
+
+    // $geq v: any element >= v — DataFusion: array_max(arr) >= v
+    let locs = query_locs!(&mut client, "$geq", 30);
+    assert!(
+        !locs.contains(&format!("{seq}/topic_a")),
+        "$geq 30: max(a)=3, excluded"
+    );
+    assert!(
+        locs.contains(&format!("{seq}/topic_b")),
+        "$geq 30: max(b)=30 >= 30, included"
+    );
+
+    let locs = query_locs!(&mut client, "$geq", 31);
+    assert!(
+        !locs.contains(&format!("{seq}/topic_a")),
+        "$geq 31: excluded"
+    );
+    assert!(
+        !locs.contains(&format!("{seq}/topic_b")),
+        "$geq 31: max(b)=30 < 31, excluded"
+    );
+
+    // $lt v: any element < v — DataFusion: array_min(arr) < v
+    let locs = query_locs!(&mut client, "$lt", 2);
+    assert!(
+        locs.contains(&format!("{seq}/topic_a")),
+        "$lt 2: min(a)=1 < 2, included"
+    );
+    assert!(
+        !locs.contains(&format!("{seq}/topic_b")),
+        "$lt 2: min(b)=10, excluded"
+    );
+
+    let locs = query_locs!(&mut client, "$lt", 1);
+    assert!(
+        !locs.contains(&format!("{seq}/topic_a")),
+        "$lt 1: min(a)=1 not < 1, excluded"
+    );
+    assert!(!locs.contains(&format!("{seq}/topic_b")), "$lt 1: excluded");
+
+    // $leq v: any element <= v — DataFusion: array_min(arr) <= v
+    let locs = query_locs!(&mut client, "$leq", 1);
+    assert!(
+        locs.contains(&format!("{seq}/topic_a")),
+        "$leq 1: min(a)=1 <= 1, included"
+    );
+    assert!(
+        !locs.contains(&format!("{seq}/topic_b")),
+        "$leq 1: min(b)=10, excluded"
+    );
+
+    let locs = query_locs!(&mut client, "$leq", 0);
+    assert!(
+        !locs.contains(&format!("{seq}/topic_a")),
+        "$leq 0: excluded"
+    );
+    assert!(
+        !locs.contains(&format!("{seq}/topic_b")),
+        "$leq 0: excluded"
+    );
+
+    // Sanity: both topics have elements > 0
+    let locs = query_locs!(&mut client, "$gt", 0);
+    assert!(
+        locs.contains(&format!("{seq}/topic_a")),
+        "$gt 0: topic_a included"
+    );
+    assert!(
+        locs.contains(&format!("{seq}/topic_b")),
+        "$gt 0: topic_b included"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_any_between(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_any_between";
+    // topic_a elements: [1, 2, 3], topic_b elements: [10, 20, 30]
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_list_batch(10_000, &[1], &[vec![1, 2, 3]])),
+            ("topic_b", int_list_batch(20_000, &[2], &[vec![10, 20, 30]])),
+        ],
+    )
+    .await;
+
+    // [5, 9]: gap between both topics — neither has an element in [5, 9]
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$between": [5, 9] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "$between [5,9]: topic_a excluded"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "$between [5,9]: topic_b excluded"
+    );
+
+    // [5, 15]: only topic_b has element 10 in range
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$between": [5, 15] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "$between [5,15]: topic_a excluded"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "$between [5,15]: topic_b included (10 in [5,15])"
+    );
+
+    // [2, 12]: both have an element in range (2 for a, 10 for b)
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$between": [2, 12] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "$between [2,12]: topic_a included (2 in range)"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "$between [2,12]: topic_b included (10 in range)"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_any_in(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_any_in";
+    // topic_a elements: [1, 2, 3], topic_b elements: [10, 20, 30]
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_list_batch(10_000, &[1], &[vec![1, 2, 3]])),
+            ("topic_b", int_list_batch(20_000, &[2], &[vec![10, 20, 30]])),
+        ],
+    )
+    .await;
+
+    // Neither topic has 5 or 7
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$in": [5, 7] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "$in [5,7]: topic_a excluded"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "$in [5,7]: topic_b excluded"
+    );
+
+    // topic_a has 2, topic_b has neither 2 nor 99
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$in": [2, 99] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "$in [2,99]: topic_a has 2, included"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "$in [2,99]: topic_b excluded"
+    );
+
+    // Both match: topic_a has 3, topic_b has 10
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$in": [3, 10] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "$in [3,10]: topic_a has 3, included"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "$in [3,10]: topic_b has 10, included"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_all_eq(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_all_eq";
+    // topic_a: [7,7,7] — all elements equal 7 (min=max=7)
+    // topic_b: [1,2,3] — mixed elements
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_list_batch(10_000, &[1], &[vec![7, 7, 7]])),
+            ("topic_b", int_list_batch(20_000, &[2], &[vec![1, 2, 3]])),
+        ],
+    )
+    .await;
+
+    // $eq 7
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[!]": { "$eq": 7 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "topic_a should be included (all elements are 7)"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "topic_b should be excluded (elements [1,2,3] not all equal 7)"
+    );
+
+    // $eq 2: no list is uniformly 2
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[!]": { "$eq": 2 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "$eq 2: topic_a excluded"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "$eq 2: topic_b excluded"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_all_neq(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_all_neq";
+    // topic_a: [1,2,3], topic_b: [4,5,6]
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_list_batch(10_000, &[1], &[vec![1, 2, 3]])),
+            ("topic_b", int_list_batch(20_000, &[2], &[vec![4, 5, 6]])),
+        ],
+    )
+    .await;
+
+    // $neq 9: neither topic contains 9
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[!]": { "$neq": 9 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "$neq 9: topic_a included"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "$neq 9: topic_b included"
+    );
+
+    // $neq 2: topic_a contains 2 -> excluded; topic_b has no 2 -> included
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[!]": { "$neq": 2 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "$neq 2: topic_a has 2, excluded"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "$neq 2: topic_b has no 2, included"
+    );
+
+    // $neq 5: topic_a has no 5 -> included; topic_b contains 5 -> excluded
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[!]": { "$neq": 5 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "$neq 5: topic_a has no 5, included"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "$neq 5: topic_b has 5, excluded"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_all_ordering(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_all_ord";
+    // topic_a elements: [1, 2, 3] (min=1, max=3)
+    // topic_b elements: [10, 20, 30] (min=10, max=30)
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_list_batch(10_000, &[1], &[vec![1, 2, 3]])),
+            ("topic_b", int_list_batch(20_000, &[2], &[vec![10, 20, 30]])),
+        ],
+    )
+    .await;
+
+    macro_rules! query_locs {
+        ($client:expr, $op:literal, $val:expr) => {{
+            let items = actions::query(
+                $client,
+                json!({ "ontology": { "mock.list_test[!]": { $op: $val } } }),
+            )
+            .await
+            .unwrap();
+            topic_locators(&items)
+        }};
+    }
+
+    // $gt v: all elements > v — DataFusion: array_min(arr) > v
+    let locs = query_locs!(&mut client, "$gt", 9);
+    assert!(
+        !locs.contains(&format!("{seq}/topic_a")),
+        "$gt 9: min(a)=1, excluded"
+    );
+    assert!(
+        locs.contains(&format!("{seq}/topic_b")),
+        "$gt 9: min(b)=10 > 9, included"
+    );
+
+    let locs = query_locs!(&mut client, "$gt", 10);
+    assert!(
+        !locs.contains(&format!("{seq}/topic_a")),
+        "$gt 10: excluded"
+    );
+    assert!(
+        !locs.contains(&format!("{seq}/topic_b")),
+        "$gt 10: min(b)=10 not > 10, excluded"
+    );
+
+    // $geq v: all elements >= v — DataFusion: array_min(arr) >= v
+    let locs = query_locs!(&mut client, "$geq", 10);
+    assert!(
+        !locs.contains(&format!("{seq}/topic_a")),
+        "$geq 10: min(a)=1, excluded"
+    );
+    assert!(
+        locs.contains(&format!("{seq}/topic_b")),
+        "$geq 10: min(b)=10 >= 10, included"
+    );
+
+    let locs = query_locs!(&mut client, "$geq", 1);
+    assert!(
+        locs.contains(&format!("{seq}/topic_a")),
+        "$geq 1: min(a)=1 >= 1, included"
+    );
+    assert!(
+        locs.contains(&format!("{seq}/topic_b")),
+        "$geq 1: min(b)=10 >= 1, included"
+    );
+
+    // $lt v: all elements < v
+    let locs = query_locs!(&mut client, "$lt", 5);
+    assert!(
+        locs.contains(&format!("{seq}/topic_a")),
+        "$lt 5: max(a)=3 < 5, included"
+    );
+    assert!(
+        !locs.contains(&format!("{seq}/topic_b")),
+        "$lt 5: max(b)=30, excluded"
+    );
+
+    let locs = query_locs!(&mut client, "$lt", 3);
+    assert!(
+        !locs.contains(&format!("{seq}/topic_a")),
+        "$lt 3: max(a)=3 not < 3, excluded"
+    );
+    assert!(!locs.contains(&format!("{seq}/topic_b")), "$lt 3: excluded");
+
+    // $leq v: all elements <= v
+    let locs = query_locs!(&mut client, "$leq", 3);
+    assert!(
+        locs.contains(&format!("{seq}/topic_a")),
+        "$leq 3: max(a)=3 <= 3, included"
+    );
+    assert!(
+        !locs.contains(&format!("{seq}/topic_b")),
+        "$leq 3: max(b)=30, excluded"
+    );
+
+    let locs = query_locs!(&mut client, "$leq", 0);
+    assert!(
+        !locs.contains(&format!("{seq}/topic_a")),
+        "$leq 0: excluded"
+    );
+    assert!(
+        !locs.contains(&format!("{seq}/topic_b")),
+        "$leq 0: excluded"
+    );
+
+    // $between [a, b]: all elements in [a, b]
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[!]": { "$between": [1, 3] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "$between [1,3]: topic_a [1,2,3] fully in range, included"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "$between [1,3]: topic_b min=10 > 3, excluded"
+    );
+
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[!]": { "$between": [5, 35] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "$between [5,35]: topic_a min=1 < 5, excluded"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "$between [5,35]: topic_b [10,20,30] fully in [5,35], included"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_at_eq(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_at_eq";
+    // topic_a: [10, 20, 30] — index 0->10, 1->20, 2->30
+    // topic_b: [40, 50, 60] — index 0->40, 1->50, 2->60
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_list_batch(10_000, &[1], &[vec![10, 20, 30]])),
+            ("topic_b", int_list_batch(20_000, &[2], &[vec![40, 50, 60]])),
+        ],
+    )
+    .await;
+
+    // [0] $eq 10: first element — topic_a matches, topic_b excluded
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[0]": { "$eq": 10 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "[0]$eq 10: topic_a[0]=10, included"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "[0]$eq 10: topic_b[0]=40, excluded"
+    );
+
+    // [1] $eq 50: second element — topic_b matches, topic_a excluded
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[1]": { "$eq": 50 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "[1]$eq 50: topic_a[1]=20, excluded"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "[1]$eq 50: topic_b[1]=50, included"
+    );
+
+    // [2] $eq 30: third element — topic_a matches, topic_b excluded
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[2]": { "$eq": 30 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "[2]$eq 30: topic_a[2]=30, included"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "[2]$eq 30: topic_b[2]=60, excluded"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_at_ordering(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_at_ord";
+    // topic_a: [10, 20, 30], topic_b: [40, 50, 60]
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_list_batch(10_000, &[1], &[vec![10, 20, 30]])),
+            ("topic_b", int_list_batch(20_000, &[2], &[vec![40, 50, 60]])),
+        ],
+    )
+    .await;
+
+    // [1] $gt 45: topic_a[1]=20 not > 45; topic_b[1]=50 > 45
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[1]": { "$gt": 45 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "[1]$gt 45: topic_a[1]=20, excluded"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "[1]$gt 45: topic_b[1]=50, included"
+    );
+
+    // [0] $leq 10: topic_a[0]=10 <= 10; topic_b[0]=40 not <= 10
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[0]": { "$leq": 10 } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "[0]$leq 10: topic_a[0]=10, included"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "[0]$leq 10: topic_b[0]=40, excluded"
+    );
+
+    // [2] $between [25, 35]: topic_a[2]=30 in [25,35]; topic_b[2]=60 not
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[2]": { "$between": [25, 35] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "[2]$between [25,35]: topic_a[2]=30, included"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "[2]$between [25,35]: topic_b[2]=60, excluded"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_list_db_pruning(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_list_pruning";
+    // Elements span [1, 30] — DB stores min_element=1, max_element=30
+    setup_topics(
+        &mut client,
+        seq,
+        vec![(
+            "topic_a",
+            int_list_batch(10_000, &[1, 2], &[vec![1, 15, 30], vec![5, 10, 20]]),
+        )],
+    )
+    .await;
+
+    // Values at the element range boundaries are found
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$eq": 1 } } }),
+    )
+    .await
+    .unwrap();
+    assert!(
+        !topic_locators(&items).is_empty(),
+        "$eq 1: element 1 at boundary, should be found"
+    );
+
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$eq": 30 } } }),
+    )
+    .await
+    .unwrap();
+    assert!(
+        !topic_locators(&items).is_empty(),
+        "$eq 30: element 30 at boundary, should be found"
+    );
+
+    // Values outside element range [1, 30]
+    // v=0: 1 <= 0 is false -> chunk excluded at DB level
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$eq": 0 } } }),
+    )
+    .await
+    .unwrap();
+    assert!(
+        topic_locators(&items).is_empty(),
+        "$eq 0: below element range [1,30], chunk pruned"
+    );
+
+    // v=99: 30 >= 99 is false -> chunk excluded at DB level
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$eq": 99 } } }),
+    )
+    .await
+    .unwrap();
+    assert!(
+        topic_locators(&items).is_empty(),
+        "$eq 99: above element range [1,30], chunk pruned"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_any_match(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_any_match";
+    // topic_a: strings starting with 'a' and 'b'
+    // topic_b: strings with no 'a' prefix
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            (
+                "topic_a",
+                string_list_batch(10_000, &[1], &[vec!["apple", "banana", "cherry"]]),
+            ),
+            (
+                "topic_b",
+                string_list_batch(20_000, &[2], &[vec!["dog", "cat", "fish"]]),
+            ),
+        ],
+    )
+    .await;
+
+    // "^a": topic_a has "apple" -> included; topic_b has none starting with 'a' -> excluded
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$match": "^a" } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        r#"$match "^a": topic_a has "apple", included"#
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        r#"$match "^a": topic_b has no element starting with 'a', excluded"#
+    );
+
+    // "^d": topic_b has "dog" -> included; topic_a has none starting with 'd' -> excluded
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$match": "^d" } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        r#"$match "^d": topic_a excluded"#
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        r#"$match "^d": topic_b has "dog", included"#
+    );
+
+    // "a": both have an element containing 'a' ("banana"/"apple" for a, "cat" for b)
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$match": "a" } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        r#"$match "a": topic_a has "apple"/"banana", included"#
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        r#"$match "a": topic_b has "cat", included"#
+    );
+
+    // "^z": no element in either topic starts with 'z' -> both excluded
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$match": "^z" } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        r#"$match "^z": topic_a excluded"#
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        r#"$match "^z": topic_b excluded"#
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_all_match(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_all_match";
+    // topic_a: all elements start with 'a'
+    // topic_b: mixed — not all start with 'a'
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            (
+                "topic_a",
+                string_list_batch(10_000, &[1], &[vec!["ant", "arrow", "alpha"]]),
+            ),
+            (
+                "topic_b",
+                string_list_batch(20_000, &[2], &[vec!["cat", "dog", "ant"]]),
+            ),
+        ],
+    )
+    .await;
+
+    // "^a": topic_a all match; topic_b has "cat"/"dog" that don't -> excluded
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[!]": { "$match": "^a" } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        r#"$match "^a": topic_a all start with 'a', included"#
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        r#"$match "^a": topic_b has "cat"/"dog", excluded"#
+    );
+
+    // ".": matches any non-empty string -> all elements in both topics match
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[!]": { "$match": "." } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        r#"$match ".": topic_a included"#
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        r#"$match ".": topic_b included"#
+    );
+
+    // "^z": no element starts with 'z' -> NOT all elements match -> both excluded
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[!]": { "$match": "^z" } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        r#"$match "^z": topic_a excluded"#
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        r#"$match "^z": topic_b excluded"#
     );
 
     server.shutdown().await;

--- a/mosaicod/tests/tests/ontology_query.rs
+++ b/mosaicod/tests/tests/ontology_query.rs
@@ -10,6 +10,8 @@ use tests::{actions, common};
 
 use arrow::array::ArrayRef;
 
+/// Builds a [`RecordBatch`] with a list column (list of i64) used to test filters
+/// (equal, at least on, all) against list-typed ontology columns.
 fn int_list_batch(ts_start: i64, values: &[i64], list_test: &[Vec<i64>]) -> RecordBatch {
     assert_eq!(
         values.len(),
@@ -29,6 +31,8 @@ fn int_list_batch(ts_start: i64, values: &[i64], list_test: &[Vec<i64>]) -> Reco
 
     let timestamps: Vec<i64> = (0..values.len() as i64).map(|i| ts_start + i * 5).collect();
 
+    // Each inner Vec becomes one list entry; values are appended element by element,
+    // then append(true) closes the current list and moves to the next row.
     let mut list_builder = ListBuilder::new(Int64Builder::new()).with_field(Field::new(
         "item",
         DataType::Int64,


### PR DESCRIPTION
Add support for querying Arrow list columns stored in Parquet files using the `[i]`, `[?]` and `[!]` index specifiers. This allows writing filter expressions that target individual elements, require at least one element to match, or require all elements to satisfy a predicate.

Replace the fragile value/tag_offset pair in `OntologyField` with a plain tag: String field alongside the existing `OntologyFieldPath`. The full string representation is now reconstructed on demand via Display, removing the risk of the offset going stale if the raw string were ever mutated.

`OntologyFieldPath` and `IndexSpecifier` gain `PartialEq, Eq, Hash` and `Display` impls so that `OntologyField` can derive its own equality and hashing from the structured data rather than from a cached string.

Close #558 