### PR TITLE
feat(mosaicod): add outside([a, b]) operator 

### DIFF
--- a/mosaicod/crates/mosaicod-db/src/sql/pg_queries/builders.rs
+++ b/mosaicod/crates/mosaicod-db/src/sql/pg_queries/builders.rs
@@ -212,6 +212,20 @@ impl query::CompileClause for ChunkQueryBuilder {
                 query::CompiledClause::new(build_clause(clause, &vmin), vec![vmin, vmax])
             }
 
+            query::Op::Outside(range) => {
+                let vmin = range.min.into();
+                let vmax = range.max.into();
+                let pmin = self.consume_placeholder();
+                let pmax = self.consume_placeholder();
+                let column_name = column_table_name();
+
+                let clause = format!(
+                    "{column_name} = {field} AND (__stats__.min_value < {pmin} OR __stats__.max_value > {pmax})"
+                );
+
+                query::CompiledClause::new(build_clause(clause, &vmin), vec![vmin, vmax])
+            }
+
             query::Op::In(items) => {
                 let values: Vec<query::Value> = items.into_iter().map(Into::into).collect();
 

--- a/mosaicod/crates/mosaicod-db/src/sql/pg_queries/compilers.rs
+++ b/mosaicod/crates/mosaicod-db/src/sql/pg_queries/compilers.rs
@@ -108,6 +108,17 @@ impl query::CompileClause for SqlQueryCompiler {
 
                 query::CompiledClause::new(clause, vec![min, max])
             }
+            query::Op::Outside(range) => {
+                let min: query::Value = range.min.into();
+                let max: query::Value = range.max.into();
+
+                let pmin = self.consume_placeholder();
+                let pmax = self.consume_placeholder();
+
+                let clause = format!("(({field} < {pmin}) OR ({field} > {pmax}))");
+
+                query::CompiledClause::new(clause, vec![min, max])
+            }
             query::Op::In(items) => {
                 if items.is_empty() {
                     return Err(query::Error::empty_in(field.to_owned()));
@@ -277,6 +288,21 @@ mod internal {
                     query::CompiledClause::new(
                         format!(
                             "jsonb_path_exists({}, '{} ? (@ >= $min && @ <= $max)', jsonb_build_object('min', {}, 'max', {}))",
+                            self.field, field, pmin, pmax
+                        ),
+                        vec![min, max],
+                    )
+                }
+                query::Op::Outside(range) => {
+                    let min: query::Value = range.min.into();
+                    let max: query::Value = range.max.into();
+
+                    let pmin = self.consume_placeholder();
+                    let pmax = self.consume_placeholder();
+
+                    query::CompiledClause::new(
+                        format!(
+                            "jsonb_path_exists({}, '{} ? (@ < $min || @ > $max)', jsonb_build_object('min', {}, 'max', {}))",
                             self.field, field, pmin, pmax
                         ),
                         vec![min, max],

--- a/mosaicod/crates/mosaicod-marshal/src/query.rs
+++ b/mosaicod/crates/mosaicod-marshal/src/query.rs
@@ -94,6 +94,8 @@ enum Op {
     In(Vec<Value>),
     #[serde(rename = "$match")]
     Match(Value),
+    #[serde(rename = "$outside")]
+    Outside([Value; 2]),
 }
 
 impl TryInto<query::Op<query::Text>> for Op {
@@ -108,6 +110,7 @@ impl TryInto<query::Op<query::Text>> for Op {
             Op::Lt(_) => return Err(query::OpError::UnsupportedOperation),
             Op::Gt(_) => return Err(query::OpError::UnsupportedOperation),
             Op::Between(_) => return Err(query::OpError::UnsupportedOperation),
+            Op::Outside(_) => return Err(query::OpError::UnsupportedOperation),
             Op::Ex => query::Op::Ex,
             Op::Nex => query::Op::Nex,
             Op::In(vec) => query::Op::In(
@@ -135,6 +138,9 @@ impl TryInto<query::Op<query::Timestamp>> for Op {
             Op::Between([min, max]) => {
                 query::Op::Between(query::Range::try_new(min.try_into()?, max.try_into()?)?)
             }
+            Op::Outside([min, max]) => {
+                query::Op::Outside(query::Range::try_new(min.try_into()?, max.try_into()?)?)
+            }
             Op::In(vec) => query::Op::In(
                 vec.into_iter()
                     .map(|v| v.try_into())
@@ -159,6 +165,9 @@ impl TryInto<query::Op<query::Value>> for Op {
             Op::Nex => query::Op::Nex,
             Op::Between([min, max]) => {
                 query::Op::Between(query::Range::try_new(min.into(), max.into())?)
+            }
+            Op::Outside([min, max]) => {
+                query::Op::Outside(query::Range::try_new(min.into(), max.into())?)
             }
             Op::In(vec) => query::Op::In(vec.into_iter().map(Into::into).collect()),
             Op::Match(v) => query::Op::Match(v.into()),

--- a/mosaicod/crates/mosaicod-query/src/filter.rs
+++ b/mosaicod/crates/mosaicod-query/src/filter.rs
@@ -542,12 +542,15 @@ pub enum Op<T> {
     Ex,
     /// Not exists
     Nex,
-    /// In between a two value range [a, b] with a >= b
+    /// In between a two value range [a, b] with a <= b
     Between(Range<T>),
     /// Found in a set
     In(Vec<T>),
     /// Matches a certain expression
     Match(T),
+    /// Outside a two value range [a, b], the strict complement of `Between`:
+    /// v < a or v > b, with a <= b
+    Outside(Range<T>),
 }
 
 impl<T> Op<T>
@@ -565,6 +568,7 @@ where
             Op::Ex => true,
             Op::Nex => true,
             Op::Between(range) => range.min.support_ordering(),
+            Op::Outside(range) => range.min.support_ordering(),
             // If no elements are provided the operation is unsupported
             // (cabba) TODO: check if there is a way to access these methods
             // directly from T

--- a/mosaicod/crates/mosaicod-query/src/timeseries.rs
+++ b/mosaicod/crates/mosaicod-query/src/timeseries.rs
@@ -366,6 +366,11 @@ fn scalar_op_to_df_expr<V: Into<Value>>(expr: Expr, op: Op<V>) -> Result<Option<
             let vmax = value_to_df_expr(range.max.into());
             expr.clone().gt_eq(vmin).and(expr.lt_eq(vmax))
         }
+        Op::Outside(range) => {
+            let vmin = value_to_df_expr(range.min.into());
+            let vmax = value_to_df_expr(range.max.into());
+            expr.clone().lt(vmin).or(expr.gt(vmax))
+        }
         Op::In(items) => {
             let list = items
                 .into_iter()
@@ -405,6 +410,13 @@ fn any_op_to_df_expr<V: Into<Value>>(arr: Expr, op: Op<V>) -> Result<Option<Expr
             let vmax = value_to_df_expr(range.max.into());
             let x = lambda_var("x");
             let body = x.clone().gt_eq(vmin).and(x.lt_eq(vmax));
+            array_any_match(arr, lambda(["x"], body))
+        }
+        Op::Outside(range) => {
+            let vmin = value_to_df_expr(range.min.into());
+            let vmax = value_to_df_expr(range.max.into());
+            let x = lambda_var("x");
+            let body = x.clone().lt(vmin).or(x.gt(vmax));
             array_any_match(arr, lambda(["x"], body))
         }
         Op::In(items) => {
@@ -459,6 +471,15 @@ fn all_op_to_df_expr<V: Into<Value>>(arr: Expr, op: Op<V>) -> Result<Option<Expr
             array_min(arr.clone())
                 .gt_eq(vmin)
                 .and(array_max(arr).lt_eq(vmax))
+        }
+        Op::Outside(range) => {
+            let vmin = value_to_df_expr(range.min.into());
+            let vmax = value_to_df_expr(range.max.into());
+
+            // all elements outside [a, b] <-> no element is inside [a, b]
+            let x = lambda_var("x");
+            let inside = x.clone().gt_eq(vmin).and(x.lt_eq(vmax));
+            not(array_any_match(arr, lambda(["x"], inside)))
         }
         Op::In(items) => {
             let set = make_array(
@@ -586,6 +607,11 @@ fn struct_elem_predicate<V: Into<Value>>(
             let vmin = value_to_df_expr(range.min.into());
             let vmax = value_to_df_expr(range.max.into());
             make_fe().gt_eq(vmin).and(make_fe().lt_eq(vmax))
+        }
+        Op::Outside(range) => {
+            let vmin = value_to_df_expr(range.min.into());
+            let vmax = value_to_df_expr(range.max.into());
+            make_fe().lt(vmin).or(make_fe().gt(vmax))
         }
         Op::In(items) => {
             let list = items

--- a/mosaicod/tests/tests/ontology_query.rs
+++ b/mosaicod/tests/tests/ontology_query.rs
@@ -1717,6 +1717,80 @@ async fn test_ontology_at_ordering(pool: sqlx::Pool<db::DatabaseType>) {
 }
 
 #[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_at_outside(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_at_outside";
+    // topic_a: [10, 20, 30], topic_b: [40, 50, 60]
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_list_batch(10_000, &[1], &[vec![10, 20, 30]])),
+            ("topic_b", int_list_batch(20_000, &[2], &[vec![40, 50, 60]])),
+        ],
+    )
+    .await;
+
+    // [2] $outside [25, 35]: strict complement of the [2] $between [25, 35] case.
+    // topic_a[2]=30 is inside [25,35] -> excluded; topic_b[2]=60 > 35 -> included.
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[2]": { "$outside": [25, 35] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "[2]$outside [25,35]: topic_a[2]=30 inside, excluded"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "[2]$outside [25,35]: topic_b[2]=60 > 35, included"
+    );
+
+    // [1] $outside [45, 55]: topic_a[1]=20 < 45 -> included; topic_b[1]=50 inside -> excluded.
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[1]": { "$outside": [45, 55] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "[1]$outside [45,55]: topic_a[1]=20 < 45, included"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "[1]$outside [45,55]: topic_b[1]=50 inside, excluded"
+    );
+
+    // [0] $outside [5, 100]: both first elements are inside the wide range -> both excluded.
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[0]": { "$outside": [5, 100] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "[0]$outside [5,100]: topic_a[0]=10 inside, excluded"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "[0]$outside [5,100]: topic_b[0]=40 inside, excluded"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
 async fn test_ontology_list_db_pruning(pool: sqlx::Pool<db::DatabaseType>) {
     let server = common::ServerBuilder::new(common::HOST, pool).build().await;
     let mut client = common::ClientBuilder::new(common::HOST, server.port())
@@ -2377,6 +2451,225 @@ async fn test_ontology_list_of_struct_bool(pool: sqlx::Pool<db::DatabaseType>) {
     assert!(
         !locators.contains(&format!("{seq}/topic_b")),
         "topic_b should be excluded (active=false)"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_scalar_outside(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_scalar_outside";
+    // Topic A: value range [1, 7], Topic B: value range [100, 106]
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_batch(10_000, &[1, 2, 3, 4, 5, 6, 7])),
+            (
+                "topic_b",
+                int_batch(20_000, &[100, 101, 102, 103, 104, 105, 106]),
+            ),
+        ],
+    )
+    .await;
+
+    // outside([1, 7]): matches v < 1 || v > 7.
+    // topic_a has no value below 1 or above 7 -> excluded (also exercises the chunk
+    // stats pre-filter: min=1, max=7 -> neither min<1 nor max>7).
+    // topic_b: 100 > 7 -> included.
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$outside": [1, 7] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "$outside [1,7]: topic_a has no value <1 or >7, excluded"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "$outside [1,7]: topic_b min=100 > 7, included"
+    );
+
+    // outside([0, 200]): both ranges are fully inside [0, 200] -> both excluded.
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$outside": [0, 200] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "$outside [0,200]: topic_a fully inside, excluded"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "$outside [0,200]: topic_b fully inside, excluded"
+    );
+
+    // outside([50, 60]): topic_a all < 50, topic_b all > 60 -> both included.
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.value": { "$outside": [50, 60] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "$outside [50,60]: topic_a values < 50, included"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "$outside [50,60]: topic_b values > 60, included"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_any_outside(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_any_outside";
+    // topic_a elements: [1, 2, 3], topic_b elements: [10, 20, 30]
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            ("topic_a", int_list_batch(10_000, &[1], &[vec![1, 2, 3]])),
+            ("topic_b", int_list_batch(20_000, &[2], &[vec![10, 20, 30]])),
+        ],
+    )
+    .await;
+
+    // [?] outside([a, b]): at least one element is < a || > b.
+
+    // outside([0, 30]): no element below 0 or above 30 in either topic -> both excluded.
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$outside": [0, 30] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "$outside [0,30]: topic_a has no element outside, excluded"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "$outside [0,30]: topic_b has no element outside, excluded"
+    );
+
+    // outside([0, 25]): only topic_b has 30 > 25.
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$outside": [0, 25] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        !locators.contains(&format!("{seq}/topic_a")),
+        "$outside [0,25]: topic_a all in [0,25], excluded"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_b")),
+        "$outside [0,25]: topic_b has 30 > 25, included"
+    );
+
+    // outside([2, 30]): only topic_a has 1 < 2.
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[?]": { "$outside": [2, 30] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+    assert!(
+        locators.contains(&format!("{seq}/topic_a")),
+        "$outside [2,30]: topic_a has 1 < 2, included"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_b")),
+        "$outside [2,30]: topic_b all in [2,30], excluded"
+    );
+
+    server.shutdown().await;
+}
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_ontology_all_outside(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_all_outside";
+    // [!] outside([5, 35]) means EVERY element is < 5 || > 35, i.e. no element inside [5, 35].
+    setup_topics(
+        &mut client,
+        seq,
+        vec![
+            // all < 5 -> all outside -> included
+            ("topic_low", int_list_batch(10_000, &[1], &[vec![1, 2, 3]])),
+            // all in [5, 35] -> none outside -> excluded
+            (
+                "topic_mid",
+                int_list_batch(20_000, &[2], &[vec![10, 20, 30]]),
+            ),
+            // 1 < 5 (outside) but 10 in [5, 35] (inside) -> NOT all outside -> excluded.
+            (
+                "topic_straddle",
+                int_list_batch(30_000, &[3], &[vec![1, 10]]),
+            ),
+            // all > 35 -> all outside -> included
+            ("topic_high", int_list_batch(40_000, &[4], &[vec![40, 50]])),
+            // 1 < 5 and 40 > 35, both outside -> all outside -> included
+            ("topic_split", int_list_batch(50_000, &[5], &[vec![1, 40]])),
+        ],
+    )
+    .await;
+
+    let items = actions::query(
+        &mut client,
+        json!({ "ontology": { "mock.list_test[!]": { "$outside": [5, 35] } } }),
+    )
+    .await
+    .unwrap();
+    let locators = topic_locators(&items);
+
+    assert!(
+        locators.contains(&format!("{seq}/topic_low")),
+        "$outside [5,35]: topic_low [1,2,3] all < 5, included"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_mid")),
+        "$outside [5,35]: topic_mid [10,20,30] all inside, excluded"
+    );
+    assert!(
+        !locators.contains(&format!("{seq}/topic_straddle")),
+        "$outside [5,35]: topic_straddle [1,10] has 10 inside [5,35], excluded"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_high")),
+        "$outside [5,35]: topic_high [40,50] all > 35, included"
+    );
+    assert!(
+        locators.contains(&format!("{seq}/topic_split")),
+        "$outside [5,35]: topic_split [1,40] both outside, included"
     );
 
     server.shutdown().await;

--- a/mosaicod/tests/tests/query.rs
+++ b/mosaicod/tests/tests/query.rs
@@ -677,3 +677,58 @@ async fn test_query_invalid_keys(pool: sqlx::Pool<db::DatabaseType>) {
 
     server.shutdown().await;
 }
+
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_query_user_metadata_outside_integer(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let seq = "seq_umeta_outside";
+    setup_topics_with_metadata(
+        &mut client,
+        seq,
+        &[
+            ("topic_1", json!({"x": 1})),
+            ("topic_6", json!({"x": 6})),
+            ("topic_99", json!({"x": 99})),
+        ],
+    )
+    .await;
+
+    // outside([5, 50]): matches x < 5 || x > 50.
+    let items = actions::query(
+        &mut client,
+        json!({
+            "topic": {
+                "user_metadata": {
+                    "x": { "$outside": [5, 50] }
+                }
+            }
+        }),
+    )
+    .await
+    .unwrap();
+
+    let locators = topic_locator_and_ontology(&items);
+    assert_eq!(
+        locators.len(),
+        2,
+        "expected 2 matching topics, got: {locators:?}"
+    );
+    assert!(
+        locators.contains(&(format!("{seq}/topic_1"), "mock".to_owned())),
+        "topic_1 (x=1 < 5) included"
+    );
+    assert!(
+        locators.contains(&(format!("{seq}/topic_99"), "mock".to_owned())),
+        "topic_99 (x=99 > 50) included"
+    );
+    assert!(
+        !locators.contains(&(format!("{seq}/topic_6"), "mock".to_owned())),
+        "topic_6 (x=6 inside [5,50]) excluded"
+    );
+
+    server.shutdown().await;
+}


### PR DESCRIPTION
Add a new scalar range operator `outside([a, b])`, defined as the strict complement of `between`: it matches values where v < a || v > b (with a <= b). 

Close #655
