### PR TITLE
feat(py): ros adapter checks msgtype in topic metadata first and fallabacks to ontology tag

### DIFF
--- a/mosaico-sdk-py/src/mosaicolabs/handlers/internal/topic_read_state.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/internal/topic_read_state.py
@@ -34,6 +34,7 @@ class _TopicReadState:
         self,
         topic_name: str,
         ontology_tag: str,
+        msg_count: Optional[int],
         reader: Optional[fl.FlightStreamReader],
     ):
         """
@@ -42,6 +43,7 @@ class _TopicReadState:
         Args:
             topic_name (str): The name of the topic.
             ontology_tag (str): The identifier for the ontology data type.
+            msg_count (int): The number of messages in the topic.
             reader (Optional[fl.FlightStreamReader]): The active stream reader.
 
         Raises:
@@ -53,6 +55,7 @@ class _TopicReadState:
         self.topic_name: str = topic_name
         self.reader: Optional[fl.FlightStreamReader] = reader
         self.ontology_tag: str = ontology_tag
+        self.msg_count: Optional[int] = msg_count
 
         # --- Schema Validation & Setup ---
         self.column_names: List[str] = []

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/sequence_reader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/sequence_reader.py
@@ -206,6 +206,21 @@ class SequenceDataStreamer:
                 "at the beginning of the session."
             )
 
+    @property
+    def msg_count(self) -> int:
+        """
+        The sum of all messages within each topic streamer.
+
+        Returns:
+            The sum of all messages within each topic streamer.
+        """
+
+        return sum(
+            filter(
+                None, (t_reader.msg_count for t_reader in self._topic_readers.values())
+            )
+        )
+
     # --- Iterator Protocol Implementation ---
 
     def __iter__(self) -> "SequenceDataStreamer":

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/topic_reader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/topic_reader.py
@@ -141,11 +141,13 @@ class TopicDataStreamer:
             _decode_schema_metadata(reader.schema.metadata)
         )
         ontology_tag = topic_mdata.properties.ontology_tag
+        msg_count = topic_mdata.properties.msg_count
 
         rdstate = _TopicReadState(
             topic_name=topic_name,
             reader=reader,
             ontology_tag=ontology_tag,
+            msg_count=msg_count,
         )
         return cls(
             client=client,
@@ -283,6 +285,16 @@ class TopicDataStreamer:
             The ontology tag.
         """
         return self._rdstate.ontology_tag
+
+    @property
+    def msg_count(self) -> Optional[int]:
+        """
+        The number of messages associated with this streamer.
+
+        Returns:
+            The number of messages. None if an error occurred during message count retrieval
+        """
+        return self._rdstate.msg_count
 
     def __iter__(self) -> "TopicDataStreamer":
         """Returns self as iterator."""

--- a/mosaico-sdk-py/src/mosaicolabs/platform/metadata.py
+++ b/mosaico-sdk-py/src/mosaicolabs/platform/metadata.py
@@ -8,7 +8,7 @@ PyArrow Flight protocol. It also handles Mosaico-specific namespacing.
 
 import json
 from dataclasses import dataclass
-from typing import Any, ClassVar, Dict, Literal
+from typing import Any, ClassVar, Dict, Literal, Optional
 
 from typing_extensions import Self
 
@@ -111,7 +111,7 @@ class TopicMetadata(PlatformMetadata):
 
     Attributes:
         context (str): The context type (must be "topic").
-        properties (Properties): System-level properties (ontology tag, format).
+        properties (Properties): System-level properties (ontology tag, msg_count, format).
         user_metadata (dict): A dictionary of user-provided metadata keys/values.
     """
 
@@ -120,12 +120,14 @@ class TopicMetadata(PlatformMetadata):
     @dataclass(slots=True)
     class Properties:
         ontology_tag: str
+        msg_count: Optional[int]
         serialization_format: SerializationFormat
 
         @classmethod
         def _from_dict(cls, data: dict):
             return cls(
                 ontology_tag=data["ontology_tag"],
+                msg_count=data.get("message_count"),
                 serialization_format=SerializationFormat(data["serialization_format"]),
             )
 

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/__init__.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/__init__.py
@@ -12,7 +12,11 @@ from .injector import (
     RosbagInjector as RosbagInjector,
     ROSInjectionConfig as ROSInjectionConfig,
 )
-from .loader import LoaderErrorPolicy as LoaderErrorPolicy, ROSLoader as ROSLoader
+from .loader import (
+    LoaderErrorPolicy as LoaderErrorPolicy,
+    MosaicoLoader as MosaicoLoader,
+    ROSLoader as ROSLoader,
+)
 from .registry import ROSTypeRegistry as ROSTypeRegistry
 from .ros_bridge import (
     ROSBridge as ROSBridge,

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/helpers.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/helpers.py
@@ -4,10 +4,17 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 from rosbags.interfaces import TopicInfo
 
+from mosaicolabs import SequenceHandler
 from mosaicolabs.logging_config import get_logger
 
 # Set the hierarchical logger
 logger = get_logger(__name__)
+
+
+def validate_sequence(seq_handler: Optional[SequenceHandler]) -> SequenceHandler:
+    if seq_handler is None:
+        raise (ValueError("Your requested sequence could not be found!"))
+    return seq_handler
 
 
 def _to_dict(message: Any) -> Any:

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
@@ -772,15 +772,15 @@ class MosaicoLoader:
         adapter = None
         resolved_rosmsg_type = None
 
-        # Try looking for adapter using msgtype (may still not be adapted)
+        # Try looking for adapter using msgtype
         if declared_rosmsg_type is not None:
             adapter = ROSBridge.get_default_adapter(declared_rosmsg_type)
             resolved_rosmsg_type = declared_rosmsg_type
 
-        # If here adapter has not been found and therefore declared_rosmsg_type
-        # needs to be overriden -> Fallaback using the ontology tag from topic handler and get
-        # its default msgtype (if ontology is adapted otherwise mantain what has already been found)
         if not adapter:
+            # If here adapter has not been found -> Fallback to adapter associated to
+            # the ontology tag and get its default msgtype (if ontology is
+            # adapted, otherwise mantain what has already been found)
             adapter = ROSBridge.get_default_mosaico_adapter(t_handler.ontology_tag)
             resolved_rosmsg_type = (
                 adapter.get_default_ros_msg() if adapter else resolved_rosmsg_type
@@ -797,11 +797,23 @@ class MosaicoLoader:
 
         1. Fetches the :class:`SequenceHandler` for the configured sequence name
            and validates it exists.
-        2. Applies the topic filter via :func:`_filter_topics_from_list`.
-        3. Clips ``start_timestamp_ns`` / ``end_timestamp_ns`` to the sequence bounds,
+        2. Clips ``start_timestamp_ns`` / ``end_timestamp_ns`` to the sequence bounds,
            logging a warning if clipping occurs.
-        4. Creates the :class:`SequenceDataStreamer` that will be returned by
-           :meth:`__iter__`.
+        3. Applies the topic filter via :func:`_filter_topics_from_list`.
+        4. For each matched topic, extracts its Mosaico adapter via
+           :meth:`_resolve_topic_adapter`. Adapter is first looked up using
+           ``_ros_`` metadata, falling back to adapter associated to the ontology
+           tag. Afterward, msgtype is extracted from found adapter if metadata did
+           not hold this information.
+           Topics that pass all checks are accepted, together with their extracted
+           ROS metadata and adapter, cached in ``_topic_ros_metadata`` and
+           ``_topic_cached_adapters`` respectively. On the other hand, a topic may
+           be rejected because:
+            - adapter is not found
+            - malformed metadata
+            - msgtype is not present within ROS typestore
+        5. Creates the :class:`SequenceDataStreamer` over the accepted topics, to be
+           returned by :meth:`__iter__`.
 
         """
         if self.seq_handler is not None:

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
@@ -25,7 +25,12 @@ from mosaicolabs import (
 from mosaicolabs.logging_config import get_logger
 
 from .adapter_base import ROSAdapterBase
-from .helpers import _filter_topics_from_dict, _filter_topics_from_list, _to_dict
+from .helpers import (
+    _filter_topics_from_dict,
+    _filter_topics_from_list,
+    _to_dict,
+    validate_sequence,
+)
 from .registry import ROSTypeRegistry
 from .ros_bridge import ROSBridge, ROSMessage
 
@@ -714,14 +719,6 @@ class MosaicoLoader:
             str, type[ROSAdapterBase]
         ] = {}  # Dictionary containing a map from moisaco accepted topics to mosaico adapter
 
-    def validate_sequence(self):
-        if self.seq_handler is None:
-            raise (
-                ValueError(
-                    f"Your requested sequence '{self.sequence_name}' could not be found!"
-                )
-            )
-
     def _extract_declared_rosmsg_type(self, t_handler: TopicHandler) -> Optional[str]:
         """
         Reads and validates the ``_ros_.msgtype`` metadata field, if present.
@@ -815,7 +812,14 @@ class MosaicoLoader:
             sequence_name=self.sequence_name
         )
 
-        self.validate_sequence()
+        try:
+            self.seq_handler = validate_sequence(self.seq_handler)
+        except ValueError:
+            raise (
+                ValueError(
+                    f"Your requested sequence {self.sequence_name} could not be found!"
+                )
+            )
 
         self._resolved_topics = self.seq_handler.topics
 
@@ -914,10 +918,6 @@ class MosaicoLoader:
         Returns the total number of messages for the given topic, or for all
         resolved topics combined.
 
-        Note:
-            This performs a full traversal of each topic's data streamer to produce
-            the count, which may be slow for large sequences.
-
         Args:
             topic: If provided, count messages for that specific topic only.
                 If ``None``, sum across all resolved topics.
@@ -925,15 +925,24 @@ class MosaicoLoader:
         Returns:
             The total message count.
         """
-        s_handler = self._resolve_sequence()
+        self._resolve_sequence()
+
+        if not self.streamer:
+            raise Exception(
+                "Impossible to start streaming: SequenceDataStreamer is not initialised. Did you forget calling _resolve_sequence()?"
+            )
 
         topics_to_count = [topic] if topic else self._accepted_topics
 
-        total_msg_count = 0
-        for t in topics_to_count:
-            t_handler = s_handler.get_topic_handler(t)
-
-            total_msg_count += sum(1 for _ in t_handler.get_data_streamer())
+        total_msg_count = sum(
+            filter(
+                None,
+                (
+                    self.streamer._topic_readers[topic].msg_count
+                    for topic in topics_to_count
+                ),
+            )
+        )
 
         return total_msg_count
 

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
@@ -16,9 +16,15 @@ from rosbags.interfaces import Connection, TopicInfo
 from rosbags.typesys import Stores, get_typestore
 from rosbags.typesys.store import Typestore
 
-from mosaicolabs import MosaicoClient, SequenceDataStreamer, SequenceHandler
+from mosaicolabs import (
+    MosaicoClient,
+    SequenceDataStreamer,
+    SequenceHandler,
+    TopicHandler,
+)
 from mosaicolabs.logging_config import get_logger
 
+from .adapter_base import ROSAdapterBase
 from .helpers import _filter_topics_from_dict, _filter_topics_from_list, _to_dict
 from .registry import ROSTypeRegistry
 from .ros_bridge import ROSBridge, ROSMessage
@@ -36,6 +42,7 @@ class TopicStatus(Enum):
         FILTERED: Enum specifying the Topic has been rejected since user provided a filter that excludes the topic.
         NOT_ADAPTED: Enum specifying the Topic has been rejected since it has no Mosaico adapter.
         NOT_IN_TYPESTORE: Enum specifying the Topic has been rejected since it is not present in ROS typestore.
+        MALFORMED_METADATA: Enum specifying the Topic has been rejected since its ``_ros_`` metadata is malformed.
     """
 
     ACCEPTED = "Accepted"
@@ -50,6 +57,9 @@ class TopicStatus(Enum):
     NOT_IN_TYPESTORE = "Not in typestore"
     """ Status indicating the Topic has been rejected since it is not present in ROS typestore """
 
+    MALFORMED_METADATA = "Malformed metadata"
+    """ Status indicating the Topic has been rejected since its '_ros_' metadata is malformed """
+
     def display_color(self) -> str:
         """Returns the Rich color string used to render this status in the progress UI."""
         _colors = {
@@ -57,6 +67,7 @@ class TopicStatus(Enum):
             TopicStatus.FILTERED: "bright_yellow",
             TopicStatus.NOT_ADAPTED: "dark_orange",
             TopicStatus.NOT_IN_TYPESTORE: "orange1",
+            TopicStatus.MALFORMED_METADATA: "red1",
         }
         return _colors.get(self, "bright_red")
 
@@ -658,9 +669,9 @@ class MosaicoLoader:
         m_client: MosaicoClient,
         typestore: Typestore,
         sequence_name: str,
-        topics: Optional[List[str]],
-        start_timestamp_ns: Optional[int],
-        end_timestamp_ns: Optional[int],
+        topics: Optional[List[str]] = None,
+        start_timestamp_ns: Optional[int] = None,
+        end_timestamp_ns: Optional[int] = None,
     ):
 
         self.client = m_client
@@ -689,11 +700,19 @@ class MosaicoLoader:
             str
         ] = []  # The topics whose message type is not present within the typestore
 
+        self._malformed_metadata_topics: list[
+            str
+        ] = []  # The topics whose '_ros_' metadata is malformed
+
         self._filtered_topics: list[str] = []  # The topics filtered by user
 
         self._topic_ros_metadata: dict[
             str, Any
-        ] = {}  # Dictionary containing ros specific metadata extracted from accepted Mosaico sequence topics
+        ] = {}  # Dictionary containing a map from moisaco accepted topics to ros specific metadata (extracted from Mosaico topics)
+
+        self._topic_cached_adapters: dict[
+            str, type[ROSAdapterBase]
+        ] = {}  # Dictionary containing a map from moisaco accepted topics to mosaico adapter
 
     def validate_sequence(self):
         if self.seq_handler is None:
@@ -702,6 +721,75 @@ class MosaicoLoader:
                     f"Your requested sequence '{self.sequence_name}' could not be found!"
                 )
             )
+
+    def _extract_declared_rosmsg_type(self, t_handler: TopicHandler) -> Optional[str]:
+        """
+        Reads and validates the ``_ros_.msgtype`` metadata field, if present.
+
+        Args:
+            t_handler: The topic handler whose metadata should be inspected.
+
+        Returns:
+            The declared ROS msgtype string, or ``None`` if the topic carries no
+            ``_ros_`` metadata (or no ``msgtype`` within it).
+
+        Raise: TypeError when the topic's ``_ros_`` metadata carries a non-string ``msgtype`` (malformed
+            metadata)
+        """
+        declared_rosmsg_type = (t_handler.user_metadata.get("_ros_") or {}).get(
+            "msgtype"
+        )
+
+        if declared_rosmsg_type is not None and not isinstance(
+            declared_rosmsg_type, str
+        ):
+            raise TypeError(
+                f"Topic {t_handler.name} contains msgtype within metadata but it has unexpected type. Expected {str.__name__} but got {type(declared_rosmsg_type).__name__}"
+            )
+
+        return declared_rosmsg_type
+
+    def _resolve_topic_adapter(
+        self, t_handler: TopicHandler
+    ) -> Tuple[Optional[type[ROSAdapterBase]], Optional[str]]:
+        """
+        Resolves a topic's Mosaico adapter and the ROS msgtype used to validate it
+        against the typestore.
+
+        The adapter is looked up first using the rosmsg_type stored in the topic's
+        ``_ros_`` metadata (if present), falling back to the default adapter
+        registered for the topic's ontology tag.
+
+        Args:
+            t_handler: The topic handler whose adapter should be resolved.
+
+        Returns:
+            A ``(adapter, rosmsg_type)`` pair.
+
+        Raise: TypeError when the topic's ``_ros_`` metadata carries a non-string ``msgtype`` (malformed
+            metadata)
+
+        """
+        declared_rosmsg_type = self._extract_declared_rosmsg_type(t_handler)
+
+        adapter = None
+        resolved_rosmsg_type = None
+
+        # Try looking for adapter using msgtype (may still not be adapted)
+        if declared_rosmsg_type is not None:
+            adapter = ROSBridge.get_default_adapter(declared_rosmsg_type)
+            resolved_rosmsg_type = declared_rosmsg_type
+
+        # If here adapter has not been found and therefore declared_rosmsg_type
+        # needs to be overriden -> Fallaback using the ontology tag from topic handler and get
+        # its default msgtype (if ontology is adapted otherwise mantain what has already been found)
+        if not adapter:
+            adapter = ROSBridge.get_default_mosaico_adapter(t_handler.ontology_tag)
+            resolved_rosmsg_type = (
+                adapter.get_default_ros_msg() if adapter else resolved_rosmsg_type
+            )
+
+        return adapter, resolved_rosmsg_type
 
     def _resolve_sequence(self) -> SequenceHandler:
         """
@@ -767,10 +855,18 @@ class MosaicoLoader:
                 self._filtered_topics.append(t_name)
                 continue
 
-            # 2) Mosaico-adapted topic
             t_handler = self.seq_handler.get_topic_handler(t_name)
 
-            adapter = ROSBridge.get_default_mosaico_adapter(t_handler.ontology_tag)
+            # 2) Find Mosaico topic's adapter using:
+            #     - rosmsg_type got from topic metadata
+            #     - topic ontology (falling back to default adapter)
+
+            # Extract rosmsg_type from topic_handler metadata (if available) and ensure that it is a string
+            try:
+                adapter, rosmsg_type = self._resolve_topic_adapter(t_handler)
+            except TypeError:
+                self._malformed_metadata_topics.append(t_name)
+                continue
 
             if not adapter:
                 logger.warning(
@@ -779,11 +875,8 @@ class MosaicoLoader:
                 self._not_adapted_topics.append(t_name)
                 continue
 
-            # 3) ros_msgtype not present within typestore
-            try:  # rosmsg_type can be through metadata
-                rosmsg_type = t_handler.user_metadata["_ros_"]["msgtype"]
-            except KeyError:
-                # Or obtained from adapter through default
+            # 3) check that rosmsg_type (either from metadata or default adapter) is present within typestore
+            if not rosmsg_type:
                 rosmsg_type = adapter.get_default_ros_msg()
 
             if self.typestore.types.get(rosmsg_type) is None:
@@ -799,6 +892,7 @@ class MosaicoLoader:
             self._topic_ros_metadata.update(
                 {t_name: t_handler.user_metadata.get("_ros_")}
             )
+            self._topic_cached_adapters.update({t_name: adapter})
 
         if not self._accepted_topics:
             raise RuntimeError(
@@ -951,11 +1045,15 @@ class MosaicoLoader:
         for t_unregistered in self._unregistered_topics:
             rejected_topics.append((t_unregistered, TopicStatus.NOT_IN_TYPESTORE))
 
+        # Metadata malformed
+        for t_unregistered in self._malformed_metadata_topics:
+            rejected_topics.append((t_unregistered, TopicStatus.MALFORMED_METADATA))
+
         return rejected_topics
 
     # --- Core Logic ---
 
-    def resolve_ros_msgtype(self, topic_name: str) -> Optional[str]:
+    def resolve_rosmsg_type(self, topic_name: str) -> Optional[str]:
         """
         Returns the original ROS message type for a topic stored in Mosaico.
 
@@ -974,8 +1072,26 @@ class MosaicoLoader:
             unknown, the ``_ros_`` metadata block is absent, or the ``msgtype``
             key is missing from that block.
         """
+        self._resolve_sequence()
 
         return (self._topic_ros_metadata.get(topic_name) or {}).get("msgtype")
+
+    def resolve_adapter(self, topic_name: str) -> Optional[type[ROSAdapterBase]]:
+        """
+        Returns the resolve adapter for accepted topic.
+
+        Args:
+            topic_name: The topic name whose adapter should be resolved.
+                Must be one of the accepted topics produced by :meth:`_resolve_sequence`.
+
+        Returns:
+            The Mosaico->ROS adapter type obtained during :meth:`_resolve_sequence`.
+            Adapter is resolved through the rosmsg_type within Mosaico topic metadata
+            (if available) or getting the default adapter associated to the topic's ontology.
+        """
+        self._resolve_sequence()
+
+        return self._topic_cached_adapters.get(topic_name)
 
     def __iter__(self):
         self._resolve_sequence()

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
@@ -329,7 +329,6 @@ class ROSSequenceExtractor:
 
         # --- Resolve Adapter Check ---
         # For each Mosaico type Message find its adapter
-        mosaico_type = ms_msg.ontology_tag()
         adapter = self.mosaico_loader.resolve_adapter(t_name)
 
         if adapter is None:
@@ -343,7 +342,7 @@ class ROSSequenceExtractor:
         except TypeError as e:
             self.ignored_topics.add(t_name)
             logger.warning(
-                f"Could not encode to ros '{mosaico_type}' type because: {e}. Skipping the topic associated to this message"
+                f"Could not encode to ros '{ms_msg.ontology_tag()}' type because: {e}. Skipping the topic associated to this message"
             )
             ui.update_status(t_name, "Failed encoding", style="yellow")
             ui.advance_global()

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
@@ -29,7 +29,6 @@ from rosbags.typesys.store import Typestore
 
 from mosaicolabs import Message, MosaicoClient
 from mosaicolabs.logging_config import get_logger, setup_sdk_logging
-from mosaicolabs.ros_bridge import ROSBridge
 from mosaicolabs.ros_bridge.loader import MosaicoLoader, ProgressManager
 from mosaicolabs.ros_bridge.qos import get_qos_for_topic
 from mosaicolabs.ros_bridge.registry import ROSTypeRegistry
@@ -331,13 +330,13 @@ class ROSSequenceExtractor:
         # --- Resolve Adapter Check ---
         # For each Mosaico type Message find its adapter
         mosaico_type = ms_msg.ontology_tag()
-        adapter = ROSBridge.get_default_mosaico_adapter(mosaico_type)
+        adapter = self.mosaico_loader.resolve_adapter(t_name)
 
         if adapter is None:
             return  # This should not happen since MosaicoLoader should filter unsupported message types
 
         # --- Translate Check ---
-        ros_msg_type = self.mosaico_loader.resolve_ros_msgtype(t_name)
+        ros_msg_type = self.mosaico_loader.resolve_rosmsg_type(t_name)
 
         try:
             ros_msg = adapter.to_ros(ms_msg, self.typestore, ros_msg_type)

--- a/mosaico-sdk-py/src/testing/integration/ros_bridge/test_mosaico_loader.py
+++ b/mosaico-sdk-py/src/testing/integration/ros_bridge/test_mosaico_loader.py
@@ -1,0 +1,157 @@
+import pytest
+from rosbags.typesys import Stores, get_typestore
+
+from mosaicolabs import Pose, Serializable, SessionLevelErrorPolicy
+from mosaicolabs.ros_bridge import MosaicoLoader
+
+
+def test_valid_msgtype(mosaico_client):
+    ros_distro = Stores.ROS2_JAZZY
+    ros_sequence_name = "ros-sequence-with-metadata"
+    ros_topic_name = "/car/pose"
+    topic_with_ros_metadata = {"_ros_": {"msgtype": "geometry_msgs/msg/PoseStamped"}}
+
+    with mosaico_client:
+        # Writing topic
+        with mosaico_client.sequence_create(
+            ros_sequence_name, {}, SessionLevelErrorPolicy.Delete
+        ) as s_writer:
+            s_writer.topic_create(ros_topic_name, topic_with_ros_metadata, Pose)
+
+        t_handler = mosaico_client.topic_handler(ros_sequence_name, ros_topic_name)
+
+        # Reading topic
+        mosaico_loader = MosaicoLoader(
+            mosaico_client, get_typestore(ros_distro), ros_sequence_name
+        )
+        adapter, rosmsg_type = mosaico_loader._resolve_topic_adapter(t_handler)
+
+        assert adapter and adapter.ontology_data_type() is Pose
+        assert (
+            rosmsg_type is not None and rosmsg_type == "geometry_msgs/msg/PoseStamped"
+        )
+
+        mosaico_client.sequence_delete(ros_sequence_name)
+
+
+def test_invalid_msgtype(mosaico_client):
+    ros_distro = Stores.ROS2_JAZZY
+    ros_sequence_name = "ros-sequence-with-wrong-metadata-"
+    ros_topic_name = "/car/pose"
+    topic_with_ros_metadata = {"_ros_": {"msgtype": 1234}}
+
+    with mosaico_client:
+        # Writing topic
+        with mosaico_client.sequence_create(
+            ros_sequence_name, {}, SessionLevelErrorPolicy.Delete
+        ) as s_writer:
+            s_writer.topic_create(ros_topic_name, topic_with_ros_metadata, Pose)
+
+        # Reading topic
+        t_handler = mosaico_client.topic_handler(ros_sequence_name, ros_topic_name)
+
+        mosaico_loader = MosaicoLoader(
+            mosaico_client, get_typestore(ros_distro), ros_sequence_name
+        )
+
+        with pytest.raises(
+            TypeError,
+            match=f"Topic {t_handler.name} contains msgtype within metadata but it has unexpected type.",
+        ):
+            mosaico_loader._resolve_topic_adapter(t_handler)
+
+        mosaico_client.sequence_delete(ros_sequence_name)
+
+
+def test_no_msgtype_fallback_to_default_adapter(mosaico_client):
+    ros_distro = Stores.ROS2_JAZZY
+    ros_sequence_name = "ros-sequence-no-msgtype-fallabck-to-default-adapter"
+    ros_topic_name = "/car/pose"
+    topic_with_ros_metadata = {}
+
+    with mosaico_client:
+        # Writing topic
+        with mosaico_client.sequence_create(
+            ros_sequence_name, {}, SessionLevelErrorPolicy.Delete
+        ) as s_writer:
+            s_writer.topic_create(ros_topic_name, topic_with_ros_metadata, Pose)
+
+        # Reading topic
+        t_handler = mosaico_client.topic_handler(ros_sequence_name, ros_topic_name)
+
+        mosaico_loader = MosaicoLoader(
+            mosaico_client, get_typestore(ros_distro), ros_sequence_name
+        )
+
+        adapter, rosmsg_type = mosaico_loader._resolve_topic_adapter(t_handler)
+
+        assert adapter and adapter.ontology_data_type() is Pose
+        assert (
+            rosmsg_type is not None and rosmsg_type == adapter.get_default_ros_msg()
+        )  # Here you need to get the default since there are no info on topic's metadata
+
+        mosaico_client.sequence_delete(ros_sequence_name)
+
+
+class NotAdaptedClass(Serializable): ...
+
+
+def test_no_adapter_available(mosaico_client):
+
+    ros_distro = Stores.ROS2_JAZZY
+    ros_sequence_name = "ros-sequence-without-adapter"
+    ros_topic_name = "/car/pose"
+    topic_with_ros_metadata = {"_ros_": {"msgtype": "not_adapted_ontology"}}
+
+    with mosaico_client:
+        # Writing topic
+        with mosaico_client.sequence_create(
+            ros_sequence_name, {}, SessionLevelErrorPolicy.Delete
+        ) as s_writer:
+            s_writer.topic_create(
+                ros_topic_name, topic_with_ros_metadata, NotAdaptedClass
+            )  # Serializable has no adapter!
+
+        # Reading topic
+        t_handler = mosaico_client.topic_handler(ros_sequence_name, ros_topic_name)
+
+        mosaico_loader = MosaicoLoader(
+            mosaico_client, get_typestore(ros_distro), ros_sequence_name
+        )
+
+        adapter, rosmsg_type = mosaico_loader._resolve_topic_adapter(t_handler)
+
+        assert adapter is None
+        assert rosmsg_type == "not_adapted_ontology"
+
+        mosaico_client.sequence_delete(ros_sequence_name)
+
+
+def test_not_adapter_msgtype_fallack_to_default_adapter(
+    mosaico_client,
+):
+    ros_distro = Stores.ROS2_JAZZY
+    ros_sequence_name = "ros-sequence-not-adapter-msgtype-fallack-to-default-adapter"
+    ros_topic_name = "/car/pose"
+    topic_with_ros_metadata = {"_ros_": {"msgtype": "not_existing"}}
+
+    with mosaico_client:
+        with mosaico_client.sequence_create(
+            ros_sequence_name, {}, SessionLevelErrorPolicy.Delete
+        ) as s_writer:
+            s_writer.topic_create(ros_topic_name, topic_with_ros_metadata, Pose)
+
+        t_handler = mosaico_client.topic_handler(ros_sequence_name, ros_topic_name)
+
+        mosaico_loader = MosaicoLoader(
+            mosaico_client, get_typestore(ros_distro), ros_sequence_name
+        )
+
+        adapter, rosmsg_type = mosaico_loader._resolve_topic_adapter(t_handler)
+
+        assert adapter and adapter.ontology_data_type() is Pose
+        assert (
+            rosmsg_type is not None and rosmsg_type == adapter.get_default_ros_msg()
+        )  # Here you need to get the default since topic metadata hint to a non existing adapter
+
+        mosaico_client.sequence_delete(ros_sequence_name)

--- a/mosaico-sdk-py/src/testing/integration/ros_bridge/test_mosaico_loader.py
+++ b/mosaico-sdk-py/src/testing/integration/ros_bridge/test_mosaico_loader.py
@@ -7,7 +7,7 @@ from mosaicolabs.ros_bridge import MosaicoLoader
 
 def test_valid_msgtype(mosaico_client):
     ros_distro = Stores.ROS2_JAZZY
-    ros_sequence_name = "ros-sequence-with-metadata"
+    ros_sequence_name = "ros-sequence-valid-msgtype"
     ros_topic_name = "/car/pose"
     topic_with_ros_metadata = {"_ros_": {"msgtype": "geometry_msgs/msg/PoseStamped"}}
 
@@ -36,7 +36,7 @@ def test_valid_msgtype(mosaico_client):
 
 def test_invalid_msgtype(mosaico_client):
     ros_distro = Stores.ROS2_JAZZY
-    ros_sequence_name = "ros-sequence-with-wrong-metadata-"
+    ros_sequence_name = "ros-sequence-invalid-msgtype"
     ros_topic_name = "/car/pose"
     topic_with_ros_metadata = {"_ros_": {"msgtype": 1234}}
 
@@ -99,7 +99,7 @@ class NotAdaptedClass(Serializable): ...
 def test_no_adapter_available(mosaico_client):
 
     ros_distro = Stores.ROS2_JAZZY
-    ros_sequence_name = "ros-sequence-without-adapter"
+    ros_sequence_name = "ros-sequence-no-adapter-available"
     ros_topic_name = "/car/pose"
     topic_with_ros_metadata = {"_ros_": {"msgtype": "not_adapted_ontology"}}
 
@@ -127,11 +127,11 @@ def test_no_adapter_available(mosaico_client):
         mosaico_client.sequence_delete(ros_sequence_name)
 
 
-def test_not_adapter_msgtype_fallack_to_default_adapter(
+def test_not_adapted_msgtype_fallack_to_default_adapter(
     mosaico_client,
 ):
     ros_distro = Stores.ROS2_JAZZY
-    ros_sequence_name = "ros-sequence-not-adapter-msgtype-fallack-to-default-adapter"
+    ros_sequence_name = "ros-sequence-not-adapted-msgtype-fallack-to-default-adapter"
     ros_topic_name = "/car/pose"
     topic_with_ros_metadata = {"_ros_": {"msgtype": "not-adapted"}}
 

--- a/mosaico-sdk-py/src/testing/integration/ros_bridge/test_mosaico_loader.py
+++ b/mosaico-sdk-py/src/testing/integration/ros_bridge/test_mosaico_loader.py
@@ -133,7 +133,7 @@ def test_not_adapter_msgtype_fallack_to_default_adapter(
     ros_distro = Stores.ROS2_JAZZY
     ros_sequence_name = "ros-sequence-not-adapter-msgtype-fallack-to-default-adapter"
     ros_topic_name = "/car/pose"
-    topic_with_ros_metadata = {"_ros_": {"msgtype": "not_existing"}}
+    topic_with_ros_metadata = {"_ros_": {"msgtype": "not-adapted"}}
 
     with mosaico_client:
         with mosaico_client.sequence_create(
@@ -152,6 +152,6 @@ def test_not_adapter_msgtype_fallack_to_default_adapter(
         assert adapter and adapter.ontology_data_type() is Pose
         assert (
             rosmsg_type is not None and rosmsg_type == adapter.get_default_ros_msg()
-        )  # Here you need to get the default since topic metadata hint to a non existing adapter
+        )  # Here you need to get the default since topic metadata hints to a non existing adapter but the ontology tag is adapted and can fallback to default
 
         mosaico_client.sequence_delete(ros_sequence_name)

--- a/mosaico-sdk-py/src/testing/integration/test_endpoints.py
+++ b/mosaico-sdk-py/src/testing/integration/test_endpoints.py
@@ -217,3 +217,33 @@ def test_topic_streamer_manifest_timestamps(
 
     # free resources
     mosaico_client.close()
+
+
+def test_msg_count(
+    mosaico_client: MosaicoClient,
+    inject_synthetic_sequence,  # Ensure the data are available on the data platform
+):
+    """
+    Test that the sequence and topic streamer message count is coherent wrt the loaded data for each topic.
+    """
+
+    total_topics_msg_count = (
+        0  # usefull to compare later with SequenceDataStreamer.msg_count
+    )
+
+    for topic in topic_list:
+        t_handler = mosaico_client.topic_handler(UPLOADED_SEQUENCE_NAME, topic)
+
+        assert t_handler is not None
+
+        current_topic_msg_count = t_handler.get_data_streamer().msg_count
+        assert current_topic_msg_count is not None
+        assert current_topic_msg_count == 25
+
+        total_topics_msg_count += current_topic_msg_count
+
+    s_handler = mosaico_client.sequence_handler(UPLOADED_SEQUENCE_NAME)
+    assert s_handler is not None
+    assert s_handler.get_data_streamer().msg_count == total_topics_msg_count
+
+    mosaico_client.close()


### PR DESCRIPTION
Fixes #597 and integrates changes to read topic message count from `do_get`