### PR TITLE
docs: fix SDK reference accuracy, fix learn guides, add three new learn guides

### DIFF
--- a/docs/main/docs/examples/custom_ontology.mdx
+++ b/docs/main/docs/examples/custom_ontology.mdx
@@ -40,9 +40,9 @@ The custom ontology is loaded as part of the ROS Ingestion example. The full sou
 
 ## Defining the Model
 
-Data models in Mosaico are defined by inheriting from `Serializable`. This triggers automatic Apache Arrow schema generation and registers the type in the internal ontology registry the moment the class is loaded by the Python interpreter. The type is then valid as an `ontology_type` in `topic_create()` and its fields become available through the `.Q` query proxy for content-based filtering.
+Data models in Mosaico are defined by inheriting from `Serializable`. The moment the class is loaded by the Python interpreter, this triggers automatic Apache Arrow schema generation and registers the type in the internal ontology registry. From then on, the type is valid as an `ontology_type` in `topic_create()`, and its fields become available through the `.Q` query proxy for content-based filtering.
 
-`MosaicoType` provides the available primitive types (`uint32`, `uint64`, `float32`, `string`, and more). `MosaicoField` attaches a human-readable description to each field, which is stored alongside the data in the catalog.
+`MosaicoType` provides the available primitive types (`uint32`, `uint64`, `float32`, `string`, and more), one per field. `MosaicoField` attaches a human-readable description to each field, which is stored alongside the data in the catalog.
 
 ```python title="EncoderTicks custom model"
 from mosaicolabs import MosaicoField, MosaicoType, Serializable
@@ -67,6 +67,8 @@ Registration happens at class definition time, not at application startup. If th
 The safe pattern is to import your ontology module explicitly at the application entry point before any SDK calls are made.
 
 ```python title="Import to trigger registration"
+# `my_project.ontology.encoders` is a placeholder for wherever your own
+# Serializable subclasses live; substitute your actual module path here.
 import my_project.ontology.encoders as encoders  # registration happens here
 
 from mosaicolabs import MosaicoClient

--- a/docs/main/docs/examples/data_inspection.mdx
+++ b/docs/main/docs/examples/data_inspection.mdx
@@ -65,7 +65,7 @@ for sequence_name in seq_list:
         size_mb = shandler.total_size_bytes / (1024 * 1024)
         print(f"Sequence: {shandler.name}")
         print(f"  Remote Size:  {size_mb:.2f} MB")
-        print(f"  Created At:   {shandler.created_datetime}")
+        print(f"  Created At:   {shandler.created_timestamp}")
         print(f"  Time Span:    {shandler.timestamp_ns_min} to {shandler.timestamp_ns_max} ns")
 ```
 

--- a/docs/main/docs/examples/mujoco_visualisation.mdx
+++ b/docs/main/docs/examples/mujoco_visualisation.mdx
@@ -51,6 +51,10 @@ MuJoCo is not included in the default SDK dependencies — install it before run
 pip install mujoco
 ```
 
+:::note
+On first run, if the model files are not found locally at `MUJOCO_XML_SCENE_PATH`, the example automatically downloads them from the [MuJoCo Menagerie](https://github.com/google-deepmind/mujoco_menagerie) GitHub repository. This requires outbound network access to GitHub.
+:::
+
 ## Locating the Joint State Topic
 
 `QuerySequence` and `QueryTopic` are combined to find the right channel in a single server-side query. Filtering by `RobotJoint.ontology_tag()` ensures the result contains only joint state topics, regardless of how the channel is named in the bag.
@@ -89,6 +93,19 @@ for items in result:
 
 Each `RobotJoint` message is timestamped in nanoseconds relative to the recording start. That offset drives the simulation forward so the replay matches the original motion at the correct cadence. Joint positions are applied directly to the MuJoCo model state and the viewer is updated each frame.
 
+:::note
+The snippet below is a simplified illustration and omits setup boilerplate (loading the MJCF scene, syncing `relative_ts` to wall-clock time, joint-name-to-`qpos`-index lookups, error handling). See the [full source on GitHub](https://github.com/mosaico-labs/mosaico/blob/main/mosaico-sdk-py/src/mosaicolabs/examples/mujoco_vis.py) for a runnable version.
+:::
+
+```python title="Set up the MuJoCo model, data, and viewer"
+import mujoco
+import mujoco.viewer
+
+mj_model = mujoco.MjModel.from_xml_path(MUJOCO_XML_SCENE_PATH)
+mj_data = mujoco.MjData(mj_model)
+viewer = mujoco.viewer.launch_passive(mj_model, mj_data)
+```
+
 ```python title="Stream joints and drive the simulation"
 for joint_msg in top_handler.get_data_streamer():
     relative_ts = (
@@ -97,7 +114,7 @@ for joint_msg in top_handler.get_data_streamer():
 
     joints = joint_msg.get_data(RobotJoint)
     mj_data.qpos[:] = joints.positions
-    mj.mj_forward(mj_model, mj_data)
+    mujoco.mj_forward(mj_model, mj_data)
     viewer.sync()
 ```
 

--- a/docs/main/docs/examples/querying_catalogs.mdx
+++ b/docs/main/docs/examples/querying_catalogs.mdx
@@ -41,7 +41,16 @@ The daemon must be running and contain data ingested via the [ROS Ingestion](./r
 
 ## The Query Builder Pattern
 
-Mosaico's query API uses fluent builder objects. Passing multiple builders to `client.query()` joins them with a logical AND, evaluated entirely server-side in a single round trip. Nothing is joined or filtered on the client side.
+Mosaico's query API uses fluent builder objects. Passing multiple builders to `client.query()` joins them with a logical AND, evaluated entirely server-side in a single round trip. Nothing is joined or filtered on the client side:
+
+```python title="Two builders joined server-side"
+client.query(
+    QueryTopic().with_name_match("*imu*"),      # AND
+    QueryOntologyCatalog(IMU.Q.acceleration.y.geq(1.0)),
+)
+```
+
+The sections below build up from a single builder to combinations of them.
 
 ## Finding Topics by Name
 
@@ -78,7 +87,7 @@ results = client.query(
 
 ## Multi-Domain Queries
 
-`QueryOntologyCatalog` combined with `QueryTopic` lets you filter by both sensor type and field value in one call. The `.Q` proxy provides type-safe dot-notation expressions: `IMU.Q.acceleration.y.geq(1.0)` means "find messages where IMU y-axis acceleration is >= 1.0 m/s²".
+`QueryOntologyCatalog` combined with `QueryTopic` lets you filter by both sensor type and field value in one call. The `.Q` proxy provides type-safe dot-notation expressions: `IMU.Q.acceleration.y.geq(1.0)` means "find messages where IMU y-axis acceleration is >= 1.0 m/s²". Here `QueryTopic` uses `with_name()`, i.e. an exact topic path, instead of the `with_ontology_tag()` seen above, since the physical filter on `IMU.Q...` already narrows the search to IMU data; restricting further to one specific topic path pins down *which* IMU stream the acceleration threshold applies to.
 
 ```python title="Multi-domain query with physics filter"
 from mosaicolabs import IMU, QueryOntologyCatalog, QueryTopic
@@ -93,6 +102,10 @@ results = client.query(
 
 
 ## Replaying an Event
+
+:::note
+This pattern is not part of the `query_catalogs` example script itself; it illustrates a natural next step once you have a query response, combining `clusterize()` with [`get_data_streamer()`](./data_inspection) (see the Data Inspection example).
+:::
 
 The returned query response can be used directly to slice a data stream to the exact windows containing the event. The example adds one second of padding on each side to capture the run-up and recovery.
 
@@ -112,3 +125,11 @@ if results:
                 for msg in streamer:
                     pass  # process the event window
 ```
+
+## Which Builder For Which Question
+
+| Question | Builder | Method |
+| --- | --- | --- |
+| "Which topics match this name pattern?" | `QueryTopic` | `with_name_match()` |
+| "Which topics carry this sensor type?" | `QueryTopic` | `with_ontology_tag()` |
+| "Which topics satisfy this physical condition?" | `QueryOntologyCatalog` | `.Q` proxy expression, e.g. `IMU.Q.acceleration.y.geq(1.0)` |

--- a/docs/main/docs/examples/reconstruct_rosbag.mdx
+++ b/docs/main/docs/examples/reconstruct_rosbag.mdx
@@ -42,30 +42,23 @@ The full source is on [GitHub](https://github.com/mosaico-labs/mosaico/blob/main
 
 ## Custom Ontology Definition
 
-The R2B dataset includes `isaac_ros_nova_interfaces/msg/EncoderTicks`, the same custom, hand-modeled type introduced in the [Custom Ontology](./custom_ontology) example to make wheel-encoder ticks ingestible:
-
-```python title="Custom EncoderTicks model"
-from mosaicolabs import MosaicoField, MosaicoType, Serializable
-
-class EncoderTicks(Serializable):
-    left_ticks: MosaicoType.uint32 = MosaicoField(
-        description="Cumulative counts from the left wheel encoder."
-    )
-    right_ticks: MosaicoType.uint32 = MosaicoField(
-        description="Cumulative counts from the right wheel encoder."
-    )
-    encoder_timestamp: MosaicoType.uint64 = MosaicoField(
-        description="Timestamp of the encoder ticks."
-    )
-```
+The R2B dataset includes `isaac_ros_nova_interfaces/msg/EncoderTicks`, the same custom, hand-modeled type introduced in the [Custom Ontology](./custom_ontology) example to make wheel-encoder ticks ingestible (reused here without modification).
 
 ## No Adapter Needed to Reconstruct
 
-The [ROS Ingestion](./ros_ingestion) example writes `EncoderTicksAdapter` by hand (imported here via `ros_injection.custom_ontology`, see [ROS Ingestion](./ros_ingestion#ros-adapter)) to get a fully-typed, queryable `EncoderTicks` model, but that step is a choice, not a requirement. Writing a reverse adapter is optional too: for any topic that reaches the extractor with no adapter registered for its ROS message type, the bridge falls back to the same automatic [Unmodeled Adapter](https://docs.mosaico.dev/python-sdk/SDK/bridges/ros/#extending-the-bridge-unmodeled-adapters) used at ingestion time. Since the original `.msg` definition was already captured as topic metadata when the sequence was ingested, the extractor can recover it, re-register it with the local ROS typestore, and reconstruct the native ROS message from it. See [Advanced: Ingesting Unmodeled Ontologies](https://docs.mosaico.dev/python-sdk/SDK/ontology/#advanced-ingesting-unmodeled-ontologies) for the full mechanics of this round-trip.
+**Reuse, not required.** The [ROS Ingestion](./ros_ingestion) example writes `EncoderTicksAdapter` by hand (imported here via `ros_injection.custom_ontology`, see [ROS Ingestion](./ros_ingestion#ros-adapter)) to get a fully-typed, queryable `EncoderTicks` model, but that step is a choice, not a requirement.
+
+**Automatic fallback.** Writing a reverse adapter is optional too: for any topic that reaches the extractor with no adapter registered for its ROS message type, the bridge falls back to the same automatic [Unmodeled Adapter](https://docs.mosaico.dev/python-sdk/SDK/bridges/ros/#extending-the-bridge-unmodeled-adapters) used at ingestion time. Since the original `.msg` definition was already captured as topic metadata when the sequence was ingested, the extractor can recover it, re-register it with the local ROS typestore, and reconstruct the native ROS message from it. See [Advanced: Ingesting Unmodeled Ontologies](https://docs.mosaico.dev/python-sdk/SDK/ontology/#advanced-ingesting-unmodeled-ontologies) for the full mechanics of this round-trip.
 
 ## Reconstruction Pipeline
 
-`ROSSequenceExtractor.run()` mirrors the injector's pipeline in reverse: it connects to Mosaico, streams every message of the requested sequence back out, resolves the adapter for each topic (falling back to the automatic [Unmodeled Adapter](https://docs.mosaico.dev/python-sdk/SDK/bridges/ros/#extending-the-bridge-unmodeled-adapters) as described above), and writes the translated ROS messages into a fresh bag under `rosbag_path/sequence_name`.
+`ROSSequenceExtractor.run()` mirrors the injector's pipeline in reverse:
+
+**Connect.** Opens a connection to Mosaico using the credentials and TLS settings in `ROSExtractorConfig`.
+
+**Stream.** Reads back every message of the requested sequence, resolving the adapter for each topic (falling back to the automatic [Unmodeled Adapter](https://docs.mosaico.dev/python-sdk/SDK/bridges/ros/#extending-the-bridge-unmodeled-adapters) as described above).
+
+**Write.** Translates each message back into its native ROS type and writes it into a fresh bag under `rosbag_path/sequence_name`.
 
 ```python title="Reconstruct every ingested sequence"
 BAG_FILE_PATH = Path(ASSET_DIR) / "reconstructed"

--- a/docs/main/docs/examples/ros_ingestion.mdx
+++ b/docs/main/docs/examples/ros_ingestion.mdx
@@ -42,7 +42,7 @@ The full source is on [GitHub](https://github.com/mosaico-labs/mosaico/blob/main
 
 ## Custom Ontology Definition
 
-The NVIDIA Isaac Nova encoder produces `isaac_ros_nova_interfaces/msg/EncoderTicks`, a message type with no equivalent in the built-in ontology. Before the injector can run, we define a custom model by inheriting from `Serializable`. This registers the type automatically in the Mosaico ecosystem at import time, making it available as an `ontology_type` for topic creation and enabling the `.Q` query proxy on its fields.
+The NVIDIA Isaac Nova encoder produces `isaac_ros_nova_interfaces/msg/EncoderTicks`, a message type with no equivalent in the built-in ontology. Before the injector can run, we define a custom model by inheriting from `Serializable`. This registers the type automatically at import time. From then on, it is available as an `ontology_type` for topic creation, with the `.Q` query proxy enabled on its fields.
 
 ```python title="Custom EncoderTicks model"
 from mosaicolabs import MosaicoField, MosaicoType, Serializable
@@ -67,6 +67,7 @@ Because `EncoderTicks` is a custom type, no default adapter exists. We subclass 
 This adapter only implements `from_dict`, so it only supports the ROS → Mosaico direction. To also support Mosaico → ROS — reconstructing a native ROS message from `EncoderTicks` — implement `to_ros()` as well.
 
 ```python title="EncoderTicks ROS adapter"
+from mosaicolabs import Message
 from mosaicolabs.ros_bridge import ROSMessage, ROSAdapterBase, register_default_adapter
 from mosaicolabs.ros_bridge.adapters.helpers import _validate_msgdata
 from .isaac import EncoderTicks
@@ -102,7 +103,7 @@ Even if `EncoderTicksAdapter` didn't exist, `RosbagInjector` would still ingest 
 
 The example loops over each bag file in the dataset and runs three phases: download, ingest, verify.
 
-**Download.** `download_asset` fetches the raw `.mcap` from NVIDIA with a progress bar and caches it locally so re-runs skip the download.
+**Download.** `download_asset` (defined in the example's `helpers.py`) fetches the raw `.mcap` from NVIDIA with a progress bar and caches it locally so re-runs skip the download.
 
 **Ingest.** `RosbagInjector` handles the full write pipeline: it opens the MCAP, routes each message through its registered adapter, batches the resulting `Message` objects, and transmits them to the daemon over gRPC. The sequence name is derived from the filename so each bag becomes a separate, independently queryable recording session.
 

--- a/docs/main/docs/learn/chained_queries.mdx
+++ b/docs/main/docs/learn/chained_queries.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chained Queries
-sidebar_position: 9
+sidebar_position: 10
 description: "How to correlate conditions across two different Topic types using chained queries. Covers converting a QueryResponse into a locked QuerySequence domain with to_query_sequence(), then running a second targeted query restricted to only the matching sessions."
 ---
 
@@ -9,13 +9,19 @@ import TabItem from '@theme/TabItem';
 
 ## Using Results to Scope a Second Query
 
-A single `client.query()` call applies AND across all conditions for a single **topic**. That constraint is fundamental: a topic has exactly one declared type, so it cannot simultaneously be a `GPS` stream and a `String` log. If you need to ask "find me sessions that have high-precision GPS data *and* contain error log messages", you cannot express that in one shot; those two conditions live on two different topics of two different types.
+Say you want sessions that have high-precision GPS data *and* contain error log messages. It's tempting to pass both conditions to a single `client.query()` call:
 
-Chained queries solve this. The pattern is to run an initial broad query to find candidate sequences, convert the response into a new query builder scoped to exactly those sequences, then run a second query within that narrowed domain. You get the intersection of both conditions without loading any data client-side.
+```python
+# Looks for ONE topic that is BOTH GPS data AND named /localization/log_string
+client.query(
+    QueryOntologyCatalog(GPS.Q.status.status.eq(2)),
+    QueryTopic().with_name("/localization/log_string"),
+)
+```
 
-:::info[Why is Chaining Necessary?]
-A single `client.query()` call applies AND across all conditions for a single **topic**. A topic cannot be both a `GPS` stream and a `String` log, so chaining is required to correlate two different topics within the same sequence.
-:::
+This returns nothing. All builders passed to one `client.query()` call are ANDed together and evaluated against each *individual* topic — so the query above asks the daemon to find a topic that is simultaneously typed as `GPS` and named `/localization/log_string`. Since a topic has exactly one name and one ontology type, no topic can ever satisfy both, even if a GPS topic and a `/localization/log_string` topic both exist side by side in the very same sequence.
+
+What you actually want is two *separate* topics — one carrying the GPS data, one carrying the logs — correlated within the same sequence. Chained queries solve this: run an initial broad query to find candidate sequences, convert the response into a new query builder scoped to exactly those sequences, then run a second query within that narrowed domain to find the log topic. You get the intersection of both conditions without loading any data client-side.
 
 <Tabs>
 
@@ -43,7 +49,7 @@ The Rust SDK is currently in development.
 
 **Broad search.** The first query casts a wide net. You may use only a `QueryOntologyCatalog` filter here, or combine it with a `QuerySequence` if you already know something about the sessions you care about. The result is a `QueryResponse` containing every sequence where the condition was satisfied.
 
-**Domain locking.** Call `to_query_sequence()` on the response. This converts the `QueryResponse` into a new `QuerySequence` builder that is already pre-filtered to the sequence IDs returned by the first query. The second query will only search within those sessions; the daemon will not touch any other data. This is what makes chaining both correct and efficient: you are not re-scanning the entire catalog, just the sessions you already know are relevant.
+**Domain locking.** Call `to_query_sequence()` on the response. This converts the `QueryResponse` into a new `QuerySequence` builder that is already pre-filtered to the sequence names returned by the first query. The second query will only search within those sessions; the daemon will not touch any other data. This is what makes chaining both correct and efficient: you are not re-scanning the entire catalog, just the sessions you already know are relevant.
 
 **Targeted refinement.** Pass the locked `QuerySequence` as the first argument of a new `client.query()` call, then add whichever `QueryTopic` and `QueryOntologyCatalog` conditions you need. The daemon evaluates the combination and returns only sessions that satisfy every condition across both queries.
 
@@ -90,8 +96,6 @@ The Rust SDK is currently in development.
 
 ## Key Concepts
 
-**`to_query_sequence()`** is the bridge between the two queries. When called on a `QueryResponse`, it produces a `QuerySequence` builder pre-populated with the IDs of all sequences that appeared in the response. Passing this builder as the first argument of the next `client.query()` call tells the daemon to restrict the search scope to those sessions only. No session outside that set will ever be evaluated, regardless of what the other filters say.
+**`to_query_topic()`** is the topic-level equivalent of `to_query_sequence()` used above. Instead of locking down to a set of sequences, it produces a `QueryTopic` builder pre-scoped to the specific topic paths returned by the previous response. Use this when you want to chain on exact topic identity, for instance when the first query already narrowed you to a particular channel and you want the second query to be applied to that same channel without re-specifying its name.
 
-**`to_query_topic()`** is the topic-level equivalent. Instead of locking down to a set of sequences, it produces a `QueryTopic` builder pre-scoped to the specific topic paths returned by the previous response. Use this when you want to chain on exact topic identity, for instance when the first query already narrowed you to a particular channel and you want the second query to be applied to that same channel without re-specifying its name.
-
-**Why not just filter client-side?** You could collect all sequence IDs from the first response and write a loop in Python. Chaining is preferable because both queries run entirely server-side. The daemon evaluates the second filter against only the relevant data without transferring intermediate results over the network. For large catalogs, the difference in latency is significant.
+**Why not just filter client-side?** Both queries in a chain run entirely server-side: the daemon evaluates the second filter against only the relevant data without transferring intermediate results over the network. For large catalogs, this is significantly faster than collecting sequence names from the first response and looping over them in Python.

--- a/docs/main/docs/learn/ml_training_batches.mdx
+++ b/docs/main/docs/learn/ml_training_batches.mdx
@@ -1,0 +1,206 @@
+---
+title: Preparing PyTorch Training Batches
+sidebar_position: 13
+description: "How to turn a multi-sensor Mosaico Sequence into fixed-length, synchronized tensors ready for a PyTorch DataLoader. Covers windowed extraction with DataFrameExtractor, multi-rate resampling with SyncTransformer and SyncHold, handling the NaNs that precede a sensor's first measurement, and streaming sliding windows through a PyTorch IterableDataset."
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Everything read back so far in these guides comes out one `Message` at a time, at whatever rate each sensor was originally recorded. That is the right shape for replay and analysis, but not for training: a model expects dense, fixed-shape batches, with every input feature aligned to the same timeline. This guide builds that bridge for a concrete case — fusing a high-rate IMU and a low-rate GPS into fixed-length windows a PyTorch `DataLoader` can consume — using the [ML module](https://docs.mosaico.dev/python-sdk/SDK/bridges/ml/) covered in the Python SDK reference.
+
+<Tabs>
+
+<TabItem value="python" label="Python" default>
+:::tip[Learn]
+[Doc: Machine Learning & Analytics](https://docs.mosaico.dev/python-sdk/SDK/bridges/ml/)
+
+[API Reference: ML Module](https://docs.mosaico.dev/python-sdk/SDK/API_reference/bridges/ml/)
+:::
+</TabItem>
+
+<TabItem value="cpp" label="C++">
+The C++ SDK is currently in development.
+</TabItem>
+
+<TabItem value="rust" label="Rust">
+The Rust SDK is currently in development.
+</TabItem>
+
+</Tabs>
+
+```bash title="Install PyTorch"
+pip install mosaicolabs torch
+```
+
+## The Three-Stage Pipeline
+
+Getting from a Sequence to a training batch means solving three separate problems, each handled by its own component:
+
+1. **Extract**: pull a Sequence's Topics into memory as tabular chunks without loading the whole recording at once — [`DataFrameExtractor`](https://docs.mosaico.dev/python-sdk/SDK/bridges/ml/#from-sequences-to-dataframes).
+2. **Synchronize**: an IMU firing at 100 Hz and a GPS updating at 5 Hz do not share a timeline; align both onto one fixed-frequency grid — [`SyncTransformer`](https://docs.mosaico.dev/python-sdk/SDK/bridges/ml/#sparse-to-dense-representation).
+3. **Window**: slice the now-dense, uniformly-sampled stream into fixed-length tensors a model can batch — plain PyTorch, shown below.
+
+The example ingests `/vehicle/imu` (`IMU`, `acceleration.x/y/z`) and `/vehicle/gps` (`GPS`, `position.x/y/z`) from a Sequence named `road_test_003`, and produces windows of shape `(window_size, 6)` — three IMU axes plus three GPS position components per timestep.
+
+## Extracting Windowed DataFrames
+
+<Tabs groupId="lang" defaultValue="python">
+<TabItem value="python" label="Python">
+
+`DataFrameExtractor.to_pandas_chunks()` yields one flattened, sparse `pandas.DataFrame` per time window, instead of loading the entire Sequence into RAM. Columns are named `{topic_name}.{ontology_tag}.{field_path}`; rows without a measurement for a given column at that exact timestamp are `NaN` — this is expected, since the IMU and the GPS were not sampled at the same instants.
+
+```python title="Windowed extraction"
+from mosaicolabs import MosaicoClient
+from mosaicolabs.ml import DataFrameExtractor
+
+FEATURE_COLUMNS = [
+    "/vehicle/imu.IMU.acceleration.x",
+    "/vehicle/imu.IMU.acceleration.y",
+    "/vehicle/imu.IMU.acceleration.z",
+    "/vehicle/gps.GPS.position.x",
+    "/vehicle/gps.GPS.position.y",
+    "/vehicle/gps.GPS.position.z",
+]
+
+with MosaicoClient.connect("localhost", 6726) as client:
+    seq_handler = client.sequence_handler("road_test_003")
+    extractor = DataFrameExtractor(seq_handler)
+
+    for sparse_chunk in extractor.to_pandas_chunks(
+        topics=["/vehicle/imu", "/vehicle/gps"],
+        window_sec=10.0,
+    ):
+        print(sparse_chunk[["timestamp_ns", *FEATURE_COLUMNS]].head())
+```
+
+</TabItem>
+<TabItem value="cpp" label="C++">
+
+The C++ SDK is currently in development.
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+The Rust SDK is currently in development.
+
+</TabItem>
+</Tabs>
+
+`window_sec` trades off memory against overhead: smaller windows keep RAM usage low on long recordings, at the cost of more round trips. See [Memory & Performance Best Practices](https://docs.mosaico.dev/python-sdk/SDK/bridges/ml/#memory-performance-best-practices) for tuning guidance.
+
+## Resampling onto a Fixed Grid
+
+<Tabs groupId="lang" defaultValue="python">
+<TabItem value="python" label="Python">
+
+`SyncTransformer` turns each sparse chunk into a dense one, sampled at a constant `target_fps`, carrying the last known value of each column forward via a `SyncPolicy` — here `SyncHold`, the simplest and most common choice for continuous physical signals like acceleration or position.
+
+```python title="Multi-rate resampling"
+from mosaicolabs.ml import SyncTransformer, SyncHold
+
+# Created ONCE, outside the loop: see the warning below.
+sync = SyncTransformer(target_fps=50.0, policy=SyncHold())
+
+for sparse_chunk in extractor.to_pandas_chunks(
+    topics=["/vehicle/imu", "/vehicle/gps"],
+    window_sec=10.0,
+):
+    dense_chunk = sync.fit(sparse_chunk).transform(sparse_chunk)
+```
+
+</TabItem>
+<TabItem value="cpp" label="C++">
+
+The C++ SDK is currently in development.
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+The Rust SDK is currently in development.
+
+</TabItem>
+</Tabs>
+
+:::danger["Re-instantiation" breaks continuity]
+`SyncTransformer` is **stateful**: it remembers the last value of every column and the next expected grid tick across chunks. Creating a new instance inside the `for` loop resets that state on every chunk, causing discontinuities right where consecutive chunks meet. See [The 'Re-instantiation' Trap](https://docs.mosaico.dev/python-sdk/SDK/bridges/ml/#internal-state-management) for the full explanation.
+:::
+
+`dense_chunk` now has one row per grid tick (every 20ms, at 50 Hz) and the same `FEATURE_COLUMNS` as before, but fully populated — with one exception: grid ticks that occur **before** the very first GPS fix (or the very first IMU sample) have no prior value to hold, so `SyncHold` leaves them as `NaN` rather than inventing one. In practice this only affects the opening milliseconds of the very first chunk.
+
+## From Dense Rows to Training Windows
+
+<Tabs groupId="lang" defaultValue="python">
+<TabItem value="python" label="Python">
+
+With a dense, fixed-rate stream in hand, the remaining step is plain PyTorch: slice it into fixed-length, overlapping-free windows and hand them to a `DataLoader`. Because chunks arrive one at a time from the extractor, an `IterableDataset` is a better fit here than a map-style `Dataset` — it can start yielding windows as soon as the first chunk is synchronized, without knowing the total length of the Sequence up front. A small `carry` buffer holds the leftover rows that don't fill a complete window yet, so no data is dropped at chunk boundaries.
+
+```python title="Streaming windows into a PyTorch IterableDataset"
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, IterableDataset
+
+from mosaicolabs import MosaicoClient
+from mosaicolabs.ml import DataFrameExtractor, SyncTransformer, SyncHold
+
+WINDOW_SIZE = 50  # 1 second of context at 50 Hz
+
+
+class ImuGpsWindowDataset(IterableDataset):
+    def __init__(self, sequence_handler, window_size=WINDOW_SIZE, target_fps=50.0):
+        self._sequence_handler = sequence_handler
+        self._window_size = window_size
+        self._target_fps = target_fps
+
+    def __iter__(self):
+        extractor = DataFrameExtractor(self._sequence_handler)
+        sync = SyncTransformer(target_fps=self._target_fps, policy=SyncHold())
+        carry = np.empty((0, len(FEATURE_COLUMNS)), dtype=np.float32)
+
+        for sparse_chunk in extractor.to_pandas_chunks(
+            topics=["/vehicle/imu", "/vehicle/gps"],
+            window_sec=10.0,
+        ):
+            dense_chunk = sync.fit(sparse_chunk).transform(sparse_chunk)
+
+            # Drop rows preceding the first measurement of any feature (see note above)
+            values = dense_chunk[FEATURE_COLUMNS].dropna().to_numpy(dtype=np.float32)
+            values = np.concatenate([carry, values], axis=0)
+
+            n_windows = len(values) // self._window_size
+            for i in range(n_windows):
+                window = values[i * self._window_size : (i + 1) * self._window_size]
+                yield torch.from_numpy(window)
+
+            carry = values[n_windows * self._window_size :]
+
+
+with MosaicoClient.connect("localhost", 6726) as client:
+    seq_handler = client.sequence_handler("road_test_003")
+    dataset = ImuGpsWindowDataset(seq_handler)
+    loader = DataLoader(dataset, batch_size=32)
+
+    for batch in loader:
+        # batch.shape == (32, WINDOW_SIZE, 6): (batch, time, IMU+GPS features)
+        pass  # feed `batch` into your model's training step
+```
+
+</TabItem>
+<TabItem value="cpp" label="C++">
+
+The C++ SDK is currently in development.
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+The Rust SDK is currently in development.
+
+</TabItem>
+</Tabs>
+
+## Key Concepts
+
+- **Three independent stages**: extraction (I/O and memory), synchronization (temporal alignment), windowing (batch shape). Each can be tuned or swapped without touching the others — e.g. changing `target_fps` or the `SyncPolicy` never requires touching the extraction or windowing code.
+- **Statefulness matters twice**: `SyncTransformer` must be created once and reused across chunks, and the sliding-window `carry` buffer above serves the same purpose one level up — preserving continuity across chunk boundaries so no window is lost or duplicated.
+- **`IterableDataset` fits streaming extraction**: unlike a map-style `Dataset`, it does not require knowing the Sequence's total length upfront, and lets training start consuming windows before the whole Sequence has been read.
+- **Images need one more stage**: if a Topic carries `CompressedImage` data, decode it with [`VideoDecodingTransformer`](https://docs.mosaico.dev/python-sdk/SDK/bridges/ml/#video-decoding-for-ml-pipelines) *before* the `SyncTransformer` step — decoding must happen while frames are still in their original chronological order.

--- a/docs/main/docs/learn/multi_domain_query.mdx
+++ b/docs/main/docs/learn/multi_domain_query.mdx
@@ -55,10 +55,3 @@ The comparison operators available on a field path (`.gt()`, `.lt()`, `.eq()`, `
 - `item.topics`: the list of topics within that sequence that satisfied the Topic and OntologyCatalog conditions
 
 Each topic also carries the time interval where the query condition held true. See [Temporal Windows](./temporal_windows.mdx) to extract and compare these intervals across topics and sequences.
-
-## Key Concepts
-
-- **Single round trip**: all builders passed to `client.query()` are AND-joined and evaluated server-side in one request, avoiding multiple network calls and client-side joins
-- **`.Q` Proxy**: every Ontology model exposes a `.Q` attribute for type-safe, IDE-autocomplete-friendly field path expressions
-- **Three filter layers**: Sequence (session metadata) → Topic (channel + type) → OntologyCatalog (actual data values)
-- **Temporal windows**: extract and compare time intervals from a response with `clusterize()` and `intersect()` — see [Temporal Windows](./temporal_windows.mdx)

--- a/docs/main/docs/learn/query_sequences.mdx
+++ b/docs/main/docs/learn/query_sequences.mdx
@@ -95,8 +95,4 @@ The Rust SDK is currently in development.
 
 ## Key Concepts
 
-**Convenience methods** like `with_name_match()` and `with_user_metadata()` cover the most common filtering patterns. `with_name_match()` is intentionally fuzzy so you can match recording names without knowing them exactly. `with_user_metadata()` gives you precise control over any field you stored at ingestion time, with a full set of comparison operators.
-
-**Generic methods** using `with_expression()` and the `.Q` proxy give you access to the full operator set (`.gt()`, `.lt()`, `.between()`, and others) when the convenience methods do not cover your use case. The `.Q` proxy builds type-safe field paths from Ontology models, ensuring that the field names in your query match the actual schema.
-
-**Dynamic metadata** through dot notation means you can query any depth of nesting in the metadata you stored at recording time. There is no fixed schema for user metadata; whatever JSON-like structure you attached to the Sequence is fully searchable using `"key.subkey.deeper"` paths.
+**Generic methods** using `with_expression()` and the `.Q` proxy give you access to the full operator set (`.gt()`, `.lt()`, `.between()`, and others) when the convenience methods above do not cover your use case. See [The `.Q` Proxy](./multi_domain_query.mdx#the-q-proxy) for how it builds type-safe field paths from Ontology models.

--- a/docs/main/docs/learn/query_topics.mdx
+++ b/docs/main/docs/learn/query_topics.mdx
@@ -7,9 +7,9 @@ description: "How to search for specific sensor channels (Topics) across the dat
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-While Sequence queries let you find recording sessions by their session-level metadata, Topic queries let you go one level deeper: you search for specific sensor channels across your entire dataset, regardless of which recording session they belong to. This is useful when you are not looking for a particular mission but for a particular kind of sensor. For example, you might want to find every IMU channel recorded through a serial interface across all sessions, perhaps to audit hardware configurations, build a training dataset for a model that requires IMU data, or check which sessions have coverage from a particular sensor type.
+While Sequence queries let you find recording sessions by their session-level metadata, Topic queries let you go one level deeper: you search for specific sensor channels across your entire dataset, regardless of which recording session they belong to. This is useful when you are not looking for a particular mission but for a particular kind of sensor — for example, finding every IMU channel recorded through a serial interface across all sessions.
 
-The `QueryTopic` builder works the same way as `QuerySequence`: each `.with_*()` call you chain onto it adds another AND condition, and the daemon evaluates all conditions together on the server side. Only Topics that satisfy every constraint are returned.
+The `QueryTopic` builder works the same way as [`QuerySequence`](./query_sequences.mdx): each `.with_*()` call you chain onto it adds another AND condition, and the daemon evaluates all conditions together on the server side. Only Topics that satisfy every constraint are returned.
 
 <Tabs>
 
@@ -41,16 +41,7 @@ You can narrow the results further by chaining `with_user_metadata()` calls, com
 
 ### Pattern Matching: Wildcards and Glob Keys
 
-Both `with_name_match()` and the `match=` keyword of `with_user_metadata()` accept a lightweight glob-style pattern instead of an exact value:
-
-| Wildcard | Description | Example | Matches |
-| --- | --- | --- | --- |
-| `*` | Zero or more characters, including spaces | `/front*` | `/front/camera`, `/front/imu` |
-| `?` | Exactly one character, including spaces | `?.2.0` | `1.2.0`, `3.2.0` (not `10.2.0`) |
-| `[]` | A character set or range | `[gs]*` | `gyrolytics`, `satnavics` |
-| `#` | Any single digit (`0`-`9`); shorthand for `[0-9]` | `camera_#` | `camera_1` |
-
-These wildcards apply to the Topic `name`, or metadata **values** passed through `with_user_metadata(key, match=...)`. Glob patterns apply to metadata **keys only**: `*` matches exactly one key segment, and `**` matches one or more segments at any depth. For example, `"*.type"` matches `interface.type` or `sensor.type`, while `"**.type"` also matches `interface.driver.type`.
+`with_name_match()` and the `match=` keyword of `with_user_metadata()` accept the same lightweight glob syntax (`*`, `?`, `[]`, `#`) described in [Query Sequences](./query_sequences.mdx#pattern-matching-wildcards-and-glob-keys), applied here to Topic names instead of Sequence names — e.g. `/front*` matches `/front/camera` and `/front/imu`. Metadata key globs work identically.
 
 In the example below, the query combines the IMU type filter with a metadata filter matching any key ending in `.type` (one level deep) whose value starts with `serial`. The AND semantics mean both conditions must hold simultaneously.
 
@@ -92,8 +83,6 @@ The Rust SDK is currently in development.
 
 ## Key Concepts
 
-**Ontology tags** are the primary way to filter by sensor type. Each Ontology type in Mosaico carries a tag that uniquely identifies it in the catalog. Calling `.ontology_tag()` on a model class (for example `IMU.ontology_tag()`) returns the string identifier that the daemon uses internally to classify Topics. Using this tag as a filter guarantees type safety: you get back only Topics whose data actually conforms to the IMU schema, not just Topics that happen to be named `/imu`.
+**Type safety via ontology tags.** Filtering with `with_ontology_tag()` guarantees you get back only Topics whose data actually conforms to that schema, not just Topics that happen to be named similarly (e.g. `/imu`).
 
-**Combining filters** with `with_ontology_tag()` and `with_user_metadata()` narrows results with AND semantics. Because every `.with_*()` call adds an additional required condition, you can compose arbitrarily specific queries. Start with a type filter to establish the sensor kind, then add metadata conditions to select by hardware variant, interface type, calibration status, or any other field you stored at ingestion time.
-
-**Generic methods** using `with_expression()` and the `.Q` proxy give you access to the full operator set when the convenience methods do not cover your use case. The `.Q` proxy builds type-safe field paths directly from Ontology model definitions, so your queries stay consistent with the schema even as it evolves.
+**Generic methods** using `with_expression()` and the `.Q` proxy give you access to the full operator set when the convenience methods do not cover your use case. The `.Q` proxy builds type-safe field paths directly from Ontology model definitions, so your queries stay consistent with the schema even as it evolves. See [Multi-Domain Queries](./multi_domain_query.mdx#the-q-proxy) for how the proxy works.

--- a/docs/main/docs/learn/queryable_fields_queries.mdx
+++ b/docs/main/docs/learn/queryable_fields_queries.mdx
@@ -90,7 +90,7 @@ from mosaicolabs.query.queryable_fields import QueryableNumeric
 with MosaicoClient.connect("localhost", 6726) as client:
     # Find sequences where the gyro's X-axis reading exceeded 0.5 rad/s
     results = client.query(
-        QueryOntologyCatalog(include_timestamp_range=True).with_expression(
+        QueryOntologyCatalog().with_expression(
             QueryableNumeric("GyroRaw.gyro.x").gt(0.5)
         )
     )
@@ -99,7 +99,8 @@ with MosaicoClient.connect("localhost", 6726) as client:
         for item in results:
             print(f"Sequence: {item.sequence.name}")
             for topic in item.topics:
-                start, end = topic.timestamp_range.start, topic.timestamp_range.end
+                cluster = topic.clusterize()[0]
+                start, end = cluster.timerange.start, cluster.timerange.end
                 print(f"  Topic: {topic.name} | Match Window: {start} to {end}")
 ```
 </TabItem>
@@ -156,8 +157,8 @@ The Rust SDK is currently in development.
 **Field paths are the contract, not the class.** `IMU.Q.acceleration.x` and `QueryableNumeric("IMU.acceleration.x")` compile down to the identical `f"{ontology_tag}.field.subfield"` string the server matches against. The class is a convenience for building that string safely; it isn't required to build it.
 
 **Operator sets mirror the `.Q` proxy, with one gap.** 
-* `QueryableNumeric` supports `.eq()`, `.neq()`, `.lt()`, `.leq()`, `.gt()`, `.geq()`, `.in_()`, and `.between()`.
-* `QueryableString` supports `.eq()`, `.match()`, `.lt()`, `.leq()`, `.gt()`, `.geq()`, and `.in_()` - it does not have `.neq()` or `.between()`.
+* `QueryableNumeric` supports `.eq()`, `.neq()`, `.lt()`, `.leq()`, `.gt()`, `.geq()`, `.in_()`, `.between()`, and `.outside()`.
+* `QueryableString` supports `.eq()`, `.match()`, `.lt()`, `.leq()`, `.gt()`, `.geq()`, `.in_()`, `.between()`, and `.outside()`.
 
 **There's no client-side schema check.** Because no class is involved, the SDK cannot verify that `"GyroRaw.gyro.x"` actually exists or is really numeric before sending the query. A typo'd path or a type mismatch doesn't raise an error - it simply matches nothing.
 

--- a/docs/main/docs/learn/secure_connection.mdx
+++ b/docs/main/docs/learn/secure_connection.mdx
@@ -1,7 +1,7 @@
 ---
 title: Secure Connection
-sidebar_position: 10
-description: "How to secure SDK connections to mosaicod in production. Covers one-way TLS with a CA-signed certificate, two-way TLS with a custom certificate file, API key injection, and reading credentials from environment variables."
+sidebar_position: 11
+description: "How to secure SDK connections to mosaicod in production. Covers one-way TLS with a CA-signed certificate, one-way TLS with a custom CA certificate file, API key injection, and reading credentials from environment variables."
 ---
 
 import Tabs from '@theme/Tabs';
@@ -39,13 +39,13 @@ Mosaico supports two TLS modes that correspond to the same distinction you encou
 
 **One-way TLS** (`enable_tls=True`) works like standard HTTPS. The server presents a certificate during the TLS handshake; the client verifies it against a trusted Certificate Authority. The server is authenticated, but the client presents no certificate of its own. Use this mode when `mosaicod` is deployed behind a cloud load balancer or a reverse proxy that holds a CA-signed certificate (e.g. Let's Encrypt or a managed certificate from your cloud provider).
 
-**Two-way TLS with a certificate file** (`tls_cert_path`) is used when you need the client to validate the server against a specific certificate, typically a self-signed certificate or one issued by an internal PKI that is not in the system's default CA bundle. You point `tls_cert_path` at the PEM file for the server's CA certificate, and the SDK uses that file exclusively to verify the server identity. This is the right choice for on-premise deployments, edge robots with a private certificate authority, or any environment where you manage your own PKI.
+**One-way TLS with a custom CA certificate** (`tls_cert_path`) is used when you need the client to validate the server against a specific certificate, typically a self-signed certificate or one issued by an internal PKI that is not in the system's default CA bundle. You point `tls_cert_path` at the PEM file for the server's CA certificate, and the SDK uses that file exclusively to verify the server identity. This is still a server-authenticated connection, not mutual TLS: the client presents no certificate of its own. This is the right choice for on-premise deployments, edge robots with a private certificate authority, or any environment where you manage your own PKI.
 
 ### API Keys: Authenticating the Caller
 
 API keys are opaque tokens that the SDK injects as gRPC metadata on every call to the daemon. The daemon validates the key server-side before executing any request. Keys are created and revoked through the daemon's key management commands; consult the CLI reference for the exact commands.
 
-Never hard-code an API key in source code that gets committed to version control. If the key is exposed it must be rotated immediately. In production code, read credentials from environment variables or a secrets manager at runtime.
+Never hard-code an API key in source code that gets committed to version control — see [Production Best Practice](#production-best-practice-use-environment-variables) below for the safe pattern.
 
 ## Option 1: One-Way TLS
 
@@ -82,25 +82,18 @@ The Rust SDK is currently in development.
 </TabItem>
 </Tabs>
 
-## Option 2: Two-Way TLS with Certificate
+## Option 2: One-Way TLS with a Custom CA Certificate
 
-Use this when the daemon uses a self-signed certificate or an internal CA certificate that is not in your system's default trust store. The `tls_cert_path` parameter tells the SDK exactly which certificate to trust when verifying the server.
+Use this when the daemon uses a self-signed certificate or an internal CA certificate that is not in your system's default trust store. Same as Option 1, but pass `tls_cert_path` pointing to the server's CA certificate instead of `enable_tls=True` — the SDK enables TLS automatically whenever a certificate path is provided.
 
 <Tabs>
 <TabItem value="python" label="Python" default>
-```python title="Two-way TLS with certificate"
-from mosaicolabs import MosaicoClient
-
-MOSAICO_HOST = "mosaico.production.yourdomain.com"
-MOSAICO_PORT = 6726
-CERT_PATH = "/etc/mosaico/certs/server_ca.pem"
-MY_API_KEY = "msco_vy9lqa7u4lr7w3vimhz5t8bvvc0xbmk2_9c94a86"
-
+```python title="One-way TLS with a custom CA certificate"
 with MosaicoClient.connect(
     host=MOSAICO_HOST,
     port=MOSAICO_PORT,
     api_key=MY_API_KEY,
-    tls_cert_path=CERT_PATH
+    tls_cert_path="/etc/mosaico/certs/server_ca.pem"
 ) as client:
     print(f"Connected to version: {client.version()}")
     sequences = client.list_sequences()
@@ -126,25 +119,19 @@ Hard-coding credentials in source code is a security risk. If the file is accide
 ```python title="Read credentials from environment"
 import os
 MY_API_KEY = os.environ["MOSAICO_API_KEY"]
-CERT_PATH = os.environ.get("MOSAICO_CERT_PATH")
+CERT_PATH = os.environ.get("MOSAICO_TLS_CERT_FILE")
 ```
 Use a secrets manager (such as AWS Secrets Manager, HashiCorp Vault, or Kubernetes Secrets) to inject these variables into the process environment at deploy time. Never commit `.env` files that contain real keys.
 :::
 
-The example below shows a fully environment-driven connection that handles both TLS modes automatically: if `MOSAICO_CERT_PATH` is set, the SDK uses the certificate file; if not, it falls back to `None` (no TLS or plain `enable_tls` depending on your deployment).
+Rather than reading these variables manually, [`MosaicoClient.from_env()`](https://docs.mosaico.dev/python-sdk/SDK/API_reference/comm/#mosaicolabs.comm.MosaicoClient.from_env) does it for you: it resolves `MOSAICO_TLS_CERT_FILE` and `MOSAICO_API_KEY` from the environment and passes them to `connect()`, enabling TLS automatically when a certificate path is found and falling back to plain gRPC otherwise.
 
 <Tabs>
 <TabItem value="python" label="Python" default>
 ```python title="Environment-driven connection"
-import os
 from mosaicolabs import MosaicoClient
 
-with MosaicoClient.connect(
-    host=os.environ["MOSAICO_HOST"],
-    port=int(os.environ.get("MOSAICO_PORT", "6726")),
-    api_key=os.environ["MOSAICO_API_KEY"],
-    tls_cert_path=os.environ.get("MOSAICO_CERT_PATH"),
-) as client:
+with MosaicoClient.from_env(host="mosaico.production.yourdomain.com", port=6726) as client:
     sequences = client.list_sequences()
 ```
 </TabItem>
@@ -164,6 +151,6 @@ The Rust SDK is currently in development.
 
 - **Plain gRPC** is the default and is suitable for localhost or trusted private networks
 - **`enable_tls=True`** enables one-way TLS; the server is authenticated using the system CA bundle; use this for cloud deployments with CA-signed certificates
-- **`tls_cert_path`** enables TLS with a specific certificate file; use this for self-signed certificates or internal PKI
+- **`tls_cert_path`** enables one-way TLS with a specific CA certificate file; use this for self-signed certificates or internal PKI
 - **API keys** are injected as gRPC metadata on every call; they are created and managed via the `mosaicod` key management CLI commands
-- **Never hard-code credentials**; read them from environment variables or a secrets manager at runtime
+- **Never hard-code credentials**; read them from environment variables or a secrets manager at runtime, or use `MosaicoClient.from_env()` to resolve `MOSAICO_TLS_CERT_FILE` and `MOSAICO_API_KEY` automatically

--- a/docs/main/docs/learn/streaming_data.mdx
+++ b/docs/main/docs/learn/streaming_data.mdx
@@ -13,7 +13,7 @@ The first mode, `SequenceDataStreamer`, is for situations where you need to work
 
 The second mode, `TopicDataStreamer`, is for situations where you only need one sensor. Because there is nothing to merge, the streamer reads directly from a single topic stream with minimal overhead. This is the right choice when you are isolating a sensor for analysis, building a calibration pipeline, or feeding a single data channel into a machine learning model. There is no point paying the cost of a merge when you only care about one input.
 
-Both streamers support temporal slicing: you supply `start_timestamp_ns` and `end_timestamp_ns` to bound the replay window, so you never have to load a full recording when you only care about a segment. These bounds are matched against the `Message.timestamp_ns` of each record, the playback time, not the sensor measurement time stored in the Ontology's `Header` field.
+Both streamers support temporal slicing: you supply `start_timestamp_ns` and `end_timestamp_ns` to bound the replay window, so you never have to load a full recording when you only care about a segment. These bounds are matched against the `Message.timestamp_ns` of each record, the playback time, not the sensor measurement time stored in the Ontology's `Header` field. `start_timestamp_ns` is inclusive and `end_timestamp_ns` is exclusive.
 
 <Tabs>
 
@@ -81,7 +81,7 @@ The Rust SDK is currently in development.
 
 Because there is no merge happening, each message you receive is of a known type. In the example below every iteration yields an IMU message, and you call `.get_data(IMU)` to extract the typed payload directly. This pattern is common in ML data pipelines where a dataloader needs a clean, single-type stream it can batch without branching on sensor identity.
 
-`next_timestamp()` is available here too, and serves the same purpose: peek at the first sample's timestamp before committing to the loop. It is particularly handy when you are building a custom synchronization loop across multiple `TopicDataStreamer` instances and need to decide which one to advance next.
+`next_timestamp()` is available here too, with the same purpose described above — particularly handy when building a custom synchronization loop across multiple `TopicDataStreamer` instances and deciding which one to advance next.
 
 As with `SequenceHandler`, always call `top_handler.close()` when the loop is done to release the server-side connection.
 
@@ -116,8 +116,6 @@ The Rust SDK is currently in development.
 </Tabs>
 
 ## Streamer Comparison
-
-The table below summarizes the trade-offs. In practice, reach for `SequenceDataStreamer` whenever you need a global view of what happened during a recording: system-level replays, event correlation, multi-sensor visualizations. Reach for `TopicDataStreamer` whenever your downstream consumer only cares about one channel and you want the lowest possible overhead.
 
 | Feature | SequenceDataStreamer | TopicDataStreamer |
 |---|---|---|

--- a/docs/main/docs/learn/streaming_to_foxglove.mdx
+++ b/docs/main/docs/learn/streaming_to_foxglove.mdx
@@ -1,0 +1,360 @@
+---
+title: Live Streaming to Foxglove
+sidebar_position: 14
+description: "How to stream Mosaico Sequence data directly into a live Foxglove session over the Foxglove WebSocket protocol, without exporting to MCAP first. Covers starting a Foxglove WebSocket server as the only sink, mapping Mosaico Ontology fields onto well-known Foxglove schemas instead of raw JSON, correctly mapping Message.timestamp_ns and Header.timestamp onto Foxglove's log_time and schema-level timestamp, pacing a replay to wall-clock time, and the WebSocketServer lifecycle."
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Getting a Mosaico Sequence into Foxglove doesn't require an intermediate file. The [Foxglove SDK](https://pypi.org/project/foxglove-sdk/) can open a live WebSocket server directly inside your Python process; anything you `log()` to it is broadcast immediately to whatever Foxglove app is connected, with nothing ever written to disk. This guide covers replaying an already-ingested Sequence into a live Foxglove session at its original cadence — useful for a review session or a quick sanity check — using `RobotJoint` data as the running example.
+
+<Tabs>
+
+<TabItem value="python" label="Python" default>
+:::tip[Learn]
+[Doc: The Reading Workflow](https://docs.mosaico.dev/python-sdk/SDK/handling/reading/)
+
+[Doc: Message (The Envelope)](https://docs.mosaico.dev/python-sdk/SDK/ontology/#message-the-envelope)
+:::
+</TabItem>
+
+<TabItem value="cpp" label="C++">
+The C++ SDK is currently in development.
+</TabItem>
+
+<TabItem value="rust" label="Rust">
+The Rust SDK is currently in development.
+</TabItem>
+
+</Tabs>
+
+```bash title="Install the Foxglove SDK"
+pip install mosaicolabs foxglove-sdk
+```
+
+## Why a Live WebSocket Sink, Not a File
+
+Writing an MCAP file and opening it in Foxglove is a perfectly valid workflow, but it is a *different* one: it produces a file you load afterwards. `foxglove.start_server()` instead opens a WebSocket server that acts as a live sink — every message you log through it is pushed straight to any connected Foxglove client, the moment you log it. Nothing is buffered to disk, and there is no file to clean up afterwards; the data only ever exists as a live stream, exactly like a robot's UI would display it while running. In Foxglove itself, this is "Open connection" → "Foxglove WebSocket" instead of "Open local file".
+
+## Locating the Data
+
+Finding and validating the Topic to replay uses the same `QuerySequence`/`QueryTopic` + `TopicHandler` pattern covered in the [MuJoCo Visualisation](https://docs.mosaico.dev/examples/mujoco_visualisation) example: filter by `RobotJoint.ontology_tag()` to find joint-state Topics regardless of how the channel happens to be named, then confirm the match with a `TopicHandler` before streaming anything.
+
+## Mapping Ontology Types onto Well-Known Foxglove Schemas
+
+<Tabs groupId="lang" defaultValue="python">
+<TabItem value="python" label="Python">
+
+The simplest way to get something on screen is `foxglove.log(topic, {"some": "dict"})`: it creates a schemaless JSON channel, and Foxglove can only render it generically — one line per dictionary key in a Plot panel, at best. The [`foxglove.channels`](https://pypi.org/project/foxglove-sdk/) module ships typed channels for well-known robotics concepts instead, and one of them — `JointStatesChannel` — maps directly onto `RobotJoint`: same index-aligned arrays of names, positions, velocities, and efforts, just organized as a list of per-joint structs rather than parallel lists. Using it gets you Foxglove's dedicated joint-state visualizations for free, instead of a generic plot.
+
+```python title="Well-known schema instead of raw JSON"
+from foxglove.channels import JointStatesChannel
+from foxglove.messages import JointState, JointStates
+
+# Created ONCE, outside the streaming loop — see "Server Lifecycle" below.
+joint_channel = JointStatesChannel("/robot/joint_states")
+
+def to_joint_states(joints: RobotJoint) -> JointStates:
+    return JointStates(
+        joints=[
+            JointState(name=name, position=pos, velocity=vel, effort=eff)
+            for name, pos, vel, eff in zip(
+                joints.names, joints.positions, joints.velocities, joints.efforts
+            )
+        ],
+    )
+```
+
+</TabItem>
+<TabItem value="cpp" label="C++">
+
+The C++ SDK is currently in development.
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+The Rust SDK is currently in development.
+
+</TabItem>
+</Tabs>
+
+The channel is created once, before the streaming loop, and reused for every message — exactly like a `TopicWriter` on the write side: creating a new `JointStatesChannel` for the same topic on every message would just be wasted work.
+
+## Streaming Class-less (`Unmodeled`) Data
+
+<Tabs groupId="lang" defaultValue="python">
+<TabItem value="python" label="Python">
+
+Not every Topic has a class to build a well-known schema from. For a Topic whose message type has no adapter — retrieved via `msg.get_data(Unmodeled)`, as in [Advanced: Ingesting Unmodeled Ontologies](https://docs.mosaico.dev/python-sdk/SDK/ontology/#advanced-ingesting-unmodeled-ontologies) — there is no `JointState`-style structure to build. This isn't a workaround: `Unmodeled.raw_data` is already a plain dict of the same JSON-friendly types (numbers, strings, booleans, nested dicts and lists) that `foxglove.log()` accepts directly, so you can stream it without ever resolving a Python class for the ontology tag — mirroring how [Class-Free Queries](https://docs.mosaico.dev/python-sdk/SDK/query/#class-free-queries) let you query the same data without one.
+
+```python title="Stream an Unmodeled topic as schemaless JSON"
+import base64
+
+from mosaicolabs.models.core.unmodeled import Unmodeled
+
+def to_json_safe(value):
+    # raw_data can contain `bytes` (from a pa.binary() field), which json.dumps
+    # can't serialize on its own — everything else is already JSON-friendly.
+    if isinstance(value, bytes):
+        return base64.b64encode(value).decode("ascii")
+    if isinstance(value, dict):
+        return {k: to_json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [to_json_safe(v) for v in value]
+    return value
+
+def stream_unmodeled_topic_live(top_handler) -> None:
+    wall_start = time.monotonic()
+
+    for msg in top_handler.get_data_streamer():
+        relative_ts = (msg.timestamp_ns - top_handler.timestamp_ns_min) / 1.0e9
+        sleep_for = relative_ts - (time.monotonic() - wall_start)
+        if sleep_for > 0:
+            time.sleep(sleep_for)
+
+        unmodeled = msg.get_data(Unmodeled)
+        if unmodeled is None:
+            continue
+
+        foxglove.log(top_handler.name, to_json_safe(unmodeled.raw_data), log_time=msg.timestamp_ns)
+```
+
+</TabItem>
+<TabItem value="cpp" label="C++">
+
+The C++ SDK is currently in development.
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+The Rust SDK is currently in development.
+
+</TabItem>
+</Tabs>
+
+:::info[What to expect in Foxglove]
+Since there is no schema, Foxglove treats the topic as generic JSON rather than a known message type:
+
+* The **Topics** panel lists it with no schema name, unlike the typed `/robot/joint_states` topic above.
+* Add a **Raw Messages** panel and subscribe to the topic to see `raw_data` rendered as a plain, expandable JSON tree — field names match the ontology's Arrow schema exactly (e.g. `gyro.x`).
+* A **Plot** panel can still chart individual numeric fields, using the same dot-notation message path as any other topic (e.g. `/lidar/imu_raw.gyro.x`) — you just have to know the path yourself, since there's no schema for Foxglove to autocomplete it from.
+* There is no dedicated 3D or domain-specific panel: that visualization richness is exactly what a well-known schema like `JointStatesChannel` buys you, and what streaming raw JSON gives up in exchange for needing no adapter or class at all.
+:::
+
+The same `log_time = msg.timestamp_ns` mapping from [Two Clocks, Two Timestamps](#two-clocks-two-timestamps) below still applies — it comes from the `Message` envelope regardless of whether the payload has a class. What doesn't carry over is the schema-level `timestamp` field: since `raw_data`'s shape is only known at runtime, there's no canonical place to look for a measurement timestamp the way `RobotJoint.header.timestamp` provides one, even if a particular tag's `raw_data` happens to contain a similarly-shaped field.
+
+## Two Clocks, Two Timestamps
+
+<Tabs groupId="lang" defaultValue="python">
+<TabItem value="python" label="Python">
+
+`Channel.log(msg, log_time=...)` and the `JointStates` schema itself both carry a notion of time, and they are not the same clock — the distinction is the same one covered in depth for [`Message` vs `Header`](https://docs.mosaico.dev/python-sdk/SDK/ontology/#message-the-envelope):
+
+* **`log_time`** is the channel-level time Foxglove uses to place a message on its timeline — the playback clock. This is exactly `Message.timestamp_ns`, the envelope timestamp every `RobotJoint` message already carries.
+* **`JointStates.timestamp`** is the schema's own field for *when the joints were actually measured* — the sensor clock. This is `RobotJoint.header.timestamp`, when present.
+
+```python title="Map both clocks explicitly"
+def to_joint_states(joints: RobotJoint) -> JointStates:
+    header_ts = joints.header.timestamp if joints.header else None
+    return JointStates(
+        timestamp=(
+            Timestamp(sec=header_ts.seconds, nsec=header_ts.nanoseconds)
+            if header_ts is not None
+            else None
+        ),
+        joints=[
+            JointState(name=name, position=pos, velocity=vel, effort=eff)
+            for name, pos, vel, eff in zip(
+                joints.names, joints.positions, joints.velocities, joints.efforts
+            )
+        ],
+    )
+
+# ...
+
+joint_channel.log(to_joint_states(joints), log_time=joint_msg.timestamp_ns)
+```
+
+</TabItem>
+<TabItem value="cpp" label="C++">
+
+The C++ SDK is currently in development.
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+The Rust SDK is currently in development.
+
+</TabItem>
+</Tabs>
+
+Getting these backwards is an easy mistake to make: passing `Header.timestamp` as `log_time` would place messages on Foxglove's timeline using each sensor's own clock origin — which, as covered in the `Message` guide, has no common origin across topics and cannot be relied on for ordering.
+
+## Pacing the Replay to Wall-Clock Time
+
+<Tabs groupId="lang" defaultValue="python">
+<TabItem value="python" label="Python">
+
+Streaming a `TopicDataStreamer` as fast as possible would blast years of data at Foxglove in milliseconds. To replay it at the speed it was recorded, track how far into the recording each message is and sleep until real time catches up — the same pacing technique used in the [MuJoCo Visualisation](https://docs.mosaico.dev/examples/mujoco_visualisation) example:
+
+```python title="Pace messages to their original cadence"
+import time
+
+def stream_topic_live(top_handler) -> None:
+    wall_start = time.monotonic()
+
+    for joint_msg in top_handler.get_data_streamer():
+        relative_ts = (joint_msg.timestamp_ns - top_handler.timestamp_ns_min) / 1.0e9
+
+        sleep_for = relative_ts - (time.monotonic() - wall_start)
+        if sleep_for > 0:
+            time.sleep(sleep_for)
+
+        joints = joint_msg.get_data(RobotJoint)
+        joint_channel.log(to_joint_states(joints), log_time=joint_msg.timestamp_ns)
+```
+
+</TabItem>
+<TabItem value="cpp" label="C++">
+
+The C++ SDK is currently in development.
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+The Rust SDK is currently in development.
+
+</TabItem>
+</Tabs>
+
+## Server Lifecycle
+
+<Tabs groupId="lang" defaultValue="python">
+<TabItem value="python" label="Python">
+
+`foxglove.start_server()` returns a `WebSocketServer` handle. It has no context-manager support, so nothing stops it automatically — call `.stop()` yourself once streaming is done, inside a `finally` block so a Mosaico error or a `Ctrl-C` during replay doesn't leave the server dangling:
+
+```python title="Explicit server shutdown"
+server = foxglove.start_server()
+try:
+    # ... locate topics and stream, as above ...
+    pass
+finally:
+    server.stop()
+```
+
+</TabItem>
+<TabItem value="cpp" label="C++">
+
+The C++ SDK is currently in development.
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+The Rust SDK is currently in development.
+
+</TabItem>
+</Tabs>
+
+## Full Example
+
+<Tabs groupId="lang" defaultValue="python">
+<TabItem value="python" label="Python">
+
+```python title="Full example"
+import time
+
+import foxglove
+from foxglove.channels import JointStatesChannel
+from foxglove.messages import JointState, JointStates, Timestamp
+
+from mosaicolabs import MosaicoClient, QuerySequence, QueryTopic
+from mosaicolabs.models.sensors.robot import RobotJoint
+
+ROBOT_SEQUENCE_NAME = "r2b_robotarm_0"
+
+# Created once, reused for every message.
+joint_channel = JointStatesChannel("/robot/joint_states")
+
+def to_joint_states(joints: RobotJoint) -> JointStates:
+    header_ts = joints.header.timestamp if joints.header else None
+    return JointStates(
+        timestamp=(
+            Timestamp(sec=header_ts.seconds, nsec=header_ts.nanoseconds)
+            if header_ts is not None
+            else None
+        ),
+        joints=[
+            JointState(name=name, position=pos, velocity=vel, effort=eff)
+            for name, pos, vel, eff in zip(
+                joints.names, joints.positions, joints.velocities, joints.efforts
+            )
+        ],
+    )
+
+def stream_topic_live(top_handler) -> None:
+    wall_start = time.monotonic()
+
+    for joint_msg in top_handler.get_data_streamer():
+        relative_ts = (joint_msg.timestamp_ns - top_handler.timestamp_ns_min) / 1.0e9
+
+        sleep_for = relative_ts - (time.monotonic() - wall_start)
+        if sleep_for > 0:
+            time.sleep(sleep_for)
+
+        joints = joint_msg.get_data(RobotJoint)
+        joint_channel.log(to_joint_states(joints), log_time=joint_msg.timestamp_ns)
+
+def main() -> None:
+    server = foxglove.start_server()
+    print(f"Foxglove server listening on ws://localhost:{server.port}")
+
+    try:
+        with MosaicoClient.connect("localhost", 6726) as client:
+            result = client.query(
+                QuerySequence().with_name(ROBOT_SEQUENCE_NAME),
+                QueryTopic().with_ontology_tag(RobotJoint.ontology_tag()),
+            )
+            if result is None:
+                print(f"Sequence '{ROBOT_SEQUENCE_NAME}' not found.")
+                return
+
+            for item in result:
+                for topic in item.topics:
+                    top_handler = client.topic_handler(item.sequence.name, topic.name)
+                    if top_handler is None:
+                        continue
+                    if top_handler.ontology_tag != RobotJoint.ontology_tag():
+                        continue
+
+                    stream_topic_live(top_handler)
+    finally:
+        server.stop()
+
+if __name__ == "__main__":
+    main()
+```
+
+</TabItem>
+<TabItem value="cpp" label="C++">
+
+The C++ SDK is currently in development.
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+The Rust SDK is currently in development.
+
+</TabItem>
+</Tabs>
+
+## Key Concepts
+
+- **A live sink, not a file**: `foxglove.start_server()` is a WebSocket server your process hosts directly; connected Foxglove clients receive each `log()` call immediately, with nothing written to disk.
+- **Prefer well-known schemas over raw JSON when a class is available**: `foxglove.channels` ships typed channels (`JointStatesChannel`, `PoseInFrameChannel`, `LocationFixChannel`, and others) that map naturally onto several Mosaico Ontology types and unlock Foxglove's dedicated panels, instead of a generic Plot fed by ad-hoc dictionaries.
+- **When there's no class, `raw_data` is already JSON-shaped**: `Unmodeled.raw_data` needs no schema mapping at all — only a `bytes`-to-base64 conversion — before it can be logged as generic JSON, at the cost of losing Foxglove's dedicated panels for that topic.
+- **`log_time` is `Message.timestamp_ns`; the schema's own timestamp is `Header.timestamp`**: the same envelope/measurement distinction covered for the SDK's own `Message` class applies identically on the Foxglove side.
+- **The channel is stateful, create it once**: like a `TopicWriter`, a `JointStatesChannel` should be created once per topic and reused for every message, not recreated in the streaming loop.
+- **This same pattern extends to truly live data**: nothing here is specific to replaying an archived Sequence — a process ingesting live robot data into Mosaico (as in the [Writing](./writing_single_topic.mdx) guides) can log to a Foxglove channel side by side with pushing to a `TopicWriter`, mirroring the live stream to Foxglove as it is being recorded.
+- **Scrubbing and playback control are possible but out of scope here**: the WebSocket server supports advertising `Capability.PlaybackControl` and handling seek/pause requests via a `ServerListener`, which would let a Foxglove client scrub through the Sequence instead of only watching it play forward. That is a natural next step once the streaming pattern above is in place.

--- a/docs/main/docs/learn/temporal_windows.mdx
+++ b/docs/main/docs/learn/temporal_windows.mdx
@@ -1,6 +1,6 @@
 ---
 title: Temporal Windows
-sidebar_position: 8
+sidebar_position: 9
 description: "How to extract and compare time intervals from a query response using clusterize() and intersect(), with pointers to clusterize_all() and the sequence-level intersect() for operating across every topic at once."
 ---
 
@@ -9,12 +9,12 @@ import TabItem from '@theme/TabItem';
 
 ## Extracting and Comparing Time Intervals
 
-When a query includes a `QueryOntologyCatalog` filter, a matched topic doesn't just tell you **that** its condition was satisfied but also **when**. Starting from a query response, you can compute and compare these time intervals: split a single topic's matches into distinct windows, or check whether two different signals were true at the same moment. Concretely, you can:
+When a query includes a `QueryOntologyCatalog` filter, a matched topic doesn't just tell you **that** its condition was satisfied but also **when**. Starting from a query response, you can compute and compare these time intervals: split a single topic's matches into distinct windows, or check whether two different signals were true at the same moment. This guide walks through the two operations you'll reach for most often:
 
-- retrieve and merge all the time intervals associated to one topic where the query is satisfied. See [clusterize](https://docs.mosaico.dev/python-sdk/SDK/query/#topic-clusterize) operation.
-- retrieve and compare different time intervals associated to different topics coming from different queries, finding whether two distinct events happened at the same time. See [topic intersect](https://docs.mosaico.dev/python-sdk/SDK/query/#topics-intersect) operation.
-- retrieve and merge all the time intervals associated to all sequence's topics where the query is satisfied. See [clusterize_all](https://docs.mosaico.dev/python-sdk/SDK/query/#sequence-clusterize) operation.
-- retrieve and compare different time intervals associated to different topics' sequences. See [sequence intersect](https://docs.mosaico.dev/python-sdk/SDK/query/#sequences-intersect) operation.
+- **`clusterize()`**: retrieve and merge all the time intervals associated to one topic where the query is satisfied.
+- **`intersect()`** on a `QueryResponseItem`: retrieve and compare time intervals across all of a sequence's topics at once, finding whether they were simultaneously true.
+
+Two related operations are covered only in [Key Concepts](#key-concepts) below, with a link to the full reference: `clusterize_all()` (the sequence-wide counterpart of `clusterize()`) and the topic-level `intersect()` (for correlating a hand-picked set of topics, even across different queries or sequences).
 
 <Tabs>
 

--- a/docs/main/docs/learn/updating_sequences.mdx
+++ b/docs/main/docs/learn/updating_sequences.mdx
@@ -1,0 +1,238 @@
+---
+title: Updating a Sequence
+sidebar_position: 12
+description: "How to add new Topics to a Sequence that has already been ingested and finalized, without re-uploading or touching existing data. Covers MosaicoClient.sequence_update() and SequenceHandler.update() as the two ways to obtain a SequenceUpdater, the read/write permission trade-off between them, SequenceUpdater.topic_create(), session-level error handling scoped to the update session only, verifying the update with reload(), and rolling back a single update session with session_delete()."
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+The [Writing](./writing_single_topic.mdx) guides cover the common case: you know everything you want to store in a Sequence at ingestion time. In practice, that is not always true. A post-processing pipeline might compute a derived signal hours after the original recording; a QA pass might want to attach a diagnostic stream to a mission that has already been finalized. `SequenceUpdater` covers exactly this: adding new Topics to a Sequence that already exists, without touching the data already stored in it.
+
+:::info[What updating does *not* do]
+`SequenceUpdater` can only add **new** Topics. It cannot modify the metadata of the Sequence or of an existing Topic, and it cannot append more messages to a Topic that was already finalized in a previous session. If you need to change something that already exists, that data must be re-ingested under a different Topic or Sequence.
+:::
+
+<Tabs>
+
+<TabItem value="python" label="Python" default>
+:::tip[Learn]
+[Doc: The Writing Workflow](https://docs.mosaico.dev/python-sdk/SDK/handling/writing/#sequenceupdater)
+
+[API Reference: Writing Data](https://docs.mosaico.dev/python-sdk/SDK/API_reference/handlers/writing/)
+:::
+</TabItem>
+
+<TabItem value="cpp" label="C++">
+The C++ SDK is currently in development.
+</TabItem>
+
+<TabItem value="rust" label="Rust">
+The Rust SDK is currently in development.
+</TabItem>
+
+</Tabs>
+
+## Why Update Instead of Re-Ingest
+
+Consider the `multi_sensor_ingestion` Sequence from the [Writing Multiple Topics](./writing_multiple_topics.mdx) guide: it already holds `sensors/imu`, `sensors/gps`, and `sensors/pressure`. Weeks later, an offline analysis estimates cabin temperature from the recorded pressure curve and you want that estimate queryable alongside the original data. Re-ingesting the whole Sequence just to add one derived stream would mean re-uploading gigabytes of IMU and GPS data that has not changed. `SequenceUpdater` opens a new, independent writing Session on the *existing* Sequence and lets you register only the new Topic.
+
+## Opening an Update Session
+
+There are two ways to obtain a `SequenceUpdater`, depending on which server-side permission your credentials need.
+
+<Tabs groupId="lang" defaultValue="python">
+<TabItem value="python" label="Python">
+
+**`client.sequence_update()`** opens the writing Session directly by name, with no intermediate read of the Sequence's metadata. This is the preferred way when connecting with an API-Key that only has the `write` permission — for example, an edge device or an offline processing job that should never be granted `read` access for security reasons.
+
+```python title="Open an update session (write-only credentials)"
+from mosaicolabs import MosaicoClient, SessionLevelErrorPolicy, Message, Temperature
+
+with MosaicoClient.connect("localhost", 6726) as client:
+    with client.sequence_update(
+        "multi_sensor_ingestion",
+        on_error=SessionLevelErrorPolicy.Report,
+    ) as seq_updater:
+        session_locator = seq_updater.session_locator
+        # Register the new topic and push data here...
+```
+
+If the Sequence does not exist, this raises when entering the `with` block, rather than letting you check for it upfront.
+
+**`SequenceHandler.update()`** is the better choice when you already hold a `SequenceHandler` for another reason in the same code path — for instance, you were about to inspect the Sequence's existing Topics or timestamps anyway. Obtaining that handler in the first place requires the `read` permission, on top of the `write` permission needed to actually update it:
+
+```python title="Open an update session (from an existing handler)"
+seq_handler = client.sequence_handler("multi_sensor_ingestion")  # requires 'read'
+if seq_handler is None:
+    raise RuntimeError("Sequence not found — has it been ingested yet?")
+
+with seq_handler.update(on_error=SessionLevelErrorPolicy.Report) as seq_updater:  # requires 'write'
+    session_locator = seq_updater.session_locator
+    # Register the new topic and push data here...
+```
+
+Both return the same `SequenceUpdater` and behave identically from this point on — like `SequenceWriter`, it must be used inside a `with` block.
+
+</TabItem>
+<TabItem value="cpp" label="C++">
+
+The C++ SDK is currently in development.
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+The Rust SDK is currently in development.
+
+</TabItem>
+</Tabs>
+
+:::info[Session-scoped error handling]
+`on_error` here works exactly like [`SessionLevelErrorPolicy`](./writing_single_topic.mdx#sequence-upload) on `SequenceWriter`, but the blast radius is smaller: it only governs the writing Session opened by this `.update()` call. `SessionLevelErrorPolicy.Delete` removes just the Topics created in *this* session if something goes wrong; the Topics from every previous session (`sensors/imu`, `sensors/gps`, `sensors/pressure`) are immutable and are never affected. The default is `SessionLevelErrorPolicy.Report`.
+:::
+
+`seq_updater.session_locator` identifies this specific writing Session (format `sequence_name:session_identifier`) — save it if you might need to roll back just this update later, as shown at the end of this guide.
+
+## Registering the New Topic
+
+<Tabs groupId="lang" defaultValue="python">
+<TabItem value="python" label="Python">
+
+Inside the `with` block, `seq_updater.topic_create()` works exactly like [`SequenceWriter.topic_create()`](./writing_single_topic.mdx#topic-creation): it returns a `TopicWriter` bound to one Ontology type, ready to `push()` messages.
+
+```python title="Register and push to the new topic"
+        cabin_temp_writer = seq_updater.topic_create(
+            topic_name="diagnostics/cabin_temperature",
+            metadata={"source": "offline_estimation_v2", "derived_from": "sensors/pressure"},
+            ontology_type=Temperature,
+        )
+
+        for timestamp_ns, celsius in offline_estimated_temperatures:
+            cabin_temp_writer.push(
+                message=Message(
+                    timestamp_ns=timestamp_ns,
+                    data=Temperature.from_celsius(value=celsius),
+                )
+            )
+```
+
+</TabItem>
+<TabItem value="cpp" label="C++">
+
+The C++ SDK is currently in development.
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+The Rust SDK is currently in development.
+
+</TabItem>
+</Tabs>
+
+The `metadata` dictionary above records `derived_from` alongside the source topic name — a useful convention for provenance, since nothing in the platform tracks it automatically. Multiple topics can be created in the same update Session, exactly as with `SequenceWriter`: just call `topic_create()` again with a different `topic_name`.
+
+When the `with` block exits normally, the new Topic is finalized and the update Session is marked complete — the same way it works for `SequenceWriter`.
+
+## Verifying the Update
+
+<Tabs groupId="lang" defaultValue="python">
+<TabItem value="python" label="Python">
+
+Checking the result needs a `SequenceHandler`, which in turn needs the `read` permission — if you opened the update Session with `client.sequence_update()` precisely to avoid that permission, this verification step belongs in a separate, read-capable client or process. Either way: a `SequenceHandler` caches the Sequence's topic list at the time it was obtained, so a handler obtained *before* the update Session won't reflect the new Topic on its own. Freshly obtaining one after the Session has closed already returns current data; reusing an older one requires calling `.reload()` first:
+
+```python title="Confirm the new topic is visible"
+    seq_handler.reload()
+    # Topic names are always normalized with a leading slash, regardless of
+    # whether it was included when calling topic_create().
+    assert "/diagnostics/cabin_temperature" in seq_handler.topics
+    print(f"Sequence now has {len(seq_handler.topics)} topics")
+```
+
+</TabItem>
+<TabItem value="cpp" label="C++">
+
+The C++ SDK is currently in development.
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+The Rust SDK is currently in development.
+
+</TabItem>
+</Tabs>
+
+The new Topic is queryable and readable through every mechanism covered elsewhere in these guides — [`QueryTopic`](./query_topics.mdx), [`QueryOntologyCatalog`](./multi_domain_query.mdx), [`TopicDataStreamer`](./streaming_data.mdx#targeted-access) — with no special handling required just because the data arrived in a later session. `seq_handler.sessions` also lists every writing Session (the original ingestion and every subsequent update) that contributed to the Sequence, each with its own `locator`.
+
+## Undoing an Update
+
+If an update turns out to be wrong — a bad estimation run, the wrong Topic name — you don't have to delete the entire Sequence to fix it. `MosaicoClient.session_delete()` permanently removes a single writing Session (and only the Topics it created), using the locator saved earlier:
+
+```python title="Roll back just this update"
+    client.session_delete(session_locator)
+```
+
+:::warning
+This is destructive and immediate: every Topic created during that Session is deleted, with no undo. It never touches Topics created by other sessions. If connecting through an API-Key, this requires the `delete` permission.
+:::
+
+## Full Example
+
+<Tabs groupId="lang" defaultValue="python">
+<TabItem value="python" label="Python">
+
+```python title="Full example"
+from mosaicolabs import MosaicoClient, SessionLevelErrorPolicy, Message, Temperature
+
+def offline_estimated_temperatures():
+    # Stand-in for a real offline analysis reading from `sensors/pressure`.
+    # A write-only pipeline knows these timestamps from its own source data
+    # (e.g. the original recording's log files), not from a Mosaico read.
+    start_timestamp_ns = 1738508778000000000
+    return [(start_timestamp_ns + i * 1_000_000_000, 21.5 + 0.1 * i) for i in range(10)]
+
+def main():
+    with MosaicoClient.connect("localhost", 6726) as client:
+        # No 'read' permission required for this step.
+        with client.sequence_update(
+            "multi_sensor_ingestion",
+            on_error=SessionLevelErrorPolicy.Report,
+        ) as seq_updater:
+
+            cabin_temp_writer = seq_updater.topic_create(
+                topic_name="diagnostics/cabin_temperature",
+                metadata={"source": "offline_estimation_v2", "derived_from": "sensors/pressure"},
+                ontology_type=Temperature,
+            )
+            for timestamp_ns, celsius in offline_estimated_temperatures():
+                cabin_temp_writer.push(
+                    message=Message(
+                        timestamp_ns=timestamp_ns,
+                        data=Temperature.from_celsius(value=celsius),
+                    )
+                )
+
+        # Verification below requires 'read', kept in this same script only for
+        # demo purposes. With genuinely write-only credentials, this call would
+        # fail server-side; run it from a separate, read-capable client instead.
+        seq_handler = client.sequence_handler("multi_sensor_ingestion")
+        if seq_handler is not None:
+            # Topic names are always normalized with a leading slash
+            assert "/diagnostics/cabin_temperature" in seq_handler.topics
+            print(f"Sequence now has {len(seq_handler.topics)} topics")
+
+if __name__ == "__main__":
+    main()
+```
+
+</TabItem>
+<TabItem value="cpp" label="C++">
+
+The C++ SDK is currently in development.
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+The Rust SDK is currently in development.
+
+</TabItem>
+</Tabs>

--- a/docs/main/docs/learn/writing_interleaved_topics.mdx
+++ b/docs/main/docs/learn/writing_interleaved_topics.mdx
@@ -37,19 +37,16 @@ The serial approach from the previous guide (iterate IMU completely, then GPS, t
 
 ## Architecture of Interleaved Ingestion
 
-The ingestion pipeline for an MCAP file has four layers that are worth understanding before diving into the code.
+The ingestion pipeline for an MCAP file has four layers, in the order data flows through them:
 
-First, the **source file stream**: the MCAP reader delivers a flat sequence of `(schema, channel, message)` tuples in chronological order. Each tuple carries the schema name (e.g. `"sensor_msgs/msg/Imu"`), the channel topic string (e.g. `"/sensors/imu"`), and the raw binary payload.
-
-Second, **schema detection and translation**: MCAP schemas are external definitions, typically ROS 2 message types, that do not map directly to Mosaico's Ontology. You need a translation layer that knows how to convert a `sensor_msgs/msg/Imu` payload into a Mosaico `IMU` object and return a `Message` ready for the SDK. The `Message.timestamp_ns` must be set from the MCAP envelope's `publish_time` (the DDS publish time), not from `header.stamp` inside the payload, which is the sensor measurement time. This translator is also responsible for declaring which Mosaico Ontology type corresponds to each schema.
-
-Third, **dynamic TopicWriter registration**: the first time a given channel topic appears in the stream, a new `TopicWriter` is created and cached inside the `SequenceWriter`. Every subsequent message on that channel reuses the cached writer. The `swriter.get_topic_writer()` method is the cache lookup; `swriter.topic_create()` is the cache population.
-
-Fourth, the **push path**: once a writer is obtained, the translated message is pushed through it to the daemon, exactly as in the serial guides. The only difference is that this happens inline within the single chronological scan of the file, interleaving pushes across multiple writers as messages are encountered.
+1. **Source file stream**: the MCAP reader delivers a flat sequence of `(schema, channel, message)` tuples in chronological order, each carrying a schema name (e.g. `"sensor_msgs/msg/Imu"`), a channel topic string (e.g. `"/sensors/imu"`), and the raw binary payload.
+2. **Schema detection and translation**: since MCAP schemas (typically ROS 2 message types) don't map directly to Mosaico's Ontology, a translation layer converts each payload into the matching Mosaico object and declares which Ontology type corresponds to each schema.
+3. **Dynamic `TopicWriter` registration**: the first time a channel topic appears, a new `TopicWriter` is created and cached inside the `SequenceWriter`; every subsequent message on that channel reuses it. `swriter.get_topic_writer()` is the cache lookup, `swriter.topic_create()` is the cache population.
+4. **Push path**: once a writer is obtained, the translated message is pushed through it to the daemon, exactly as in the serial guides — just interleaved across multiple writers within a single chronological scan instead of one writer at a time.
 
 ### Custom Translator and Type Mapping
 
-The translator is the bridge between the external world and the Mosaico type system. External robotics schemas like `sensor_msgs/msg/Imu` have their own field naming conventions (`linear_acceleration`, `angular_velocity`) and timestamp representation (a `header.stamp` struct with separate seconds and nanoseconds fields). Mosaico's Ontology types have their own conventions (`acceleration`, `angular_velocity` as `Vector3d`; timestamps as a single nanosecond integer on the `Message` wrapper). The translator is where you perform this mapping explicitly and consciously.
+The translator is the bridge between the external world and the Mosaico type system: it maps external field names and conventions (`linear_acceleration`, a `header.stamp` struct) onto Mosaico's own (`acceleration` as a `Vector3d`, a single nanosecond timestamp on `Message`). Keeping this mapping in one place means a source schema change or a new Ontology type only touches the translator, not the rest of the pipeline.
 
 :::info[MCAP `header.stamp` and the Message timestamp]
 In MCAP, `header.stamp` records **when the sensor took the measurement**, equivalent to the `Header` timestamp inside a Mosaico Ontology. It is **not** appropriate for `Message.timestamp_ns`, which must be a monotonic timestamp representing the playback time. In MCAP, the correct value for `Message.timestamp_ns` is `message.publish_time`, available from the MCAP message object in the ingestion loop. The translator below therefore accepts `publish_time_ns` as an explicit parameter instead of extracting a timestamp from the payload. For a full explanation of this distinction, see the [Message](https://docs.mosaico.dev/python-sdk/SDK/ontology/#message-the-envelope) guide.
@@ -102,7 +99,7 @@ The Rust SDK is currently in development.
 <Tabs groupId="lang" defaultValue="python">
 <TabItem value="python" label="Python">
 
-The ingestion loop is where the lazy registration pattern comes to life. For each message from the MCAP reader, the first question is whether a `TopicWriter` already exists for this channel. `swriter.get_topic_writer(channel.topic)` checks the `SequenceWriter`'s internal cache and returns the writer if it has been registered, or `None` if this is the first time this topic has been encountered. On first encounter, we call `determine_mosaico_type()` to learn which Ontology type this channel carries, and then create the writer with `swriter.topic_create()`. On all subsequent encounters, we skip straight to the push.
+The ingestion loop is where the lazy registration pattern comes to life: for each message, `swriter.get_topic_writer(channel.topic)` returns the cached writer, or `None` on first encounter — in which case `determine_mosaico_type()` resolves the Ontology type and `swriter.topic_create()` registers the writer before the push.
 
 The `on_error=TopicLevelErrorPolicy.Finalize` parameter is worth paying close attention to. In the serial guides, we caught push exceptions manually with `try-except` to prevent them from propagating to the sequence level. Here, `TopicLevelErrorPolicy.Finalize` provides an equivalent guarantee at the framework level: if a topic writer encounters an unrecoverable error, it closes itself gracefully (finalizes its stream) rather than raising an exception that could abort the entire sequence. Other topics continue ingesting normally. This is especially important for interleaved ingestion, where a bad message on the `/sensors/imu` topic appears in the same chronological stream as valid GPS and Pressure messages; you want those other messages to still reach the daemon even if the IMU stream has a problem.
 

--- a/docs/main/docs/learn/writing_multiple_topics.mdx
+++ b/docs/main/docs/learn/writing_multiple_topics.mdx
@@ -134,7 +134,7 @@ with MosaicoClient.connect("localhost", 6726) as client:
 It is **mandatory** to use `SequenceWriter` inside its own `with` context. Using it outside will raise an exception.
 :::
 
-**Sequence-Level Error Handling**: `SessionLevelErrorPolicy.Delete` removes the incomplete sequence entirely on an unhandled error; use this when you want an all-or-nothing guarantee. `SessionLevelErrorPolicy.Report` flags the sequence as failed while retaining whatever records were already transmitted, which can be useful when partial data has diagnostic value. In multi-topic ingestion, the stakes of a session-level abort are higher: a crash late in the GPS ingestion phase could discard IMU data that was uploaded cleanly. This makes per-topic error containment (covered in the next section) especially important.
+**Sequence-Level Error Handling**: `SessionLevelErrorPolicy.Delete` vs `Report` works exactly as described in [Writing a Single Topic](./writing_single_topic.mdx#sequence-upload). In multi-topic ingestion, the stakes of a session-level abort are higher: a crash late in the GPS ingestion phase could discard IMU data that was uploaded cleanly. This makes per-topic error containment (covered in the next section) especially important.
 
 </TabItem>
 <TabItem value="cpp" label="C++">
@@ -180,10 +180,7 @@ pressure_twriter = swriter.topic_create(
 ```
 
 :::info[Topic-Level Error Policy]
-The `TopicLevelErrorPolicy.Ignore` error policy will log on the server any error happening within the `TopicWriter` context
-(e.g. while pushing a message), and then will ignore it, keeping the injestion stream up and active. For a more detailed explanation,
-refer to the [Topic-Level Error Handling](https://docs.mosaico.dev/python-sdk/SDK/handling/writing/#topic-level-error-handling) Section.
-
+Same `TopicLevelErrorPolicy.Ignore` policy as in [Writing a Single Topic](./writing_single_topic.mdx#topic-creation), applied here to three writers instead of one.
 :::
 
 </TabItem>
@@ -236,11 +233,7 @@ for msg in stream_pressure_from_csv("pressure.csv"):
         print(f"Pressure message skipped with error: {pressure_twriter.last_error}")
 ```
 
-**Topic-Level Error Management**: The **`with`** context around each `push()` call is important.
-If an error occurs at the push level, for example a network hiccup or a type validation failure for a particular message, it will propagate up through the generator loop,
-exit the `SequenceWriter` context block abnormally, and trigger the sequence-level `on_error` policy, potentially deleting everything.
-By wrapping each operation related to a topic in the related `TopicWriter` context, you contain errors to the individual message that caused them.
-In this case, since the `TopicLevelErrorPolicy.Ignore` policy has been selected, The affected timestamp is logged remotely, and ingestion continues with the next message.
+**Topic-Level Error Management**: Same containment mechanism as [Writing a Single Topic](./writing_single_topic.mdx#pushing-data) — the `with` context around each `push()` call keeps a push-level error from escaping to the `SequenceWriter` and triggering the sequence-level `on_error` policy. Here it is applied independently to each of the three loops, so an error in the GPS stream cannot abort the IMU or Pressure ingestion.
 
 </TabItem>
 <TabItem value="cpp" label="C++">
@@ -263,8 +256,8 @@ The Rust SDK is currently in development.
 ```python title="Full example"
 import pandas as pd
 from mosaicolabs import (
-    MosaicoClient, setup_sdk_logging, SessionLevelErrorPolicy,
-    Message, IMU, Vector3d, GPS, GPSStatus, Pressure, Point3d
+    MosaicoClient, setup_sdk_logging, SessionLevelErrorPolicy, TopicLevelErrorPolicy,
+    TopicWriterStatus, Message, IMU, Vector3d, GPS, GPSStatus, Pressure, Point3d
 )
 
 def stream_imu_from_csv(file_path, chunk_size=1000, skipinitialspace=True):
@@ -312,9 +305,9 @@ def main():
             metadata={"mission": "alpha_test", "environment": "laboratory"},
             on_error=SessionLevelErrorPolicy.Delete
         ) as swriter:
-            imu_twriter = swriter.topic_create(topic_name="sensors/imu", metadata={"sensor_id": "accel_01"}, ontology_type=IMU)
-            gps_twriter = swriter.topic_create(topic_name="sensors/gps", metadata={"sensor_id": "gps_01"}, ontology_type=GPS)
-            pressure_twriter = swriter.topic_create(topic_name="sensors/pressure", metadata={"sensor_id": "pressure_01"}, ontology_type=Pressure)
+            imu_twriter = swriter.topic_create(topic_name="sensors/imu", metadata={"sensor_id": "accel_01"}, ontology_type=IMU, on_error=TopicLevelErrorPolicy.Ignore)
+            gps_twriter = swriter.topic_create(topic_name="sensors/gps", metadata={"sensor_id": "gps_01"}, ontology_type=GPS, on_error=TopicLevelErrorPolicy.Ignore)
+            pressure_twriter = swriter.topic_create(topic_name="sensors/pressure", metadata={"sensor_id": "pressure_01"}, ontology_type=Pressure, on_error=TopicLevelErrorPolicy.Ignore)
 
             # Push IMU
             for msg in stream_imu_from_csv("imu.csv"):

--- a/docs/main/docs/learn/writing_single_topic.mdx
+++ b/docs/main/docs/learn/writing_single_topic.mdx
@@ -172,7 +172,7 @@ with client.sequence_create(...) as swriter:
 
 :::info[Topic-Level Error Policy]
 The `TopicLevelErrorPolicy.Ignore` error policy will log on the server any error happening within the `TopicWriter` context
-(e.g. while pushing a message), and then will ignore it, keeping the injestion stream up and active. For a more detailed explanation,
+(e.g. while pushing a message), and then will ignore it, keeping the ingestion stream up and active. For a more detailed explanation,
 refer to the [Topic-Level Error Handling](https://docs.mosaico.dev/python-sdk/SDK/handling/writing/#topic-level-error-handling) Section.
 :::
 
@@ -233,12 +233,12 @@ The Rust SDK is currently in development.
 
 ## How It Fits Together
 
-It is worth pausing to see the full picture before looking at the complete code. The Mosaico Daemon is always running, managing storage and serving the gRPC API. Your application acts as a client: it opens a connection, instructs the daemon to create a Sequence (a catalog entry with metadata and time bounds), and then registers a Topic within that sequence (a typed, append-only stream). As you iterate through your CSV, each row becomes a `Message`, a typed, timestamped record. The SDK batches those messages and streams them to the daemon via gRPC using Arrow-encoded payloads. When the `SequenceWriter` scope exits cleanly, the daemon seals the sequence and it becomes queryable.
+Error handling in this guide is layered deliberately across the three levels introduced above. At the row level, the **generator yields `None`** for unparseable rows, keeping bad source data out of the message stream entirely. At the push level, the **`with imu_twriter:`** context catches transport or validation errors for individual messages without aborting the session. At the sequence level, the `on_error` policy decides what to do if something truly unrecoverable happens. This three-layer approach means a single bad CSV row never brings down an entire recording session.
 
 <Tabs groupId="lang" defaultValue="python">
 <TabItem value="python" label="Python">
 
-Error handling is layered deliberately. At the row level, the **generator yields `None`** for unparseable rows, keeping bad source data out of the message stream entirely. At the push level, a **`try-except`** catches transport or validation errors for individual messages without aborting the session. At the sequence level, the `on_error` policy decides what to do if something truly unrecoverable happens. This three-layer approach means a single bad CSV row never brings down an entire recording session.
+The complete, runnable script below ties these three layers together.
 
 </TabItem>
 <TabItem value="cpp" label="C++">
@@ -261,7 +261,8 @@ The Rust SDK is currently in development.
 ```python title="Full example"
 import pandas as pd
 from mosaicolabs import (
-    MosaicoClient, setup_sdk_logging, SessionLevelErrorPolicy, Message, IMU, Vector3d,
+    MosaicoClient, setup_sdk_logging, SessionLevelErrorPolicy, TopicLevelErrorPolicy,
+    TopicWriterStatus, Message, IMU, Vector3d,
 )
 
 def stream_imu_from_csv(file_path: str, chunk_size: int = 1000, skipinitialspace: bool = True):

--- a/docs/py/docs/SDK/API_reference/bridges/ros/ros.md
+++ b/docs/py/docs/SDK/API_reference/bridges/ros/ros.md
@@ -6,6 +6,7 @@ description: API Reference for ROS Bridge
 ::: mosaicolabs.ros_bridge.ROSBridge
 ::: mosaicolabs.ros_bridge.register_default_adapter
 ::: mosaicolabs.ros_bridge.loader.ROSLoader
+::: mosaicolabs.ros_bridge.loader.MosaicoLoader
 ::: mosaicolabs.ros_bridge.loader.LoaderErrorPolicy
 ::: mosaicolabs.ros_bridge.ROSMessage
 ::: mosaicolabs.ros_bridge.ROSInjectionConfig

--- a/docs/py/docs/SDK/API_reference/enum.md
+++ b/docs/py/docs/SDK/API_reference/enum.md
@@ -9,8 +9,6 @@ description: API Reference for Enum Module
 ::: mosaicolabs.enum.TopicWriterStatus
 ::: mosaicolabs.enum.SessionLevelErrorPolicy
 ::: mosaicolabs.enum.TopicLevelErrorPolicy
-::: mosaicolabs.enum.TopicLevelErrorPolicy
-::: mosaicolabs.enum.SessionLevelErrorPolicy
 ::: mosaicolabs.enum.FlightAction
 ::: mosaicolabs.enum.GRPCCompressionAlgorithm
 ::: mosaicolabs.enum.GRPCCompressionLevel

--- a/docs/py/docs/SDK/bridges/ml.md
+++ b/docs/py/docs/SDK/bridges/ml.md
@@ -34,7 +34,7 @@ This example demonstrates iterating through a sequence in 10-second tabular chun
 from mosaicolabs import MosaicoClient
 from mosaicolabs.ml import DataFrameExtractor
 
-with MosaicoClient.connect("localhost", 6726):
+with MosaicoClient.connect("localhost", 6726) as client:
     # Initialize from an existing SequenceHandler
     seq_handler = client.sequence_handler("drive_session_01")
     extractor = DataFrameExtractor(seq_handler)
@@ -42,7 +42,7 @@ with MosaicoClient.connect("localhost", 6726):
     # Iterate through 10-second chunks
     for df in extractor.to_pandas_chunks(window_sec=10.0):
         # 'df' is a pandas DataFrame with semantic columns
-        # Example: df["/front/camera/imu.imu.acceleration.x"]
+        # Example: df["/front/camera/imu.IMU.acceleration.x"]
         print(f"Processing chunk with {len(df)} rows")
 
 ```
@@ -53,7 +53,7 @@ For complex types like images that require specialized decoding, Mosaico allows 
 from mosaicolabs import MosaicoClient, Message, Image
 from mosaicolabs.ml import DataFrameExtractor
 
-with MosaicoClient.connect("localhost", 6726):
+with MosaicoClient.connect("localhost", 6726) as client:
     # Initialize from an existing SequenceHandler
     seq_handler = client.sequence_handler("drive_session_01")
     extractor = DataFrameExtractor(seq_handler)
@@ -78,7 +78,7 @@ with MosaicoClient.connect("localhost", 6726):
 ## Video Decoding for ML Pipelines
 
 ??? question "API Reference"
-[`mosaicolabs.ml.VideoDecodingTransformer`][mosaicolabs.ml.VideoDecodingTransformer]
+    [`mosaicolabs.ml.VideoDecodingTransformer`][mosaicolabs.ml.VideoDecodingTransformer]
 
 When handling multi-camera robotics datasets, managing image data presents a fundamental architectural conflict between video compression mechanics and machine learning dataloader strategies.
 
@@ -150,8 +150,6 @@ Unlike standard resamplers that treat each data batch in isolation, this transfo
 * **Protocol-Based Extensibility**: The mathematical logic for resampling is decoupled through a [`SyncPolicy`][mosaicolabs.ml.SyncPolicy] protocol, allowing for custom kernel injection.
 
 ### Implementation and Stateful Lifecycle
-
-Architecturally, the [`SyncTransformer`][mosaicolabs.ml.SyncTransformer] is implemented as a **stateful state-machine** designed to maintain signal continuity across independent data chunks. Unlike standard library resamplers that often treat each input batch as an isolated event, this transformer is engineered to "stitch" the temporal gaps between the windowed DataFrames yielded by the [`DataFrameExtractor`][mosaicolabs.ml.DataFrameExtractor].
 
 #### Internal State Management
 The transformer maintains two critical internal buffers that persist for its entire lifecycle:
@@ -258,23 +256,25 @@ By implementing the standard `fit`/`transform` interface, the [`SyncTransformer`
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 from mosaicolabs import MosaicoClient
-from mosaicolabs.ml import DataFrameExtractor, SyncTransformer, SynchHold
+from mosaicolabs.ml import DataFrameExtractor, SyncTransformer, SyncHold
 
 
 # Define a pipeline for physical AI preprocessing
 pipeline = Pipeline([
-    ('sync', SyncTransformer(target_fps=30.0, policy=SynchHold())),
+    ('sync', SyncTransformer(target_fps=30.0, policy=SyncHold())),
     ('scaler', StandardScaler())
 ])
 
-with MosaicoClient.connect("localhost", 6726):
+with MosaicoClient.connect("localhost", 6726) as client:
     # Initialize from an existing SequenceHandler
     seq_handler = client.sequence_handler("drive_session_01")
     extractor = DataFrameExtractor(seq_handler)
 
     # Process sequential chunks while maintaining signal continuity
     for sparse_chunk in extractor.to_pandas_chunks(window_sec=5.0):
-        # The transformer automatically carries state across sequential calls
-        normalized_dense_chunk = pipeline.transform(sparse_chunk)
+        # The transformer automatically carries state across sequential calls.
+        # fit_transform() is used because the scaler must (re-)compute its
+        # statistics on every chunk before applying the transformation.
+        normalized_dense_chunk = pipeline.fit_transform(sparse_chunk)
 
 ```

--- a/docs/py/docs/SDK/bridges/ros.md
+++ b/docs/py/docs/SDK/bridges/ros.md
@@ -49,7 +49,8 @@ The behavior of the ingestor is entirely driven by the **[`ROSInjectionConfig`][
 ```python
 from pathlib import Path
 from mosaicolabs import SessionLevelErrorPolicy, TopicLevelErrorPolicy
-from mosaicolabs.ros_bridge import RosbagInjector, ROSInjectionConfig, Stores
+from mosaicolabs.ros_bridge import RosbagInjector, ROSInjectionConfig
+from rosbags.typesys import Stores
 
 def run_injection():
     # Define the Injection Configuration
@@ -89,7 +90,7 @@ def run_injection():
         # Use specific adapters for designated topics instead of the default.
         # In this case, instead to use PointCloudAdapter for depth camera,
         # MyCustomRGBDAdapter will be used for the specified topic.
-        adapter_override={
+        adapter_overrides={
             "/camera/depth/points": MyCustomRGBDAdapter,
         },
 
@@ -97,7 +98,7 @@ def run_injection():
         log_level="WARNING",  # Reduce verbosity for automated scripts
 
         # Session Level Error Handling
-        on_error=SessionLevelErrorPolicy.Report # Report the error and terminate the session
+        on_error=SessionLevelErrorPolicy.Report, # Report the error and terminate the session
 
         # Topic Level Error Handling
         topics_on_error=TopicLevelErrorPolicy.Raise # Re-raise any exception
@@ -133,7 +134,7 @@ This layer represents the default semantic core of the module, translating raw R
 Users can extend the bridge to support new ROS message types by implementing a custom adapter and registering it.
 
 1.  **Inherit from `ROSAdapterBase`**: Define the input ROS type string and the target Mosaico Ontology type.
-2.  **Implement `from_dict`**: Define the logic to convert the [`ROSMessage.data`][mosaicolabs.ros_bridge.ROSMessage] dictionary into an intance of the target ontology object.
+2.  **Implement `from_dict`**: Define the logic to convert the [`ROSMessage.data`][mosaicolabs.ros_bridge.ROSMessage] dictionary into an instance of the target ontology object.
 3.  **Register**: Decorate the class with [`@register_default_adapter`][mosaicolabs.ros_bridge.register_default_adapter].
 
 ```python
@@ -164,11 +165,12 @@ This is possible because ROS bag files carry the schema of every message type al
 See [Advanced: Ingesting Unmodeled Ontologies](../ontology.md#advanced-ingesting-unmodeled-ontologies) for the full mechanics of the `Unmodeled` ontology type — including how schema-variant fingerprinting keeps multiple versions of the same tag apart, and, most importantly, how to **query** this data on the server without ever needing to resolve a Python class for it.
 
 #### Override Adapters
-This section explains how to extend the bridge's capabilities by implementing and registering Override Adapters.
+
+Unlike the Custom Adapters above, which register a *new* mapping for a ROS type that has no default adapter, Override Adapters replace the *default* adapter for one specific topic only, leaving every other topic of that same ROS type on the standard path. This section explains how to implement and register them.
 
 ##### Overriding and Extending Adapters
 While the ROS Bridge provides a robust set of default adapters for standard message types, real-world robotics often involve proprietary message definitions or non-standard uses of common types.
-Through the **`adapter_override`** parameter in the `ROSInjectionConfig`, you can explicitly map a specific topic to a chosen adapter. This is particularly useful for types like [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html), where, for example, different LiDAR vendors may encode data in unique ways that require specialized parsing logic.
+Through the **`adapter_overrides`** parameter in the `ROSInjectionConfig`, you can explicitly map a specific topic to a chosen adapter. This is particularly useful for types like [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html), where, for example, different LiDAR vendors may encode data in unique ways that require specialized parsing logic.
 
 !!! important "Override adapter usage"
     Use adapter overrides for versatile message types like [`sensor_msgs/msg/PointCloud2`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/PointCloud2.html), where different sensors (LiDAR, Radar, etc.) share the same ROS type but require unique parsing logic. Overrides should be defined and used when a given ROS message type has its own **default adapter** registered in the `ROSBridge` registry, but such an adapter cannot satisfy topic-specific requirements. If your message type is used consistently across all topics, simply use the [`@register_default_adapter`][mosaicolabs.ros_bridge.register_default_adapter] decorator to establish a global fallback.
@@ -207,7 +209,8 @@ Note that the adapter is **not** registered as default, since `sensor_msgs/msg/P
 ```python
 from typing import Any, Optional, Type
 from mosaicolabs import Message
-from mosaicolabs.ros_bridge import PointCloudAdapterBase, ROSMessage
+from mosaicolabs.ros_bridge import ROSMessage
+from mosaicolabs.ros_bridge.adapters import PointCloudAdapterBase
 from my_ontology import MyLidar # Your target Ontology class
 
 class MyLidarAdapter(PointCloudAdapterBase[MyVelodyneLidar]):
@@ -260,7 +263,7 @@ class MyLidarAdapter(PointCloudAdapterBase[MyVelodyneLidar]):
     Only `_build` is mandatory. Override `translate`, `from_dict`, or `schema_metadata` only when the default behaviour of the base class does not meet your needs.
 
 ##### Registering the Override
-Once implemented, the adapter is registered against a specific topic via `adapter_override` in [ROSInjectionConfig][mosaicolabs.ros_bridge.ROSInjectionConfig]:
+Once implemented, the adapter is registered against a specific topic via `adapter_overrides` in [ROSInjectionConfig][mosaicolabs.ros_bridge.ROSInjectionConfig]:
 
 ```python
 from .my_adapter import MyLidarAdapter
@@ -271,7 +274,7 @@ config = ROSInjectionConfig(
     file_path=Path("sensor_data.mcap"),
     sequence_name="custom_lidar_run",
     # Explicitly tell the bridge to use your custom adapter for this topic
-    adapter_override={
+    adapter_overrides={
         "/lidar/front/pointcloud": MyLidarAdapter,
     }
 )
@@ -288,7 +291,7 @@ By using this pattern, you can maintain a clean separation between your raw ROS 
 
 ##### Implementing a Custom Adapter Override
 To create a custom adapter that overrides a existing ROS message, you must inherit from `ROSAdapterBase` and define the transformation logic.
-Follow the steps described [here](#extending-the-bridge-custom-adapters) with the only caveat not to register the adapter with `@register_default_adapter` but insted [register the override](#registering-the-override)
+Follow the steps described [here](#extending-the-bridge-custom-adapters) with the only caveat not to register the adapter with `@register_default_adapter` but instead [register the override](#registering-the-override)
 
 #### CLI Usage
 
@@ -331,7 +334,8 @@ A clean way to manage large projects is to centralize your message registration 
 
 ```python
 from pathlib import Path
-from mosaicolabs.ros_bridge import ROSTypeRegistry, Stores
+from mosaicolabs.ros_bridge import ROSTypeRegistry
+from rosbags.typesys import Stores
 
 def initialize_project_schemas():
     # 1. Register a proprietary message valid for all ROS versions
@@ -354,7 +358,8 @@ Once registered, the [`RosbagInjector`][mosaicolabs.ros_bridge.RosbagInjector] (
 ```python
 # main_injection.py
 import setup_registry  # Runs the registration logic above
-from mosaicolabs.ros_bridge import RosbagInjector, ROSInjectionConfig, Stores
+from mosaicolabs.ros_bridge import RosbagInjector, ROSInjectionConfig
+from rosbags.typesys import Stores
 from pathlib import Path
 
 # Initialize registry
@@ -376,15 +381,11 @@ ingestor.run()
 
 ### Testing & Validation
 
-The ROS Bag Injection module has been validated against a variety of standard datasets to ensure compatibility with different ROS distributions, message serialization formats (CDR/ROS 1), and bag container formats (`.bag`, `.mcap`, `.db3`).
-
-#### Recommended Dataset for Verification
-
-For evaluating Mosaico capabilities, we recommend the **[NVIDIA NGC Catalog - R2B Dataset 2024](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/isaac/resources/r2bdataset2024?version=1)**. This dataset has been verified to be fully compatible with the injection pipeline.
-
-The following table details the injection performance for the **NVIDIA R2B Dataset 2024**. These benchmarks were captured on a system running **macOS 26.2** with an **Apple M2 Pro (10 cores, 16GB RAM)**.
+The ROS Bag Injection module has been validated against a variety of standard datasets to ensure compatibility with different ROS distributions, message serialization formats (CDR/ROS 1), and bag container formats (`.bag`, `.mcap`, `.db3`). For evaluating Mosaico capabilities, we recommend the **[NVIDIA NGC Catalog - R2B Dataset 2024](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/isaac/resources/r2bdataset2024?version=1)**, which has been verified to be fully compatible with the injection pipeline.
 
 #### NVIDIA R2B Dataset 2024 Injection Performance
+
+Benchmarks below were captured on **macOS 26.2**, **Apple M2 Pro (10 cores, 16GB RAM)**. Injection time includes local MCAP/DB3 deserialization via [`ROSLoader`][mosaicolabs.ros_bridge.loader.ROSLoader], semantic translation through the [`ROSBridge`][mosaicolabs.ros_bridge.ROSBridge], and transmission to the Mosaico server. Compression factor depends on the data itself: scalar telemetry compresses well (~70%), while pre-compressed video feeds show minimal gains (~1%) since the data is already dense.
 
 | Sequence Name | Compression Factor | Injection Time | Hardware Architecture | Notes |
 | --- | --- | --- | --- | --- |
@@ -393,26 +394,12 @@ The following table details the injection performance for the **NVIDIA R2B Datas
 | **`r2b_robotarm`** | ~66% | ~50 sec | Apple M2 Pro (16GB) | High efficiency for high-frequency state updates. |
 | **`r2b_whitetunnel`** | ~1% | ~30 sec | Apple M2 Pro (16GB) | Low compression; contains topics with no available adapter. |
 
-#### Understanding Performance Factors
-
-* **Compression Factors**: Sequences like `r2b_galileo2` achieve high ratios (~70%) because Mosaico optimizes the underlying columnar storage for scalar telemetry. Conversely, sequences with pre-compressed video feeds show minimal gains (~1%) because the data is already in a dense format.
-* **Injection Time**: This metric includes the overhead of local MCAP/DB3 deserialization via [`ROSLoader`][mosaicolabs.ros_bridge.loader.ROSLoader], semantic translation through the [`ROSBridge`][mosaicolabs.ros_bridge.ROSBridge], and the transmission to the Mosaico server.
-
 #### Known Issues & Limitations
 
 While the underlying `rosbags` library supports the majority of standard ROS 2 bag files, specific datasets with non-standard serialization alignment or proprietary encodings may encounter compatibility issues.
 
-**NVIDIA Isaac ROS Benchmark Dataset (2023)**
-
-  * **Source:** [NVIDIA NGC Catalog - R2B Dataset 2023](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/isaac/resources/r2bdataset2023)
-  * **Issue:** Deserialization failure during ingestion.
-  * **Technical Details:** The ingestion process fails within the [`AnyReader.deserialize`](https://ternaris.gitlab.io/rosbags/api/rosbags.highlevel.html#rosbags.highlevel.AnyReader.deserialize) method of the [`rosbags`](https://ternaris.gitlab.io/rosbags/index.html) library. The internal CDR deserializer triggers an assertion error indicating a mismatch in the expected data length vs. the raw payload size.
-  * **Error Signature:**
-    ```python
-    # In rosbags.serde.cdr:
-    assert pos + 4 + 3 >= len(rawdata)
-    ```
-  * **Recommendation:** This issue originates in the upstream parser handling of this specific dataset's serialization alignment. It is currently recommended to exclude this dataset or transcode it using standard ROS 2 tools before ingestion.
+!!! warning "NVIDIA Isaac ROS Benchmark Dataset (2023)"
+    The **[R2B Dataset 2023](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/isaac/resources/r2bdataset2023)** (unlike the 2024 release above) fails to deserialize: the [`AnyReader.deserialize`](https://ternaris.gitlab.io/rosbags/api/rosbags.highlevel.html#rosbags.highlevel.AnyReader.deserialize) method of the [`rosbags`](https://ternaris.gitlab.io/rosbags/index.html) library raises an assertion error (`assert pos + 4 + 3 >= len(rawdata)` in `rosbags.serde.cdr`), indicating a mismatch between the expected data length and the raw payload size. This originates in the upstream parser's handling of this dataset's serialization alignment; exclude it or transcode it with standard ROS 2 tools before ingestion.
 
 
 ## Supported Message Types
@@ -458,8 +445,10 @@ While the underlying `rosbags` library supports the majority of standard ROS 2 b
   | [`sensor_msgs/msg/RegionOfInterest`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/RegionOfInterest.html) | [`ROI`][mosaicolabs.models.data.ROI] | `ROIAdapter` |
   | [`sensor_msgs/msg/JointState`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/JointState.html) | [`RobotJoint`][mosaicolabs.models.sensors.RobotJoint] | `RobotJointAdapter` |
   | [`sensor_msgs/msg/BatteryState`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/BatteryState.html) | [`BatteryState`][mosaicolabs.ros_bridge.data_ontology.BatteryState] (ROS-specific)| `BatteryStateAdapter` |
-  | [`sensor_msgs/msg/Temperature`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/Temperature.html) | [`Temperature`][mosaicolabs.models.sensors.Temperature] (ROS-specific)| `TemperatureAdapter` |
-  | [`sensor_msgs/msg/FluidPressure`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/FluidPressure.html) | [`FluidPressure`][mosaicolabs.models.sensors.Pressure] (ROS-specific)| `PressureAdapter` |
+  | [`sensor_msgs/msg/Temperature`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/Temperature.html) | [`Temperature`][mosaicolabs.models.sensors.Temperature] | `TemperatureAdapter` |
+  | [`sensor_msgs/msg/FluidPressure`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/FluidPressure.html) | [`FluidPressure`][mosaicolabs.models.sensors.Pressure] | `PressureAdapter` |
+  | [`sensor_msgs/msg/LaserScan`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/LaserScan.html) | [`LaserScan`][mosaicolabs.models.futures.LaserScan] (ROS-specific)| `LaserScanAdapter` |
+  | [`sensor_msgs/msg/MultiEchoLaserScan`](https://docs.ros2.org/foxy/api/sensor_msgs/msg/MultiEchoLaserScan.html) | [`MultiEchoLaserScan`][mosaicolabs.models.futures.MultiEchoLaserScan] (ROS-specific)| `MultiEchoLaserScanAdapter` |
   | [`std_msgs/msg/String`](https://docs.ros2.org/foxy/api/std_msgs/msg/String.html)| [`String`][mosaicolabs.models.data.String]| `_GenericStdAdapter` |
   | [`std_msgs/msg/Int8(16,32,64)`](https://docs.ros2.org/foxy/api/std_msgs/msg/Int8.html) | [`Integer8(16,32,64)`][mosaicolabs.models.data.Integer8]| `_GenericStdAdapter` |
   | [`std_msgs/msg/UInt8(16,32,64)`](https://docs.ros2.org/foxy/api/std_msgs/msg/UInt8.html) | [`Unsigned8(16,32,64)`][mosaicolabs.models.data.Unsigned8]| `_GenericStdAdapter` |

--- a/docs/py/docs/SDK/client.md
+++ b/docs/py/docs/SDK/client.md
@@ -9,7 +9,7 @@ description: Architecture and design of the MosaicoClient.
 The `MosaicoClient` is a resource manager designed to orchestrate distinct **Layers** of communication and processing. 
 This layered architecture ensures that high-throughput sensor data does not block critical control operations or application logic.
 
-Creating a new client is done via the [`MosaicoClient.connect()`][mosaicolabs.comm.MosaicoClient.connect] factory method. It is recomended to always use the client inside a `with` context to ensure resources in all layers are cleanly released.
+Creating a new client is done via the [`MosaicoClient.connect()`][mosaicolabs.comm.MosaicoClient.connect] factory method. It is recommended to always use the client inside a `with` context to ensure resources in all layers are cleanly released.
 
 ```python
 from mosaicolabs import MosaicoClient
@@ -34,20 +34,18 @@ The SDK operates on a **Synchronous Processing Model**, where serialization and 
 The Security Layer manages the confidentiality and integrity of the communication channel. It is composed of two primary mechanisms that work in tandem to harden the connection.
 
 ### 1. Encryption (TLS)
-For deployments over public or shared networks, the client supports [**Transport Layer Security (TLS)**](https://docs.mosaico.dev/daemon/tls). Two connection modes are available via SDK, depending on the configuratiom of the Mosaico server:
+For deployments over public or shared networks, the client supports [**Transport Layer Security (TLS)**](https://docs.mosaico.dev/daemon/tls). Two connection modes are available via SDK, depending on the configuration of the Mosaico server:
 
-* **One-way TLS**, server authenticated only
+* **One-way TLS**, server authenticated only, using the system CA bundle
   ```python
   MosaicoClient.connect("localhost", 6726, enable_tls=True)
   ```
-* **Two-way TLS**, via providing a certificate file
+* **One-way TLS with a custom CA certificate**, via providing a certificate file
   ```python
   MosaicoClient.connect("localhost", 6726, tls_cert_path="my/cert/file/path.pem")
   ```
 
-In both modes, the client automatically switches from an insecure channel to an encrypted one via `grpc+tls` protocol. The **One-way TLS** mode is available by setting `enable_tls=True` when calling [`MosaicoClient.connect()`][mosaicolabs.comm.MosaicoClient.connect], and providing no certificate. 
-On the other hand, the **Two-way TLS** mode is available by passing the TLS certificate path via `tls_cert_path` parameter when calling [`MosaicoClient.connect()`][mosaicolabs.comm.MosaicoClient.connect]. 
-In such a case, there is no need to set the `enable_tls=True` flag.
+In both modes, the client automatically switches from an insecure channel to an encrypted one via the `grpc+tls` protocol. Note that both remain server-authenticated only: the client never presents a certificate of its own, so there is no mutual TLS (mTLS) mode. When `tls_cert_path` is set, there is no need to also set `enable_tls=True`.
 
 ### 2. Authentication (API Key)
 Mosaico uses an [**API Key** system](https://docs.mosaico.dev/daemon/api_key) to authorize every operation. When a key is provided, the client automatically attaches your unique credentials to the metadata of every gRPC and Flight call. This ensures that even if your endpoint is public, only requests with a valid, non-revoked key are processed by the server.
@@ -65,17 +63,14 @@ with MosaicoClient.connect(
 ```
 
 !!! warning "API-Key and TLS"
-    TLS is not mandatory for connecting via API-keys. It is recommended to enable the support for TLS in the server, to avoid sensitive credential to be sent on unencrypted channels.
+    TLS is not mandatory for connecting via API-keys. It is recommended to enable the support for TLS in the server, to avoid sensitive credentials being sent over unencrypted channels.
 
 ### Recommended Patterns
 
 #### Explicit Connection
-Ideal for local development or scripts where credentials are managed by a secrets manager.
+Ideal for local development or scripts where credentials are managed by a secrets manager. Same as the API Key example above, with a `tls_cert_path` added to also enable TLS:
 
 ```python
-from mosaicolabs import MosaicoClient
-
-# The client handles the handshake and credential injection automatically
 with MosaicoClient.connect(
     host="mosaico.production.cluster",
     port=6726,

--- a/docs/py/docs/SDK/handling/reading.md
+++ b/docs/py/docs/SDK/handling/reading.md
@@ -39,8 +39,8 @@ with MosaicoClient.connect("localhost", 6726) as client:
         print(f"\t| Topics: {seq_handler.topics}")
         print(f"\t| User metadata: {seq_handler.user_metadata}")
         print(f"\t| Timestamp span: {seq_handler.timestamp_ns_min} - {seq_handler.timestamp_ns_max}")
-        print(f"\t| Created {seq_handler.sequence_info.created_datetime}")
-        print(f"\t| Size (MB) {seq_handler.sequence_info.total_size_bytes/(1024*1024)}")
+        print(f"\t| Created {seq_handler.created_timestamp}")
+        print(f"\t| Size (MB) {seq_handler.total_size_bytes/(1024*1024)}")
 
         # Once done, close the reading channel (recommended)
         seq_handler.close()
@@ -71,8 +71,8 @@ with MosaicoClient.connect("localhost", 6726) as client:
         print(f"Sequence:Topic: {top_handler.sequence_name}:{top_handler.name}")
         print(f"\t| User metadata: {top_handler.user_metadata}")
         print(f"\t| Timestamp span: {top_handler.timestamp_ns_min} - {top_handler.timestamp_ns_max}")
-        print(f"\t| Created {top_handler.topic_info.created_datetime}")
-        print(f"\t| Size (MB) {top_handler.topic_info.total_size_bytes/(1024*1024)}")
+        print(f"\t| Created {top_handler.created_timestamp}")
+        print(f"\t| Size (MB) {top_handler.total_size_bytes/(1024*1024)}")
 
         # Once done, close the reading channel (recommended)
         top_handler.close()

--- a/docs/py/docs/SDK/handling/writing.md
+++ b/docs/py/docs/SDK/handling/writing.md
@@ -6,7 +6,7 @@ description: Data Writers.
 The **Writing Workflow** in Mosaico is designed for high-throughput data ingestion, ensuring that your application remains responsive even when streaming high-bandwidth sensor data like 4K video or high-frequency IMU telemetry.
 
 !!! info "API-Keys"
-    When the connection is established via the authorization middleware (i.e. using an [API-Key](../client.md#2-authentication-api-key)), the writing workflow is allowed only if the key the `write` permission.
+    When the connection is established via the authorization middleware (i.e. using an [API-Key](../client.md#2-authentication-api-key)), the writing workflow is allowed only if the key has the `write` permission.
 
 
 ## `SequenceWriter`
@@ -15,7 +15,7 @@ The **Writing Workflow** in Mosaico is designed for high-throughput data ingesti
 
 The `SequenceWriter` acts as the central controller for a recording session. It manages the high-level lifecycle of the data on the server and serves as the factory for individual sensor streams. 
 
-Spawning a new sequence writer is done via the [`MosaicoClient.connect()`][mosaicolabs.comm.MosaicoClient.connect] factory method.
+Spawning a new sequence writer is done via the [`MosaicoClient.sequence_create()`][mosaicolabs.comm.MosaicoClient.sequence_create] factory method.
 
 **Key Roles:**
 
@@ -31,23 +31,7 @@ with MosaicoClient.connect("localhost", 6726) as client:
     with client.sequence_create(
         sequence_name="mission_log_042", 
         # Custom metadata for this data sequence.
-        metadata={ # (1)!
-            "vehicle": {
-                "vehicle_id": "veh_sim_042",
-                "powertrain": "EV",
-                "sensor_rig_version": "v3.2.1",
-                "software_stack": {
-                    "perception": "perception-5.14.0",
-                    "localization": "loc-2.9.3",
-                    "planning": "plan-4.1.7",
-                },
-            },
-            "driver": {
-                "driver_id": "drv_sim_017",
-                "role": "validation",
-                "experience_level": "senior",
-            },
-        }
+        metadata={"vehicle_id": "veh_sim_042", "driver_id": "drv_sim_017"}, # (1)!
         on_error = SessionLevelErrorPolicy.Delete
         ) as seq_writer:
 
@@ -57,7 +41,7 @@ with MosaicoClient.connect("localhost", 6726) as client:
 
 ```
 
-1. The metadata fields will be queryable via the [`Query` mechanism](../query.md). The mechanism allows creating queries like: `QuerySequence().with_user_metadata("vehicle.software_stack.planning", eq="plan-4.1.7")`
+1. Metadata can be arbitrarily nested (e.g. `{"vehicle": {"software_stack": {"planning": "plan-4.1.7"}}}`) and every field is queryable via the [`Query` mechanism](../query.md), including nested ones: `QuerySequence().with_user_metadata("vehicle.software_stack.planning", eq="plan-4.1.7")`
 
 ### Sequence-Level Error Handling
 ??? question "API Reference"
@@ -102,7 +86,7 @@ Once a topic is created via [`SequenceWriter.topic_create`][mosaicolabs.handlers
                 "serial_number": "IMUF-9A31D72X",
                 "calibrated":"false",
             },
-            error_policy=TopicLevelErrorPolicy.Raise, # Raises an exception if an error occurs
+            on_error=TopicLevelErrorPolicy.Raise, # Raises an exception if an error occurs
             ontology_type=IMU, # The ontology type stored in this topic
         )
 
@@ -121,7 +105,7 @@ Once a topic is created via [`SequenceWriter.topic_create`][mosaicolabs.handlers
                     "protocol": "NMEA",
                 },
             }, # The topic/sensor custom metadata
-            error_policy=TopicLevelErrorPolicy.Ignore, # Ignore errors in this topic
+            on_error=TopicLevelErrorPolicy.Ignore, # Ignore errors in this topic
             ontology_type=GPS, # The ontology type stored in this topic
         )
 
@@ -158,7 +142,7 @@ Once a topic is created via [`SequenceWriter.topic_create`][mosaicolabs.handlers
 
 ### Topic-Level Error Handling
 
-By default, the `SequenceWriter` context manager cannot natively distinguish which specific topic failed during custom processing or data pushing. An unhandled exception in one stream will bubble up and trigger the global **Sequence-Level Error Policy**, potentially aborting the entire upload. To prevent this, the SDK introduces native **Topic-Level Error Policies**, which automate the "Defensive Ingestion" pattern directly within the `TopicWriter`. This pattern is highly recommended, in paerticular for complex ingestion pipelines (see for example the [interleaved ingestion how-to](https://docs.mosaico.dev/learn/writing_interleaved_topics)).
+By default, the `SequenceWriter` context manager cannot natively distinguish which specific topic failed during custom processing or data pushing. An unhandled exception in one stream will bubble up and trigger the global **Sequence-Level Error Policy**, potentially aborting the entire upload. To prevent this, the SDK introduces native **Topic-Level Error Policies**, which automate the "Defensive Ingestion" pattern directly within the `TopicWriter`. This pattern is highly recommended, in particular for complex ingestion pipelines (see for example the [interleaved ingestion how-to](https://docs.mosaico.dev/learn/writing_interleaved_topics)).
 
 !!! note
     The error handling is only possible inside the `TopicWriter` context manager, i.e. by wrapping the processing and pushing code inside a `with topic_writer:` block.

--- a/docs/py/docs/SDK/ontology.md
+++ b/docs/py/docs/SDK/ontology.md
@@ -166,7 +166,7 @@ In this scenario, the types are resolved using the following **fallback mapping*
 | `float` | `pa.float64()` |
 | `str` | `pa.string()` |
 | `bool` | `pa.bool_()` |
-| `bytes` | `pa.bytes()` |
+| `bytes` | `pa.binary()` |
 
 !!! note "Note"
     Just like with explicit types, using `Optional` with fallback types will correctly define the PyArrow field as **nullable**. If `Optional` is not used, the field is defined as **not nullable**.
@@ -202,10 +202,10 @@ This means:
 
 - The list can hold **any number of elements** at runtime.
 - No size constraint is enforced at the schema level.
-- This is equivalent to calling `MosaicoType.list_(str)` with no `size` argument.
+- This is equivalent to calling `MosaicoType.list_(str)` with no `list_size` argument.
 
 
-[`MosaicoType.list_()`][mosaicolabs.models.core.MosaicoType.list_] accepts an optional `size` parameter. When provided, it maps to an Arrow **fixed-size list** (`pa.list_(type, list_size=N)`), which enforces that every value in the column contains exactly `N` elements.
+[`MosaicoType.list_()`][mosaicolabs.models.core.MosaicoType.list_] accepts an optional `list_size` parameter. When provided, it maps to an Arrow **fixed-size list** (`pa.list_(type, list_size=N)`), which enforces that every value in the column contains exactly `N` elements.
 
 | | `list[str]` | `MosaicoType.list_(str)` | `MosaicoType.list_(str, 3)` |
 |---|---|---|---|
@@ -214,7 +214,7 @@ This means:
 | Interoperable with Pydantic | Yes | Yes | Yes |
 | Supports nested models | Yes | Yes | Yes |
 
-Use [`MosaicoType.list_()`][mosaicolabs.models.core.MosaicoType.list_] with a `size` argument when:
+Use [`MosaicoType.list_()`][mosaicolabs.models.core.MosaicoType.list_] with a `list_size` argument when:
 
 - The list represents a **fixed-dimensional structure**, such as a vector, a coordinate
   tuple, or an RGB triplet.
@@ -223,7 +223,7 @@ Use [`MosaicoType.list_()`][mosaicolabs.models.core.MosaicoType.list_] with a `s
 - You are working with **embedding vectors** or other ML features where dimensionality
   is always known and constant.
 
-If you do **not** pass a `size` argument, `MosaicoType.list_(T)` and `list[T]` produce
+If you do **not** pass a `list_size` argument, `MosaicoType.list_(T)` and `list[T]` produce
 an identical Arrow schema. The choice then becomes a matter of style or explicitness:
  
 ```python
@@ -232,7 +232,7 @@ tags: MosaicoType.list_(str)  # explicit Mosaico style - equivalent result
 ```
 
 !!! note "Note"
-    Explicit type definition and fallback types properties are hold in this case.
+    Explicit type definition and fallback types properties still hold in this case.
 
 #### Matrix types
 
@@ -268,16 +268,7 @@ class MyOntology(Serializable):
 | Interoperable with Pydantic | Yes | Yes | Yes |
 | Support nested models | Yes | Yes | Yes |
 
-Use [`MosaicoType.matrix()`][mosaicolabs.models.core.MosaicoType.matrix] with explicit `rows` and/or `cols` when:
-
-- The field represents a **fixed-shape 2-D structure**.
-- You want the Arrow schema to **statically encode both dimensions**, enabling optimised columnar storage and stricter validation.
-- You are working with **fixed-width embedding matrices** where the column dimension (feature size) is always constant but the number of rows may vary.
-
-If neither dimension is provided, `MosaicoType.matrix(T)` produces a fully variable nested list, equivalent to `list[list[T]]`.
-
-!!! note "Note"
-    Explicit type definition and fallback type properties apply here as well.
+The same `list_size` trade-off from [List types](#list-types) applies here, one dimension at a time: fix `rows`/`cols` when that dimension's size is a known, constant property of the data (e.g. a fixed-width embedding matrix), and leave it variable otherwise. If neither dimension is provided, `MosaicoType.matrix(T)` produces a fully variable nested list, equivalent to `list[list[T]]`.
 
 #### Tensor3d types
 
@@ -311,18 +302,9 @@ class MyOntology(Serializable):
 | Row count enforced | No | No | Yes, exactly M |
 | Column count enforced | No | No | Yes, exactly N |
 | Interoperable with Pydantic | Yes | Yes | Yes |
-| Supoprt nested model | Yes | Yes | Yes |
+| Support nested models | Yes | Yes | Yes |
 
-Use [`MosaicoType.tensor3d()`][mosaicolabs.models.core.MosaicoType.tensor3d] with explicit dimensions when:
-
-- The field represents a **fixed-shape volumetric structure**.
-- You want the Arrow schema to **statically encode all three dimensions**, enabling stricter schema validation and more efficient columnar storage.
-- You are working with **multi-channel ML features** (e.g. convolutional layer outputs) where depth, height, and width are always known and constant.
-
-If none of the dimensions are provided, `MosaicoType.tensor3d(T)` produces a fully variable nested list, equivalent to three nested `list[list[list[T]]]`.
-
-!!! note "Note"
-    Explicit type definition and fallback type properties apply here as well. When all dimensions are fixed, the Arrow schema enforces shape constraints at the column level, making `tensor3d` the recommended choice for any ML pipeline where tensor dimensionality is statically known.
+The same per-dimension trade-off applies: fix `depth`/`rows`/`cols` when that dimension is a known, constant property of the data — e.g. all three for a fixed-shape volumetric structure such as convolutional layer outputs. If none of the dimensions are provided, `MosaicoType.tensor3d(T)` produces a fully variable nested list, equivalent to three nested `list[list[list[T]]]`.
 
 #### Custom Arrow types
 
@@ -527,8 +509,6 @@ log_writer.push(message=log_msg)
 # Embedding Vector3d inside a complex IMU model
 imu_payload = IMU(
     # Embedded Field 1: Acceleration with its own specific uncertainty
-    # Here the Vector3d instance inherits the timestamp and frame_id
-    # from the parent IMU Message.
     acceleration=Vector3d(
         x=0.5, y=-0.2, z=9.8,
         covariance=[0.1, 0, 0, 0, 0.1, 0, 0, 0, 0.1]
@@ -538,7 +518,7 @@ imu_payload = IMU(
 )
 
 # Wrap the complex payload in the Message envelope
-imu_writer.push(Message(timestamp_ns=ts, frame_id="imu_link", data=imu_payload))
+imu_writer.push(Message(timestamp_ns=ts, data=imu_payload))
 
 ```
 
@@ -686,14 +666,20 @@ Because the `.Q` query proxy is built directly from the class's PyArrow schema r
 `make_unmodeled_ontology_class()` is the low-level factory, not intended for direct use. In practice, most callers, including the SDK's own reading path (`TopicDataStreamer`, `SequenceDataStreamer`), go through [`resolve_ontology_class()`][mosaicolabs.models.core.helpers.resolve_ontology_class] instead, which adds two behaviors on top:
 
 1. **Reuse before creation**: if a class is already registered for the given tag, it's returned directly instead of creating a duplicate.
-2. **Schema-variant safety**: a single ontology tag can legitimately end up associated with more than one schema shape over time — for example, two rosbags recorded with different versions of the same ROS message type, both mapped by the translation layer to the same inferred tag. When the schema passed in doesn't match what's already registered for that tag, `resolve_ontology_class()` doesn't silently decode the second version against the first version's schema. Instead, it computes a short, deterministic fingerprint of the schema and resolves (or creates) a distinct variant class for it, i.e. a separate Python class with its own [`__registry_key__`][mosaicolabs.models.core.Serializable] (`f"{tag}__{fingerprint}"`), so the SDK can always tell the two schemas apart locally. Both variants still report the *same* `ontology_tag` to the platform, so all of their data remains ingestible and queryable under one consistent, predictable tag — regardless of which schema version a given process happens to encounter first.
+2. **Schema-variant safety**: a single ontology tag can legitimately end up associated with more than one schema shape over time — for example, two rosbags recorded with different versions of the same ROS message type, both mapped by the translation layer to the same inferred tag. `resolve_ontology_class()` handles this in three steps:
+    * When the schema passed in doesn't match what's already registered for that tag, it does **not** silently decode the second version against the first version's schema.
+    * Instead, it computes a short, deterministic fingerprint of the schema and resolves (or creates) a distinct variant class for it — a separate Python class with its own [`__registry_key__`][mosaicolabs.models.core.Serializable] (`f"{tag}__{fingerprint}"`), so the SDK can always tell the two schemas apart locally.
+    * Both variants still report the *same* `ontology_tag` to the platform, so all of their data remains ingestible and queryable under one consistent, predictable tag — regardless of which schema version a given process happens to encounter first.
 
 This is what makes it safe for a component like the ROS Bridge to translate an unadapted message type into a PyArrow schema and call `resolve_ontology_class(ontology_tag=..., schema=...)` for every message, without having to track class identity or schema versions itself.
 
 #### Schema canonization
-For performance reasons, the platform's query engine (DataFusion) rewrites certain **top-level** fields of a schema when storing the data: any field declared as `pa.string()` or `pa.large_string()` comes back as `pa.string_view()`, and likewise `pa.binary()`/`pa.large_binary()` come back as `pa.binary_view()`. DataFusion effectively treats `string` and `large_string` as the same underlying concept and standardizes on `string_view` (same for the binary family) - but only for fields sitting directly at the top level of the schema, not for string/binary fields nested inside a struct. A field like `MotionState.target_frame_id` (a top-level `string` field) comes back as `string_view`; `Header.frame_id`, when `Header` is embedded via `HeaderMixin` into a class like `IMU`, stays a plain `string` inside its nested struct; however, if a `Message` of type `Header` is sent, then `frame_id` becomes a top-level field itself and it is transformed to `string_view`.
 
-This asymmetry matters directly for schema-variant resolution: a naive fingerprint comparison between a class's own locally-built schema (`string`/`binary`) and the schema echoed back by the server for the same data (`string_view`/`binary_view` at the top level) would treat them as *different* schemas - misidentifying a perfectly ordinary, correctly modeled ontology as a schema variant (or as `Unmodeled`) purely because of this server-side rewrite, not any real structural difference. To avoid that, the schema fingerprint canonizes top-level `string`/`large_string` fields to `string_view` and top-level `binary`/`large_binary` fields to `binary_view` before hashing - mirroring exactly what DataFusion does, and only at the same depth. Nested struct fields and list element types are left untouched, since the server doesn't rewrite those either.
+This is an internal detail the SDK handles for you automatically; it's documented here for readers debugging an unexpected schema-variant resolution, not something you need to act on day-to-day.
+
+* **The DataFusion context**: for performance reasons, the platform's query engine (DataFusion) rewrites certain **top-level** fields of a schema when storing data: `pa.string()`/`pa.large_string()` come back as `pa.string_view()`, and `pa.binary()`/`pa.large_binary()` come back as `pa.binary_view()`. This only applies to fields sitting directly at the top level of the schema, not to string/binary fields nested inside a struct. For example, a top-level field like `MotionState.target_frame_id` comes back as `string_view`, while `Header.frame_id` — nested inside `IMU` via `HeaderMixin` — stays a plain `string`; if a `Message` of type `Header` is sent directly, `frame_id` becomes top-level and is rewritten too.
+* **Why it matters**: a naive fingerprint comparison between a class's own locally-built schema (`string`/`binary`) and the schema echoed back by the server (`string_view`/`binary_view` at the top level) would treat them as *different* schemas — misidentifying a perfectly ordinary, correctly modeled ontology as a schema variant (or as `Unmodeled`), purely because of this server-side rewrite.
+* **How it's resolved**: the schema fingerprint canonizes top-level `string`/`large_string` fields to `string_view` and top-level `binary`/`large_binary` fields to `binary_view` before hashing, mirroring exactly what DataFusion does and only at the same depth. Nested struct fields and list element types are left untouched, since the server doesn't rewrite those either.
 
 ### Retrieving Unmodeled Data from a `Message`
 
@@ -738,7 +724,7 @@ The following table illustrates how the proxy flattens complex hierarchies into 
 
 ### Practical Usage
 
-To execute these filters, pass the expressions generated by the proxy to the [`QueryOntologyCatalog`][mosaicolabs.query.builders.QueryOntologyCatalog] builder.
+To execute these filters, pass the expressions generated by the proxy to the [`QueryOntologyCatalog`][mosaicolabs.query.builders.QueryOntologyCatalog] builder:
 
 ```python
 from mosaicolabs import MosaicoClient, IMU, GPS, QueryOntologyCatalog
@@ -750,21 +736,9 @@ with MosaicoClient.connect("localhost", 6726) as client:
         .with_expression(IMU.Q.acceleration.z.gt(15.0))
         .with_expression(GPS.Q.status.service.eq(2))
     )
-
-    # The server returns a QueryResponse grouped by Sequence for structured data management
-    if qresponse is not None:
-        for item in qresponse:
-            print(f"Sequence: {item.sequence.name}")
-            print(f"Topics: {[topic.name for topic in item.topics]}")
-    
-            # Clusterize all topics within the sequence to extract the time intervals
-            clusters_dict = item.clusterize_all()
-
-            # Since clusterize_all() used default clustering_dt_ns, each topic will have
-            # just one cluster representing the first and last moment the query was satisfied
-            for t_name, clusters in clusters_dict.items():
-                print(f"{t_name}:\\n", "\\n".join(f"{cluster}" for cluster in clusters))
 ```
+
+See the **[Full Query Documentation](./query.md)** for how to iterate the returned `QueryResponse` and extract time intervals from it.
 
 For a comprehensive list of all supported operators and advanced filtering strategies (such as query chaining), see the **[Full Query Documentation](./query.md)** and the Ontology types SDK Reference in the **API Reference**:
 
@@ -779,7 +753,7 @@ For a comprehensive list of all supported operators and advanced filtering strat
 The Mosaico SDK is built for extensibility, allowing you to define domain-specific data structures that can be registered to the platform and live alongside standard types.
 Custom types are automatically validatable, serializable, and queryable once registered in the platform.
 
-Follow these three steps to implement a compatible custom data type:
+Follow these two steps to implement a compatible custom data type:
 
 ### 1. Inheritance and Mixins
 
@@ -816,9 +790,9 @@ This example demonstrates a custom sensor for environmental monitoring that trac
 
 from typing import Optional
 import pyarrow as pa
-from mosaicolabs import MosaicoField, MosaicoType, Serializable
+from mosaicolabs import HeaderMixin, MosaicoField, MosaicoType, Serializable
 
-class EnvironmentSensor(Serializable):
+class EnvironmentSensor(Serializable, HeaderMixin):
     """
     Custom sensor reading for Temperature, Humidity, and Pressure.
     """
@@ -838,7 +812,7 @@ from mosaicolabs import Message, Header, Time
 
 # Initialize with standard metadata
 meas = EnvironmentSensor(
-    header=Header(stamp=Time.now(), frame_id="lab_sensor_1"),
+    header=Header(timestamp=Time.now(), frame_id="lab_sensor_1"),
     temperature=23.5,
     humidity=0.45
 )

--- a/docs/py/docs/SDK/query.md
+++ b/docs/py/docs/SDK/query.md
@@ -45,17 +45,8 @@ with MosaicoClient.connect("localhost", 6726) as client:
     if qresponse is not None:
         for item in qresponse:
             # 'item.sequence' contains the name for the matched sequence
-            print(f"Sequence: {item.sequence.name}") 
+            print(f"Sequence: {item.sequence.name}")
             print(f"Topics: {[topic.name for topic in item.topics]}")
-    
-            # Clusterize all topics within the sequence to extract the time intervals
-            clusters_dict = item.clusterize_all()
-
-            # Since clusterize_all() used default clustering_dt_ns, each topic will have
-            # just one cluster representing the first and last moment the query was satisfied
-            for t_name, clusters in clusters_dict.items():
-                print(f"{t_name}:\n", "\n".join(f"{cluster}" for cluster in clusters))
-
 ```
 
 The provided example illustrates the core architecture of the Mosaico Query DSL. To effectively use this module, it is important to understand the two primary mechanisms that drive data discovery:
@@ -139,6 +130,23 @@ with MosaicoClient.connect("localhost", 6726) as client:
 The `QueryResponse` class enables a powerful mechanism for **iterative search refinement** by allowing you to convert your current results back into a new query builder.
 This approach is essential for resolving complex, multi-modal dependencies where a single monolithic query would be logically ambiguous, inefficient or technically impossible.
 
+#### When Chaining is Necessary
+
+In the Mosaico Data Platform, a single `client.query()` call applies a logical **AND** across all provided builders to locate individual **data streams (topics)** that satisfy every condition simultaneously.
+Because a single topic cannot physically represent two different sensor types at once, such as being both a `GPS` sensor and a `String` log, a monolithic query attempting to filter for both on the same stream will inherently return zero results:
+
+```python
+# AMBIGUOUS: This looks for ONE topic that is BOTH GPS and String
+response = client.query(
+    QueryOntologyCatalog(GPS.Q.status.status.eq(DGPS_FIX)),
+    QueryOntologyCatalog(String.Q.data.match("*[ERR]*")),
+    QueryTopic().with_name("/localization/log_string")
+)
+
+```
+
+Chaining resolves this by allowing you to find the correct **Sequence** context in step one, then "locking" that domain to find a different **Topic** within that same context in step two, using `to_query_sequence()` or `to_query_topic()` below.
+
 | Method | Return Type | Description |
 | --- | --- | --- |
 | [`to_query_sequence()`][mosaicolabs.query.response.QueryResponse.to_query_sequence] | [`QuerySequence`][mosaicolabs.query.builders.QuerySequence] | Returns a query builder pre-filtered to include only the **sequences** present in the response. |
@@ -193,21 +201,6 @@ with MosaicoClient.connect("localhost", 6726) as client:
             initial_response.to_query_topic(),              # The "locked" topic domain
             QueryOntologyCatalog(String.Q.data.match("*[ERR]*"))  # Filter by content substring
         )
-```
-
-#### When Chaining is Necessary
-
-The previous example of the `GPS.status` query and the subsequent `/localization/log_string` topic search highlight exactly when *query chaining* becomes a technical necessity rather than just a recommendation. In the Mosaico Data Platform, a single `client.query()` call applies a logical **AND** across all provided builders to locate individual **data streams (topics)** that satisfy every condition simultaneously.
-Because a single topic cannot physically represent two different sensor types at once, such as being both a `GPS` sensor and a `String` log, a monolithic query attempting to filter for both on the same stream will inherently return zero results. Chaining resolves this by allowing you to find the correct **Sequence** context in step one, then "locking" that domain to find a different **Topic** within that same context in step two.
-
-```python
-# AMBIGUOUS: This looks for ONE topic that is BOTH GPS and String
-response = client.query(
-    QueryOntologyCatalog(GPS.Q.status.status.eq(DGPS_FIX)),
-    QueryOntologyCatalog(String.Q.data.match("*[ERR]*")),
-    QueryTopic().with_name("/localization/log_string")
-)
-
 ```
 
 ### Wildcards patterns Queries
@@ -311,7 +304,7 @@ Filters recordings based on high-level session metadata, such as the sequence na
 **Example** Querying for sequences by name and creation date
 
 ```python
-from mosaicolabs import MosaicoClient, Topic, QuerySequence
+from mosaicolabs import MosaicoClient, QuerySequence
 
 with MosaicoClient.connect("localhost", 6726) as client:
     # Search for sequences by project name and creation date
@@ -319,7 +312,7 @@ with MosaicoClient.connect("localhost", 6726) as client:
         QuerySequence()
         .with_name_match("test_drive")
         .with_user_metadata("project", eq="Apollo")
-        .with_created_timestamp(time_start=Time.from_float(1690000000.0))
+        .with_created_timestamp(time_start=1690000000_000000000)
     )
 
     # Inspect the response
@@ -338,14 +331,14 @@ Targets specific data channels within a sequence. You can search for topics by n
 **Example** Querying for image topics by ontology tag, metadata key and topic creation timestamp
 
 ```python
-from mosaicolabs import MosaicoClient, Image, Topic, QueryTopic
+from mosaicolabs import MosaicoClient, Image, QueryTopic
 
 with MosaicoClient.connect("localhost", 6726) as client:
     # Query for all 'image' topics created in a specific timeframe, matching some metadata (key, value) pair
     qresponse = client.query(
         QueryTopic()
         .with_ontology_tag(Image.ontology_tag())
-        .with_created_timestamp(time_start=Time.from_float(170000000))
+        .with_created_timestamp(time_start=1700000000_000000000)
         .with_user_metadata("camera_id.serial_number", eq="ABC123_XYZ")
     )
 
@@ -367,38 +360,31 @@ Filters based on the **actual time-series content** of the sensors (e.g., "Find 
 **Example** Querying for mixed sensor data
 
 ```python
-from mosaicolabs import MosaicoClient, QueryOntologyCatalog, GPS, IMU
+from mosaicolabs import MosaicoClient, QueryOntologyCatalog, GPS, IMU, Pose, Pressure, Temperature
 
-    with MosaicoClient.connect("localhost", 6726) as client:
-        # Chain multiple sensor filters together
-        qresponse = client.query(
-            QueryOntologyCatalog()
-            .with_expression(GPS.Q.status.satellites.geq(8))
-            .with_expression(Temperature.Q.value.between([273.15, 373.15]))
-            .with_expression(Pressure.Q.value.geq(100000))
-        )
+with MosaicoClient.connect("localhost", 6726) as client:
+    # Chain multiple sensor filters together
+    qresponse = client.query(
+        QueryOntologyCatalog()
+        .with_expression(GPS.Q.status.satellites.geq(8))
+        .with_expression(Temperature.Q.value.between([273.15, 373.15]))
+        .with_expression(Pressure.Q.value.geq(100000))
+    )
 
-        # Inspect the response
-        if qresponse is not None:
-            # Results are automatically grouped by Sequence for easier data management
-            for item in qresponse:
-                print(f"Sequence: {item.sequence.name}")
-                print(f"Topics: {[topic.name for topic in item.topics]}")
+    # Inspect the response
+    if qresponse is not None:
+        # Results are automatically grouped by Sequence for easier data management
+        for item in qresponse:
+            print(f"Sequence: {item.sequence.name}")
+            print(f"Topics: {[topic.name for topic in item.topics]}")
 
-        # Filter for a specific component value and extract the first and last occurrence times
-        qresponse = client.query(
-            QueryOntologyCatalog()
-            .with_expression(IMU.Q.acceleration.x.lt(-4.0))
-            .with_expression(IMU.Q.acceleration.y.gt(5.0))
-            .with_expression(Pose.Q.rotation.z.geq(0.707))
-        )
-
-        # Inspect the response
-        if qresponse is not None:
-            # Results are automatically grouped by Sequence for easier data management
-            for item in qresponse:
-                print(f"Sequence: {item.sequence.name}")
-                print(f"Topics: {[topic.name for topic in item.topics]}")
+    # A different filter on the same layer — same response shape as above
+    qresponse = client.query(
+        QueryOntologyCatalog()
+        .with_expression(IMU.Q.acceleration.x.lt(-4.0))
+        .with_expression(IMU.Q.acceleration.y.gt(5.0))
+        .with_expression(Pose.Q.orientation.z.geq(0.707))
+    )
 ```
 
 The Mosaico Query Module offers two distinct paths for defining filters,  **Convenience Methods** and **Generic Expression Method**, both of which support **method chaining** to compose multiple criteria into a single query using a logical **AND**.
@@ -413,8 +399,10 @@ The builder automatically selects the appropriate field and operator (such as ex
 from mosaicolabs import QuerySequence, QueryTopic, RobotJoint
 
 # Build a filter with name pattern
-qbuilder = QuerySequence()
+qbuilder = (
+    QuerySequence()
     .with_name_match("test_drive")
+)
 # Execute the query
 qresponse = client.query(qbuilder)
 
@@ -425,19 +413,13 @@ if qresponse is not None:
         print(f"Sequence: {item.sequence.name}")
         print(f"Topics: {[topic.name for topic in item.topics]}")
 
-# Build a filter with ontology tag AND a specific creation time window
-qbuilder = QueryTopic()
+# Build a filter with ontology tag AND a specific creation time window — same response shape as above
+qbuilder = (
+    QueryTopic()
     .with_ontology_tag(RobotJoint.ontology_tag())
-    .with_created_timestamp(start=t1, end=t2)
-# Execute the query
+    .with_created_timestamp(time_start=t1, time_end=t2)
+)
 qresponse = client.query(qbuilder)
-
-# Inspect the response
-if qresponse is not None:
-    # Results are automatically grouped by Sequence for easier data management
-    for item in qresponse:
-        print(f"Sequence: {item.sequence.name}")
-        print(f"Topics: {[topic.name for topic in item.topics]}")
 ```
 
 * **Best For**: Standard system-level fields like Names and Timestamps.
@@ -469,9 +451,7 @@ if qresponse is not None:
 
 ## The `.Q` Proxy Mechanism
 
-The Query Proxy is the cornerstone of Mosaico's type-safe data discovery. Every data model in the Mosaico Ontology (e.g., `IMU`, `GPS`, `Image`) is automatically injected with a static `.Q` attribute during class initialization. This mechanism transforms static data structures into dynamic, fluent interfaces for constructing complex filters.
-
-The proxy follows a three-step lifecycle to ensure that your queries are both semantically correct and high-performance:
+Building on the introduction above, the proxy follows a three-step lifecycle to ensure that your queries are both semantically correct and high-performance:
 
 1. **Intelligent Mapping**: During system initialization, the proxy inspects the sensor's schema recursively. It maps every nested field path (e.g., `"acceleration.x"`) to a dedicated *queryable* object, i.e. an object providing comparison operators and expression generation methods.
 2. **Type-Aware Operators**: The proxy identifies the data type of each field (numeric, string, dictionary, or boolean) and exposes only the operators valid for that type. This prevents logical errors, such as attempting a substring `.match()` on a numeric acceleration value.
@@ -512,7 +492,7 @@ The following table lists the supported operators for each data type:
 | Data Type | Operators |
 | --- | --- |
 | **Numeric** | [`.eq()`][mosaicolabs.query.queryable_fields.QueryableNumeric.eq], [`.lt()`][mosaicolabs.query.queryable_fields.QueryableNumeric.lt], [`.leq()`][mosaicolabs.query.queryable_fields.QueryableNumeric.leq], [`.gt()`][mosaicolabs.query.queryable_fields.QueryableNumeric.gt], [`.geq()`][mosaicolabs.query.queryable_fields.QueryableNumeric.geq], [`.between()`][mosaicolabs.query.queryable_fields.QueryableNumeric.between], [`.in_()`][mosaicolabs.query.queryable_fields.QueryableNumeric.in_], [`.outside()`][mosaicolabs.query.queryable_fields.QueryableNumeric.outside] |
-| **String** | [`.eq()`][mosaicolabs.query.queryable_fields.QueryableString.eq], [`.match()`][mosaicolabs.query.queryable_fields.QueryableString.match] (regex matching), [`.in_()`][mosaicolabs.query.queryable_fields.QueryableString.in_], [`.lt()`][mosaicolabs.query.queryable_fields.QueryableString.lt], [`.gt()`][mosaicolabs.query.queryable_fields.QueryableString.gt], [`.leq()`][mosaicolabs.query.queryable_fields.QueryableString.leq], [`.geq()`][mosaicolabs.query.queryable_fields.QueryableString.geq], [`.between()`][mosaicolabs.query.queryable_fields.QueryableString.between], [`.outside()`][mosaicolabs.query.queryable_fields.QueryableString.outside] |
+| **String** | [`.eq()`][mosaicolabs.query.queryable_fields.QueryableString.eq], [`.match()`][mosaicolabs.query.queryable_fields.QueryableString.match] (glob-style matching), [`.in_()`][mosaicolabs.query.queryable_fields.QueryableString.in_], [`.lt()`][mosaicolabs.query.queryable_fields.QueryableString.lt], [`.gt()`][mosaicolabs.query.queryable_fields.QueryableString.gt], [`.leq()`][mosaicolabs.query.queryable_fields.QueryableString.leq], [`.geq()`][mosaicolabs.query.queryable_fields.QueryableString.geq], [`.between()`][mosaicolabs.query.queryable_fields.QueryableString.between], [`.outside()`][mosaicolabs.query.queryable_fields.QueryableString.outside] |
 | **Boolean** | [`.eq(True/False)`][mosaicolabs.query.queryable_fields.QueryableBool.eq] |
 <!-- | **Dictionary** | `.eq()`, `.lt()`, `.leq()`, `.gt()`, `.geq()`, `.between()`, `.ex()`, `.match()` (regex matching), `.outside()`| -->
 
@@ -620,11 +600,11 @@ with MosaicoClient.connect("localhost", 6726) as client:
 
 | Class | Supported Operators | Value Type |
 | --- | --- | --- |
-| [`QueryableNumeric`][mosaicolabs.query.queryable_fields.QueryableNumeric] | `.eq()`, `.neq()`, `.lt()`, `.leq()`, `.gt()`, `.geq()`, `.in_()`, `.between()` | `int`, `float` |
-| [`QueryableString`][mosaicolabs.query.queryable_fields.QueryableString] | `.eq()`, `.match()`, `.lt()`, `.leq()`, `.gt()`, `.geq()`, `.in_()` | `str` |
+| [`QueryableNumeric`][mosaicolabs.query.queryable_fields.QueryableNumeric] | `.eq()`, `.neq()`, `.lt()`, `.leq()`, `.gt()`, `.geq()`, `.in_()`, `.between()`, `.outside()` | `int`, `float` |
+| [`QueryableString`][mosaicolabs.query.queryable_fields.QueryableString] | `.eq()`, `.match()`, `.lt()`, `.leq()`, `.gt()`, `.geq()`, `.in_()`, `.between()`, `.outside()` | `str` |
 | [`QueryableBool`][mosaicolabs.query.queryable_fields.QueryableBool] | `.eq()` | `bool` |
 
-### Querying List Fields
+### Querying List Fields (Class-Free)
 
 Querying list fields is possible for unmodeled ontology schemas also, exactly the same way it is done with hand-authored ontology classes. As in this case, a list field isn't a leaf value the server can compare against, so when setting the path of the list field to query against, it is necessary to select *which* element(s) the condition targets before a `Queryable*` type can wrap anything. An index selector, appended directly after the list field's name, "exposes" one conceptual element of the list, turning `list_field` (a list) into a single addressable slot the same way `.field` does for a struct.
 
@@ -856,7 +836,7 @@ with MosaicoClient.connect("localhost", 6726) as client:
 | --- | --- | --- |
 | `clustering_map` | Both | Maps each `ontology_tag` to its own `clustering_dt_ns`. Use it when your topics have very different sampling rates or noise characteristics — e.g. a high-frequency `IMU` needs a tight gap to avoid merging distinct events, while a lower-frequency `GPS` topic may need a wider one just to bridge its own sampling interval. |
 | `override_clustering_dt_ns` | Both | A single fallback `clustering_dt_ns` applied to any topic not covered by `clustering_map` (or to every topic if `clustering_map` is omitted). Use it for a quick, uniform adjustment when you don't need per-sensor tuning. |
-| `intersect_dt_ns` | `intersect()` only | Same tolerance concept as the topic-level `intersect()` above, but applied across every topic in the item at once. `0` (default) requires a strict time overlap; increasing it lets you catch causally-related events that don't land at the exact same instant — e.g. a camera flags an obstacle a few hundred milliseconds before the IMU registers the resulting swerve. |
+| `intersect_dt_ns` | `intersect()` only | Same tolerance parameter as the topic-level `intersect()` [above](#topics-intersect), applied across every topic in the item at once. |
 
 Use `clusterize_all()` when you need to inspect or debug each sensor's activity independently; use `intersect()` when the question you're actually asking spans multiple sensors at once.
 
@@ -868,7 +848,7 @@ While fully functional, the current implementation (v0.x) has a **Single Occurre
     ```python
     # INVALID: The same field (acceleration.x) is used twice in the constructor
     QueryOntologyCatalog() \
-        .with_expression(IMU.Q.acceleration.x.gt(0.5))
+        .with_expression(IMU.Q.acceleration.x.gt(0.5)) \
         .with_expression(IMU.Q.acceleration.x.lt(1.0)) # <- Error! Duplicate field path
 
     ```

--- a/docs/py/docs/code_contributing.md
+++ b/docs/py/docs/code_contributing.md
@@ -49,7 +49,7 @@ poetry run pre-commit run
 After setup, confirm the hook is in place:
 
 ```bash
-ls .git/hooks/pre-commit
+ls ../.git/hooks/pre-commit
 ```
 
 You should see the file present. If it is missing, re-run `poetry run pre-commit install`.

--- a/docs/py/docs/index.md
+++ b/docs/py/docs/index.md
@@ -5,7 +5,7 @@ description: Architecture and design of the mosaico python SDK.
 
 The Mosaico SDK is a Python interface designed specifically for managing **Physical AI and Robotics data**. Its purpose is to handle the complete lifecycle of information, from the moment it is captured by a sensor to the moment it is used to train a neural network or analyze a robot's behavior.
 
-The SDK is built on the philosophy that robotics data is **unique**. Whether it comes from a autonomous car, a drone, or a factory arm, this data is multi-modal, highly frequent, and deeply interconnected in space and time. The Mosaico SDK provides the infrastructure to treat this data as a *first-class citizen* rather than just a collection of generic numbers. It understands the geometric and physical semantics of complex data types such as LIDAR point clouds, IMU readings, high-resolution camera feeds, and rigid-body transformations.
+The SDK is built on the philosophy that robotics data is **unique**, whether it comes from an autonomous car, a drone, or a factory arm. This data is multi-modal, highly frequent, and deeply interconnected in space and time. The Mosaico SDK provides the infrastructure to treat this data as a *first-class citizen* rather than just a collection of generic numbers. It understands the geometric and physical semantics of complex data types such as LIDAR point clouds, IMU readings, high-resolution camera feeds, and rigid-body transformations.
 
 ## Installation
 Install the SDK via `pip`:
@@ -54,13 +54,18 @@ You can push data into Mosaico through two primary pathways, both designed to en
 
 ### Data Retrieval
 
-Retrieving data goes beyond simple downloading. It is possible to stream and merge multiple topics into a single, time-ordered timeline, which is essential for sensor fusion. 
-Connect directly to a specific sensor, such as just the front-facing camera, to save bandwidth and memory. 
-The SDK fetches data in batches, allowing you to process datasets that are much larger than your computer's RAM.
+Retrieving data goes beyond simple downloading:
+
+* **Multi-Topic Streaming**: Stream and merge multiple topics into a single, time-ordered timeline, essential for sensor fusion.
+* **Selective Access**: Connect directly to a specific sensor, such as just the front-facing camera, to save bandwidth and memory.
+* **Batched Fetching**: Data is fetched in batches, allowing you to process datasets that are much larger than your computer's RAM.
 
 ### Querying & Discovery
 
-Mosaico allows you to find data based on *what* happened, not just *when* it happened. You can search for specific sequences by metadata tags (like `robot_id` or `location`) or query the actual contents of the sensor data (e.g., *"Find all sequences where the vehicle acceleration exceeded 4 m/s^2"*).
+Mosaico allows you to find data based on *what* happened, not just *when* it happened:
+
+* **Metadata Search**: Find specific sequences by metadata tags, such as `robot_id` or `location`.
+* **Content Search**: Query the actual contents of the sensor data, e.g., *"Find all sequences where the vehicle acceleration exceeded 4 m/s^2"*.
 
 ### Machine Learning & Analytics
 

--- a/mosaico-sdk-py/pyproject.toml
+++ b/mosaico-sdk-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mosaicolabs"
-version = "0.6.0-dev"
+version = "0.7.0-dev"
 description = "Python SDK for Mosaico Data-Platform"
 authors = ["Mosaico Labs <info@mosaico.dev>"]
 readme = "README.md"

--- a/mosaicod/Cargo.toml
+++ b/mosaicod/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "bin/*", "tests/"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.0-dev"
+version = "0.7.0-dev"
 authors = ["Mosaico Labs <info@mosaico.dev>"]
 homepage = "https://mosaico.dev"
 repository = "https://github.com/mosaico-labs/mosaico"


### PR DESCRIPTION
This PR overhauls the Python SDK documentation (`docs/py/docs`, `docs/main/docs/examples`, `docs/main/docs/learn`) and adds three new How-To guides.

- **Correctness fixes**: removed a non-existent `Message.frame_id` field from an example, fixed `.match()` mislabeled as regex instead of glob, added a missing `.outside()` operator to the class-free query table, corrected "Two-way TLS" terminology (the SDK only supports server-authenticated TLS, no mTLS), fixed missing imports and a missing `on_error` policy in the writing guides' Full Examples, and various smaller typos/inconsistencies.
- **Clarity and structure**: reworded overly dense paragraphs, split oversized sections into bullets, reordered content where the "why" appeared after the "how", and removed redundant boilerplate repeated verbatim across code samples.
- **Cross-file de-duplication**: consolidated repeated explanations (wildcard/glob tables, `.Q` proxy description, timestamp semantics, error-policy boxes) into single canonical sources, with the sibling guides linking back instead of restating them.
- **New How-To guides**:
  - *Updating a Sequence* — adding new Topics to an already-ingested Sequence via `SequenceUpdater`, contrasting `client.sequence_update()` (write-only credentials) with `SequenceHandler.update()` (read+write).
  - *Preparing PyTorch Training Batches* — the `DataFrameExtractor` → `SyncTransformer` → windowed `IterableDataset` pipeline for feeding synchronized multi-sensor data into a PyTorch `DataLoader`.
  - *Live Streaming to Foxglove* — streaming a Sequence into a live Foxglove WebSocket session without an intermediate MCAP file, covering well-known Foxglove schemas vs. raw JSON, the `Message`/`Header` ↔ `log_time`/schema-timestamp mapping, replay pacing, server lifecycle, and the `Unmodeled` (class-less) fallback path.

All code snippets were verified against the actual SDK source.
