### PR TITLE
refactor(mosaicod): InvalidArgument returned for invalid key in user metadata

### DIFF
--- a/mosaicod/crates/mosaicod-core/src/types/metadata_blob.rs
+++ b/mosaicod/crates/mosaicod-core/src/types/metadata_blob.rs
@@ -6,13 +6,20 @@ pub enum MetadataError {
     DeserializationError(String),
     #[error("serialization error")]
     SerializationError(String),
+    #[error("invalid json key: {0}")]
+    InvalidJsonKey(String),
 }
 
 impl error::PublicError for MetadataError {
-    /// Metadata errors will always be converted to
+    /// Metadata serialization/deserialization errors will always be converted to
     /// internal errors, since are completely handled by the platform
     fn error(&self) -> error::Error {
-        error::Error::internal(Some("marshalling failed".to_owned()))
+        match self {
+            MetadataError::InvalidJsonKey(msg) => {
+                error::Error::bad_request(format!("invalid json key: {}", msg))
+            }
+            _ => error::Error::internal(Some("marshalling failed".to_owned())),
+        }
     }
 }
 

--- a/mosaicod/crates/mosaicod-marshal/src/metadata.rs
+++ b/mosaicod/crates/mosaicod-marshal/src/metadata.rs
@@ -47,10 +47,7 @@ impl MetadataBlob for JsonMetadataBlob {
             serde_json::from_str(v).map_err(|e| Error::DeserializationError(e.to_string()))?;
 
         if let Some(invalid_key) = find_invalid_keys(&json) {
-            return Err(Error::DeserializationError(format!(
-                "Found invalid key in json: {}",
-                invalid_key
-            )));
+            return Err(Error::InvalidJsonKey(invalid_key.to_owned()));
         }
 
         Ok(JsonMetadataBlob(json))
@@ -402,10 +399,10 @@ mod tests {
 
         // Verify our custom validation error message is firing correctly
         match result {
-            Err(Error::DeserializationError(msg)) => {
-                assert_eq!(msg, "Found invalid key in json: broken--key");
+            Err(Error::InvalidJsonKey(msg)) => {
+                assert_eq!(msg, "broken--key");
             }
-            _ => panic!("Expected Error::DeserializationError with our custom validation message"),
+            _ => panic!("Expected Error::InvalidJsonKey with our custom validation message"),
         }
     }
 

--- a/mosaicod/tests/tests/sequence.rs
+++ b/mosaicod/tests/tests/sequence.rs
@@ -36,6 +36,19 @@ async fn test_sequence_create(pool: sqlx::Pool<db::DatabaseType>) -> sqlx::Resul
         tonic::Code::InvalidArgument
     );
 
+    // Check invalid key in metadata json.
+    assert_eq!(
+        actions::sequence_create(
+            &mut client,
+            "test_malformed_sequence",
+            Some(r#"{"invalid--key": "dummy"}"#)
+        )
+        .await
+        .unwrap_err()
+        .code(),
+        tonic::Code::InvalidArgument
+    );
+
     server.shutdown().await;
     Ok(())
 }

--- a/mosaicod/tests/tests/topic.rs
+++ b/mosaicod/tests/tests/topic.rs
@@ -66,6 +66,20 @@ async fn test_topic_create(pool: sqlx::Pool<db::DatabaseType>) -> sqlx::Result<(
         tonic::Code::InvalidArgument
     );
 
+    // Create topic with invalid key in metadata should give an InvalidArgument error.
+    assert_eq!(
+        actions::topic_create(
+            &mut client,
+            &session_uuid,
+            "test_sequence/my_topic",
+            Some(r#"{"invalid--key": "dummy"}"#)
+        )
+        .await
+        .unwrap_err()
+        .code(),
+        tonic::Code::InvalidArgument
+    );
+
     // Trying to create a topic inside an already finalized session should return a FailedPrecondition error.
     let batches = vec![ext::arrow::testing::dummy_batch()];
 


### PR DESCRIPTION
Closes #619 