### PR TITLE
refactor(mosaicod): replaced df memory pool policy

### DIFF
--- a/mosaicod/CHANGELOG.md
+++ b/mosaicod/CHANGELOG.md
@@ -49,3 +49,4 @@ This release substantially expands the **query engine** (new operators, regex, c
 - Facade functions and DB queries reworked to **prevent race conditions**; server shuts down on the first service failure. ([#583](https://github.com/mosaico-labs/mosaico/pull/583), [#636](https://github.com/mosaico-labs/mosaico/pull/636))
 - `InvalidArgument` returned for invalid keys in user metadata. ([#620](https://github.com/mosaico-labs/mosaico/pull/620))
 - Lint fixes and cleanup. ([#618](https://github.com/mosaico-labs/mosaico/pull/618))
+- Change memory utilization of datafusion replacing `FairSpillPool` with `GreedyMemoryPool`.

--- a/mosaicod/crates/mosaicod-query/src/timeseries.rs
+++ b/mosaicod/crates/mosaicod-query/src/timeseries.rs
@@ -8,7 +8,7 @@ use super::{Error, IndexSpecifier, OntologyExprGroup, OntologyField, Op, Value};
 use arrow::datatypes::{DataType, Schema, SchemaRef};
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::execution::disk_manager::DiskManagerBuilder;
-use datafusion::execution::memory_pool::FairSpillPool;
+use datafusion::execution::memory_pool::GreedyMemoryPool;
 use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
 use datafusion::functions::core::expr_ext::FieldAccessor;
 use datafusion::functions::regex::expr_fn::regexp_like;
@@ -37,7 +37,7 @@ pub struct TimeseriesEngine {
 impl TimeseriesEngine {
     pub fn try_new(store: Arc<store::Store>, memory_limit_bytes: usize) -> Result<Self, Error> {
         let memory_pool = if memory_limit_bytes != 0 {
-            Some(Arc::new(FairSpillPool::new(memory_limit_bytes)))
+            Some(Arc::new(GreedyMemoryPool::new(memory_limit_bytes)))
         } else {
             None
         };


### PR DESCRIPTION
Now datafusion uses a greedy policy instead of the fair one.

Closes #675
