### PR TITLE
fix(scripts): dev_env script fails

### DIFF
--- a/scripts/dev_env
+++ b/scripts/dev_env
@@ -225,7 +225,7 @@ EOF
     fi
 
     title "running" "." ${BLUE}
-    "./target/$MOSAICOD_BUILD_TARGET/mosaicod" run \
+    "./target/$MOSAICOD_BUILD_TARGET/mosaicod" server \
       --port 6276 ${MOSAICOD_OPTS}
 
     MOSAICOD_PID=$!


### PR DESCRIPTION
Now dev_env use mosaicod server insted of run.

Close #651 