### PR TITLE
feat(py): Add timestamp properties to `TopicDataStreamer` and `SequenceDataStreamer`

### DIFF
--- a/mosaico-sdk-py/src/mosaicolabs/handlers/internal/topic_read_state.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/internal/topic_read_state.py
@@ -37,6 +37,8 @@ class _TopicReadState:
         ontology_tag: str,
         serialization_format: SerializationFormat,
         msg_count: Optional[int],
+        timestamp_ns_min: Optional[int],
+        timestamp_ns_max: Optional[int],
         reader: Optional[fl.FlightStreamReader],
     ):
         """
@@ -61,6 +63,8 @@ class _TopicReadState:
         self.ontology_tag: str = ontology_tag
         self.serialization_format = serialization_format
         self.msg_count: Optional[int] = msg_count
+        self.timestamp_ns_min: Optional[int] = timestamp_ns_min
+        self.timestamp_ns_max: Optional[int] = timestamp_ns_max
 
         # --- Schema Validation & Setup ---
         self.column_names: List[str] = []

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/internal/topic_read_state.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/internal/topic_read_state.py
@@ -50,6 +50,8 @@ class _TopicReadState:
             serialization_format (SerializationFormat): The serialization format of the
                 the ontology data model.
             msg_count (int): The number of messages in the topic.
+            timestamp_ns_min (int): The minimum timestamp in nanoseconds for the topic.
+            timestamp_ns_max (int): The maximum timestamp in nanoseconds for the topic.
             reader (Optional[fl.FlightStreamReader]): The active stream reader.
 
         Raises:

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/sequence_reader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/sequence_reader.py
@@ -181,7 +181,7 @@ class SequenceDataStreamer:
                 ticket=ep.ticket,
             )
             # Cache the topic reader instance
-            topic_readers[treader.name()] = treader
+            topic_readers[treader.name] = treader
 
         if not topic_readers:
             raise RuntimeError(
@@ -219,6 +219,44 @@ class SequenceDataStreamer:
             filter(
                 None, (t_reader.msg_count for t_reader in self._topic_readers.values())
             )
+        )
+
+    @property
+    def timestamp_ns_min(self) -> Optional[int]:
+        """
+        The lowest timestamp (nanoseconds) in this stream.
+
+        Returns:
+            The lowest timestamp (nanoseconds) in this stream. None if an error occurred during retrieval
+        """
+        return min(
+            filter(
+                None,
+                (
+                    t_reader.timestamp_ns_min
+                    for t_reader in self._topic_readers.values()
+                ),
+            ),
+            default=None,
+        )
+
+    @property
+    def timestamp_ns_max(self) -> Optional[int]:
+        """
+        The highest timestamp (nanoseconds) in this stream.
+
+        Returns:
+            The highest timestamp (nanoseconds) in this stream. None if an error occurred during retrieval
+        """
+        return max(
+            filter(
+                None,
+                (
+                    t_reader.timestamp_ns_max
+                    for t_reader in self._topic_readers.values()
+                ),
+            ),
+            default=None,
         )
 
     # --- Iterator Protocol Implementation ---
@@ -333,7 +371,7 @@ class SequenceDataStreamer:
 
         # Advance the Winner's stream
         self._winning_rdstate.peek_next_row()
-        return winning_topic.name(), Message._decode(
+        return winning_topic.name, Message._decode(
             tag_or_type=winning_topic._ontology_type, **row_dict
         )
 
@@ -396,6 +434,6 @@ class SequenceDataStreamer:
             try:
                 treader.close()
             except Exception as e:
-                logger.warning(f"Error closing state '{treader.name()}': '{e}'")
+                logger.warning(f"Error closing state '{treader.name}': '{e}'")
 
         logger.info(f"SequenceReader for '{self._name}' closed.")

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/topic_reader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/topic_reader.py
@@ -11,6 +11,7 @@ from typing import Any, Optional, Type
 import pyarrow as pa
 import pyarrow.flight as fl
 
+from mosaicolabs.enum.serialization_format import SerializationFormat
 from mosaicolabs.models.core import Message
 from mosaicolabs.models.core.helpers import resolve_ontology_class
 from mosaicolabs.models.core.serializable import (
@@ -166,6 +167,8 @@ class TopicDataStreamer:
             ontology_tag=topic_mdata.properties.ontology_tag,
             serialization_format=topic_mdata.properties.serialization_format,
             msg_count=topic_mdata.properties.msg_count,
+            timestamp_ns_min=topic_mdata.properties.timestamp_ns_min,
+            timestamp_ns_max=topic_mdata.properties.timestamp_ns_max,
         )
         return cls(
             client=client,
@@ -238,16 +241,7 @@ class TopicDataStreamer:
 
     def _validate_status_open(self):
         if not self._is_open:
-            raise ValueError(f"Reader closed for topic {self.name()}")
-
-    def name(self) -> str:
-        """
-        The name of the topic associated with this streamer.
-
-        Returns:
-            The name of the topic.
-        """
-        return self._rdstate.topic_name
+            raise ValueError(f"Reader closed for topic {self.name}")
 
     def next_timestamp(self) -> Optional[int]:
         """
@@ -296,6 +290,26 @@ class TopicDataStreamer:
         return int(self._rdstate.peeked_timestamp)
 
     @property
+    def name(self) -> str:
+        """
+        The name of the topic associated with this streamer.
+
+        Returns:
+            The name of the topic.
+        """
+        return self._rdstate.topic_name
+
+    @property
+    def serialization_format(self) -> SerializationFormat:
+        """
+        The ontology `SerializationFormat` associated with this data stream.
+
+        Returns:
+            The ontology `SerializationFormat`.
+        """
+        return self._rdstate.serialization_format
+
+    @property
     def ontology_tag(self) -> str:
         """
         The ontology tag associated with this streamer.
@@ -314,6 +328,26 @@ class TopicDataStreamer:
             The number of messages. None if an error occurred during message count retrieval
         """
         return self._rdstate.msg_count
+
+    @property
+    def timestamp_ns_min(self) -> Optional[int]:
+        """
+        The lowest timestamp (nanoseconds) in this stream.
+
+        Returns:
+            The lowest timestamp (nanoseconds) in this stream. None if an error occurred during retrieval
+        """
+        return self._rdstate.timestamp_ns_min
+
+    @property
+    def timestamp_ns_max(self) -> Optional[int]:
+        """
+        The highest timestamp (nanoseconds) in this stream.
+
+        Returns:
+            The highest timestamp (nanoseconds) in this stream. None if an error occurred during retrieval
+        """
+        return self._rdstate.timestamp_ns_max
 
     def __iter__(self) -> "TopicDataStreamer":
         """Returns self as iterator."""

--- a/mosaico-sdk-py/src/mosaicolabs/platform/metadata.py
+++ b/mosaico-sdk-py/src/mosaicolabs/platform/metadata.py
@@ -120,15 +120,21 @@ class TopicMetadata(PlatformMetadata):
     @dataclass(slots=True)
     class Properties:
         ontology_tag: str
-        msg_count: Optional[int]
         serialization_format: SerializationFormat
+        # Optional since not retrieved on every path
+        # (returned by a DoGet only)
+        msg_count: Optional[int]
+        timestamp_ns_min: Optional[int]
+        timestamp_ns_max: Optional[int]
 
         @classmethod
         def _from_dict(cls, data: dict):
             return cls(
                 ontology_tag=data["ontology_tag"],
-                msg_count=data.get("message_count"),
                 serialization_format=SerializationFormat(data["serialization_format"]),
+                msg_count=data.get("message_count"),
+                timestamp_ns_min=data.get("timestamp_ns_min"),
+                timestamp_ns_max=data.get("timestamp_ns_max"),
             )
 
     properties: Properties

--- a/mosaico-sdk-py/src/testing/integration/test_stream.py
+++ b/mosaico-sdk-py/src/testing/integration/test_stream.py
@@ -38,9 +38,8 @@ def test_sequence_data_stream(
         and sstream_handl.timestamp_ns_max is not None
     )
     assert (
-        synthetic_sequence_data_stream.items[0].msg.timestamp_ns
-        == sstream_handl.timestamp_ns_min
-        and synthetic_sequence_data_stream.items[-1].msg.timestamp_ns
+        synthetic_sequence_data_stream.tstamp_ns_start == sstream_handl.timestamp_ns_min
+        and synthetic_sequence_data_stream.tstamp_ns_end
         == sstream_handl.timestamp_ns_max
     )
     # Get the next timestamp, without consuming the related sample

--- a/mosaico-sdk-py/src/testing/integration/test_stream.py
+++ b/mosaico-sdk-py/src/testing/integration/test_stream.py
@@ -33,6 +33,16 @@ def test_sequence_data_stream(
     # The metadata are coherent
     assert seqhandler.user_metadata == UPLOADED_SEQUENCE_METADATA
     sstream_handl = seqhandler.get_data_streamer()
+    assert (
+        sstream_handl.timestamp_ns_min is not None
+        and sstream_handl.timestamp_ns_max is not None
+    )
+    assert (
+        synthetic_sequence_data_stream.items[0].msg.timestamp_ns
+        == sstream_handl.timestamp_ns_min
+        and synthetic_sequence_data_stream.items[-1].msg.timestamp_ns
+        == sstream_handl.timestamp_ns_max
+    )
     # Get the next timestamp, without consuming the related sample
     next_tstamp = sstream_handl.next_timestamp()
     assert next_tstamp is not None
@@ -127,9 +137,18 @@ def test_topic_data_stream(
     assert tophandler.user_metadata == topic_to_metadata_dict[topic]
     # This must raise if topic handler is malformed
     tstream_handl = tophandler.get_data_streamer()
+    assert (
+        tstream_handl.timestamp_ns_min is not None
+        and tstream_handl.timestamp_ns_max is not None
+    )
+    assert (
+        _cached_topic_data_stream[0].msg.timestamp_ns == tstream_handl.timestamp_ns_min
+        and _cached_topic_data_stream[-1].msg.timestamp_ns
+        == tstream_handl.timestamp_ns_max
+    )
 
-    _validate_returned_topic_name(tstream_handl.name())
-    assert tstream_handl.name() == topic
+    _validate_returned_topic_name(tstream_handl.name)
+    assert tstream_handl.name == topic
 
     # Topic reader must be valid
     assert tstream_handl is not None
@@ -213,6 +232,7 @@ def test_topic_data_stream_multiple_call(
 def test_sequence_data_stream_filter_topics(
     mosaico_client: MosaicoClient,
     inject_synthetic_sequence,  # necessary to make sure data are available on server
+    synthetic_sequence_data_stream,
 ):
     """Test that the sequence data stream is correctly unpacked and provided"""
     seqhandler = mosaico_client.sequence_handler(UPLOADED_SEQUENCE_NAME)
@@ -222,8 +242,24 @@ def test_sequence_data_stream_filter_topics(
     # get a subset of topics
     filtered_topics = topic_list[: round(len(topic_list) / 2)]
     assert len(filtered_topics) > 0
+    _cached_topic_data_stream = [
+        dstream
+        for dstream in synthetic_sequence_data_stream.items
+        if dstream.topic in filtered_topics
+    ]
+    min_tstamp = _cached_topic_data_stream[0].msg.timestamp_ns
+    max_tstamp = _cached_topic_data_stream[-1].msg.timestamp_ns
     ret_topics = set()
-    for topic, _ in seqhandler.get_data_streamer(topics=filtered_topics):
+    sstream_handl = seqhandler.get_data_streamer(topics=filtered_topics)
+    assert (
+        sstream_handl.timestamp_ns_min is not None
+        and sstream_handl.timestamp_ns_max is not None
+    )
+    assert (
+        sstream_handl.timestamp_ns_min == min_tstamp
+        and sstream_handl.timestamp_ns_max == max_tstamp
+    )
+    for topic, _ in sstream_handl:
         # only desired topics must be returned
         assert topic in filtered_topics
         ret_topics.add(topic)

--- a/mosaico-sdk-py/src/testing/integration/test_stream_timerange.py
+++ b/mosaico-sdk-py/src/testing/integration/test_stream_timerange.py
@@ -30,6 +30,10 @@ def _exec_test_sequence_data_stream_timerange(
         start_timestamp_ns=time_start,  # lower_bound
         end_timestamp_ns=time_end,  # upper_bound
     )
+    assert (
+        sstream_handl.timestamp_ns_min is not None
+        and sstream_handl.timestamp_ns_max is not None
+    )
     # Get the next timestamp, without consuming the related sample
     next_tstamp = sstream_handl.next_timestamp()
     assert next_tstamp is not None
@@ -59,6 +63,13 @@ def _exec_test_sequence_data_stream_timerange(
             )
             - 1
         )
+    )
+
+    assert (
+        _make_sequence_data_stream.items[msg_idx_start].msg.timestamp_ns
+        == sstream_handl.timestamp_ns_min
+        and _make_sequence_data_stream.items[msg_idx_stop].msg.timestamp_ns
+        == sstream_handl.timestamp_ns_max
     )
 
     # Start consuming data stream
@@ -141,6 +152,17 @@ def _exec_test_topic_data_stream_timerange(
     tstream_handl = tophandler.get_data_streamer(
         start_timestamp_ns=time_start,
         end_timestamp_ns=time_end,
+    )
+
+    assert (
+        tstream_handl.timestamp_ns_min is not None
+        and tstream_handl.timestamp_ns_max is not None
+    )
+    assert (
+        _cached_topic_data_stream[msg_idx_start].msg.timestamp_ns
+        == tstream_handl.timestamp_ns_min
+        and _cached_topic_data_stream[msg_idx_stop].msg.timestamp_ns
+        == tstream_handl.timestamp_ns_max
     )
 
     # Topic reader must be valid


### PR DESCRIPTION
- Updated metadata parsing in `TopicMetadata` to include `timestamp_ns_min` and `timestamp_ns_max` properties from server responses to `do_get`
- Added corresponding stream-level `timestamp_ns_min` and `timestamp_ns_max` computed properties to `SequenceDataStreamer` and `TopicDataStreamer`
- Added integration tests validating returned time information for sequence and topic data streams

## Breaking Change
- `TopicDataStreamer.name()` was changed to the `TopicDataStreamer.name` property

Closes #682  and Discussion #501 