### PR TITLE
feat(cli): CLI output and various improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# Mosaico agent instructions
+
+## Repository map
+
+- `mosaicod/`: Rust daemon, storage, database, query engine, and Arrow Flight services.
+- `mosaico-sdk-py/`: Python SDK, `mosaico` CLI, ontology, bridges, and tests.
+- `docs/main/`: Product, daemon, examples, and contributor documentation.
+- `docs/py/`: Generated Python SDK reference and LLM context output.
+- `scripts/`: Development environment, release, and test entry points.
+
+Read the nearest nested `AGENTS.md` before changing a component.
+
+## Working rules
+
+1. Preserve public Rust/Python protocol compatibility unless the task explicitly changes it.
+2. Never print API keys, authorization metadata, private-key material, or unredacted profiles.
+3. Treat CLI output selected with `--output json` or `--output jsonl` as a versioned interface.
+4. Update user documentation and tests in the same change as a public CLI or SDK change.
+5. Prefer targeted validation during iteration and the repository test runner before handoff.
+
+## Authoritative commands
+
+```bash
+# Python formatting, linting, and unit tests
+cd mosaico-sdk-py
+poetry install --extras cli
+poetry run ruff format --check .
+poetry run ruff check .
+poetry run pytest ./src/testing -k unit
+
+# Rust formatting, linting, and tests
+cd mosaicod
+cargo fmt -- --check
+cargo lint
+cargo test
+
+# Repository integration suites
+./scripts/tests --help
+./scripts/tests --full-stack
+```
+
+Use `./scripts/tests`, not `./scripts/test`. Start the daemon with the `server` subcommand.
+
+## Change-impact minimums
+
+| Change | Required validation |
+| --- | --- |
+| Python CLI | CLI unit tests, Ruff, help/output docs |
+| Python ontology/schema | Unit round trip, schema fingerprint integration test |
+| Rust action or wire format | Rust tests and Python full-stack tests |
+| SQL query or migration | SQLx metadata/migration validation and database tests |
+| Environment variable | Code, Compose examples, daemon docs, and CLI diagnostics |
+| Documentation example | Both documentation builds and executable snippet check where possible |
+
+## Handoff format
+
+Report the behavior changed, validations run, compatibility or security implications, and any work deliberately left for a later change.

--- a/docs/main/docs/clients/cli.md
+++ b/docs/main/docs/clients/cli.md
@@ -1,0 +1,58 @@
+---
+title: Mosaico CLI
+sidebar_position: 4
+description: Configure connections, inspect resources, and diagnose Mosaico from the command line.
+---
+
+The `mosaico` command is included with the Python SDK CLI extra:
+
+```bash
+pip install "mosaicolabs[cli]"
+```
+
+## Configure a profile
+
+Interactive setup:
+
+```bash
+mosaico profile add local
+```
+
+Non-interactive setup:
+
+```bash
+mosaico profile add local \
+  --no-interactive \
+  --host localhost \
+  --port 6726 \
+  --default
+```
+
+Profile files are written with owner-only permissions on POSIX systems. Prefer the `MOSAICO_API_KEY` environment variable when credentials should not be stored locally.
+
+## Diagnose a connection
+
+```bash
+mosaico doctor
+```
+
+The command checks the resolved profile, configuration permissions, TLS certificate path, DNS, and TCP connectivity. It never prints the API-key value.
+
+For automation and AI development tools, request structured output:
+
+```bash
+mosaico doctor --output json
+mosaico profile ls --output json
+mosaico sequence ls --output jsonl
+mosaico topic ls --output csv
+```
+
+JSON collection documents include a `schema_version`. Scripts should inspect that field before depending on the document structure.
+
+Skip network checks when validating only local configuration:
+
+```bash
+mosaico doctor --no-network
+```
+
+The command exits non-zero when a required check fails. Warnings, such as overly broad configuration permissions, are reported without hiding otherwise useful diagnostics.

--- a/docs/main/docs/clients/cli.md
+++ b/docs/main/docs/clients/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Mosaico CLI
-sidebar_position: 4
+sidebar_position: 1
 description: Configure connections, inspect resources, and diagnose Mosaico from the command line.
 ---
 

--- a/docs/main/docs/clients/cpp.md
+++ b/docs/main/docs/clients/cpp.md
@@ -1,6 +1,6 @@
 ---
 title: C++
-sidebar_position: 11
+sidebar_position: 4
 description: "Status page for the Mosaico C++ SDK, currently in active design. Contact the team directly if you have a specific application or integration requirement that depends on a C++ client."
 ---
 

--- a/docs/main/docs/clients/python.md
+++ b/docs/main/docs/clients/python.md
@@ -1,6 +1,6 @@
 ---
 title: Python
-sidebar_position: 1
+sidebar_position: 2
 description: "Entry point for the Mosaico Python SDK (mosaicolabs package). Links to the full API reference including class documentation, method signatures, and type definitions."
 
 ---

--- a/docs/main/docs/clients/rust.md
+++ b/docs/main/docs/clients/rust.md
@@ -1,6 +1,6 @@
 ---
 title: Rust
-sidebar_position: 12
+sidebar_position: 3
 description: "Status page for the Mosaico Rust SDK, currently in active design. Contact the team directly if you have a specific application or integration requirement that depends on a Rust client."
 ---
 

--- a/docs/main/docs/dev/ai_development.md
+++ b/docs/main/docs/dev/ai_development.md
@@ -1,0 +1,36 @@
+---
+title: AI-assisted development
+sidebar_position: 3
+description: Repository guidance and validation expectations for developers working with AI coding agents.
+---
+
+AI coding tools should begin with the repository `AGENTS.md` and then read the closest component-specific instructions. These files define current commands, trust boundaries, and the minimum validation required for a change.
+
+## Recommended workflow
+
+1. Identify the affected Rust crates, Python packages, CLI commands, and documentation.
+2. State the compatibility and security invariants before editing.
+3. Run the smallest relevant tests while iterating.
+4. Update examples and structured-output contracts with the implementation.
+5. Run the change-impact validation described in `AGENTS.md` before handoff.
+
+## Internal specialist agents
+
+Maintainers can use the separate `mosaico-agents` repository for performance, security, consistency, and general maintenance reviews. Those agents share an evidence-first reporting contract:
+
+- distinguish observations from confirmed defects;
+- include commands, workloads, or code paths supporting conclusions;
+- redact credentials and sensitive paths;
+- report validation performed and residual risk;
+- do not claim performance improvement without comparable before/after measurements.
+
+## Machine-readable CLI diagnostics
+
+Use the CLI rather than scraping formatted terminal output:
+
+```bash
+mosaico doctor --output json
+mosaico profile ls --output json
+```
+
+Structured output is intended for automation. Human-oriented tables may change presentation without notice.

--- a/docs/main/docs/dev/release_cycle.md
+++ b/docs/main/docs/dev/release_cycle.md
@@ -1,6 +1,6 @@
 ---
 title: Release Cycle
-position: 1
+sidebar_position: 1
 description: "Mosaico's monorepo branching strategy, semantic versioning policy, and release process for mosaicod and the SDK. Covers the relationship between daemon and SDK versions and how breaking changes are communicated."
 ---
 

--- a/docs/main/docs/dev/testing_and_dev.md
+++ b/docs/main/docs/dev/testing_and_dev.md
@@ -1,6 +1,6 @@
 --- 
 title: Testing & Development
-position: 2
+sidebar_position: 2
 description: "Development environment setup and contribution procedures for the Mosaico project. Covers local orchestration, database schema migration, and the test suite required before submitting changes."
 ---
 

--- a/mosaico-sdk-py/AGENTS.md
+++ b/mosaico-sdk-py/AGENTS.md
@@ -1,0 +1,26 @@
+# Python SDK and CLI instructions
+
+These instructions extend the repository-level `AGENTS.md`.
+
+## CLI contracts
+
+- Put built-in commands in `src/mosaicolabs_cli/commands/` and register them in `main.py`.
+- Keep profile resolution in `MosaicoProfile`; do not duplicate precedence rules in commands.
+- Send human diagnostics to stderr when stdout is reserved for structured or piped data.
+- Never serialize API-key values. Expose only a boolean such as `api_key_configured`.
+- JSON collection output must include `schema_version`. JSON Lines emits one complete object per line.
+- Avoid spinners, colors, headings, or explanatory prose in CSV, JSON, and JSON Lines output.
+- Preserve non-interactive operation for automation and AI agents.
+
+## Tests
+
+- Unit CLI tests live in `src/testing/unit/cli/` and use `typer.testing.CliRunner`.
+- Mock network and filesystem boundaries in unit tests.
+- Add a test for redaction whenever configuration or authentication data is involved.
+- Cover both terminal-friendly behavior and at least one structured-output mode.
+
+## Security
+
+- Write local configuration with owner-only permissions on POSIX systems.
+- Treat discovered `mosaico-*` extensions as an external trust boundary.
+- Do not forward credentials to a new subprocess or plugin without an explicit, documented permission model.

--- a/mosaico-sdk-py/src/mosaicolabs_cli/commands/doctor.py
+++ b/mosaico-sdk-py/src/mosaicolabs_cli/commands/doctor.py
@@ -1,0 +1,184 @@
+import json
+import socket
+import sys
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.table import Table
+
+from mosaicolabs_cli.utils.config import (
+    OutputFormat,
+    config_permissions,
+    console,
+    get_config_path,
+)
+from mosaicolabs_cli.utils.mosaico_profile import MosaicoProfile
+
+
+def _check(name: str, status: str, message: str) -> dict[str, str]:
+    return {"name": name, "status": status, "message": message}
+
+
+def _overall_status(checks: list[dict[str, str]]) -> str:
+    statuses = {check["status"] for check in checks}
+    if "error" in statuses:
+        return "error"
+    if "warning" in statuses:
+        return "warning"
+    return "ok"
+
+
+def _render_table(checks: list[dict[str, str]], overall: str) -> None:
+    table = Table(
+        title=f"Mosaico diagnostics: {overall}",
+        header_style="bold cyan",
+        box=None,
+    )
+    table.add_column("Check", style="bold white")
+    table.add_column("Status")
+    table.add_column("Details")
+
+    styles = {"ok": "green", "warning": "yellow", "error": "red"}
+    for check in checks:
+        status = check["status"]
+        table.add_row(
+            check["name"],
+            f"[{styles[status]}]{status}[/{styles[status]}]",
+            check["message"],
+        )
+    console.print(table)
+
+
+def doctor(
+    ctx: typer.Context,
+    network: bool = typer.Option(
+        True,
+        "--network/--no-network",
+        help="Check DNS resolution and TCP connectivity.",
+    ),
+    timeout: float = typer.Option(
+        2.0,
+        "--timeout",
+        min=0.1,
+        help="Network connection timeout in seconds.",
+    ),
+    output: Optional[OutputFormat] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Output diagnostics as table, CSV, JSON, or JSON Lines.",
+    ),
+) -> None:
+    """Diagnose local configuration and connectivity without exposing credentials."""
+    profile: MosaicoProfile = ctx.obj
+    checks: list[dict[str, str]] = []
+    config_path = get_config_path()
+
+    if config_path.exists():
+        permissions = config_permissions(config_path)
+        if permissions is not None and permissions & 0o077:
+            checks.append(
+                _check(
+                    "config_permissions",
+                    "warning",
+                    f"{config_path} is mode {permissions:04o}; use 0600.",
+                )
+            )
+        else:
+            checks.append(
+                _check("config_permissions", "ok", f"{config_path} is restricted.")
+            )
+    else:
+        checks.append(
+            _check(
+                "configuration",
+                "warning",
+                f"No configuration file found at {config_path}; environment settings may still be used.",
+            )
+        )
+
+    if profile and profile.host:
+        checks.append(
+            _check(
+                "profile",
+                "ok",
+                f"Resolved {profile.host}:{profile.port} (TLS {'on' if profile.enable_tls else 'off'}).",
+            )
+        )
+    else:
+        checks.append(
+            _check(
+                "profile",
+                "error",
+                "No host is configured. Add a profile or set MOSAICO_DAEMON_URL.",
+            )
+        )
+
+    if profile and profile.enable_tls and profile.cert_path:
+        cert_path = Path(profile.cert_path)
+        if cert_path.is_file():
+            checks.append(_check("tls_certificate", "ok", str(cert_path)))
+        else:
+            checks.append(
+                _check(
+                    "tls_certificate",
+                    "error",
+                    f"Certificate file does not exist: {cert_path}",
+                )
+            )
+
+    can_check_network = network and profile and bool(profile.host)
+    if can_check_network:
+        try:
+            socket.getaddrinfo(profile.host, profile.port, type=socket.SOCK_STREAM)
+            checks.append(_check("dns", "ok", f"Resolved {profile.host}."))
+        except OSError as exc:
+            checks.append(_check("dns", "error", str(exc)))
+
+        if checks[-1]["name"] == "dns" and checks[-1]["status"] == "ok":
+            try:
+                with socket.create_connection(
+                    (profile.host, profile.port), timeout=timeout
+                ):
+                    pass
+                checks.append(
+                    _check(
+                        "tcp",
+                        "ok",
+                        f"Connected to {profile.host}:{profile.port}.",
+                    )
+                )
+            except OSError as exc:
+                checks.append(_check("tcp", "error", str(exc)))
+
+    overall = _overall_status(checks)
+    selected_output = output or (
+        OutputFormat.TABLE if sys.stdout.isatty() else OutputFormat.JSON
+    )
+    payload = {
+        "schema_version": 1,
+        "status": overall,
+        "profile": {
+            "name": profile.name if profile else "",
+            "host": profile.host if profile else "",
+            "port": profile.port if profile else None,
+            "tls": profile.enable_tls if profile else False,
+            "api_key_configured": bool(profile and profile.api_key),
+        },
+        "checks": checks,
+    }
+
+    if selected_output == OutputFormat.TABLE:
+        _render_table(checks, overall)
+    elif selected_output == OutputFormat.CSV:
+        for check in checks:
+            print(f"{check['name']},{check['status']},{json.dumps(check['message'])}")
+    elif selected_output == OutputFormat.JSONL:
+        for check in checks:
+            print(json.dumps(check, sort_keys=True))
+    else:
+        print(json.dumps(payload, sort_keys=True))
+
+    if overall == "error":
+        raise typer.Exit(code=1)

--- a/mosaico-sdk-py/src/mosaicolabs_cli/commands/extension.py
+++ b/mosaico-sdk-py/src/mosaicolabs_cli/commands/extension.py
@@ -10,7 +10,12 @@ import typer
 from rich.table import Table
 from typer.core import TyperGroup
 
-from mosaicolabs_cli.utils.config import OutputFormat, console, error_console
+from mosaicolabs_cli.utils.config import (
+    OutputFormat,
+    console,
+    emit_structured_records,
+    error_console,
+)
 
 app = typer.Typer(no_args_is_help=True)
 
@@ -105,6 +110,11 @@ def list_extensions(
     extensions = discover_extensions()
 
     if not extensions:
+        if output in (OutputFormat.JSON, OutputFormat.JSONL):
+            emit_structured_records([], output, "extensions")
+            return
+        if output == OutputFormat.CSV:
+            return
         console.print(
             "[yellow]No external extensions discovered in your $PATH.[/yellow]"
         )
@@ -137,3 +147,14 @@ def list_extensions(
     elif output == OutputFormat.CSV:
         for name, binary_path in extensions.items():
             print(f"{name},mosaico-{name},{binary_path}")
+
+    elif output in (OutputFormat.JSON, OutputFormat.JSONL):
+        records = [
+            {
+                "name": name,
+                "binary": f"mosaico-{name}",
+                "path": binary_path,
+            }
+            for name, binary_path in extensions.items()
+        ]
+        emit_structured_records(records, output, "extensions")

--- a/mosaico-sdk-py/src/mosaicolabs_cli/commands/profile.py
+++ b/mosaico-sdk-py/src/mosaicolabs_cli/commands/profile.py
@@ -10,7 +10,7 @@ from mosaicolabs_cli.utils.config import (
     error_console,
     get_config_path,
     load_config,
-    serialize_to_toml,
+    write_config,
 )
 from mosaicolabs_cli.utils.env import DEFAULT_MOSAICO_PORT
 from mosaicolabs_cli.utils.mosaico_profile import MosaicoProfile
@@ -126,10 +126,7 @@ def add_profile(
     }
 
     try:
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-
-        toml_string = serialize_to_toml(config_data)
-        config_path.write_text(toml_string, encoding="utf-8")
+        write_config(config_data, config_path)
 
         console.print(
             f"[bold green]Success:[/bold green] Profile [yellow]'{name}'[/yellow] saved to {config_path}"
@@ -186,8 +183,7 @@ def remove_profile(
             auto_promoted_profile = first_remaining_name
 
     try:
-        toml_string = serialize_to_toml(config_data)
-        config_path.write_text(toml_string, encoding="utf-8")
+        write_config(config_data, config_path)
 
         console.print(
             f"[bold green]Success:[/bold green] Profile [yellow]'{name}'[/yellow] removed."
@@ -299,8 +295,7 @@ def set_default_profile(
                 profile_content["default"] = False
 
     try:
-        toml_string = serialize_to_toml(config_data)
-        config_path.write_text(toml_string, encoding="utf-8")
+        write_config(config_data, config_path)
         console.print(
             f"[bold green]Success:[/bold green] Switched active profile to [yellow]'{name}'[/yellow]."
         )

--- a/mosaico-sdk-py/src/mosaicolabs_cli/commands/profile.py
+++ b/mosaico-sdk-py/src/mosaicolabs_cli/commands/profile.py
@@ -7,6 +7,7 @@ from rich.table import Table
 from mosaicolabs_cli.utils.config import (
     OutputFormat,
     console,
+    emit_structured_records,
     error_console,
     get_config_path,
     load_config,
@@ -215,6 +216,11 @@ def list_profiles(
     config_data = load_config(config_path)
 
     if not config_data:
+        if output in (OutputFormat.JSON, OutputFormat.JSONL):
+            emit_structured_records([], output, "profiles")
+            return
+        if output == OutputFormat.CSV:
+            return
         console.print(
             "[yellow]No profiles configured yet.[/yellow] Use `mosaico profile add` to create one."
         )
@@ -255,9 +261,28 @@ def list_profiles(
                 )
                 console.print(p.to_csv())
 
+    elif output in (OutputFormat.JSON, OutputFormat.JSONL):
+        records = []
+        for name, content in config_data.items():
+            if isinstance(content, dict):
+                p = MosaicoProfile.from_dict(
+                    content, name=name, is_default=content.get("default", False)
+                )
+                records.append(
+                    {
+                        "name": p.name,
+                        "host": p.host,
+                        "port": p.port,
+                        "default": p.is_default,
+                        "tls": p.enable_tls,
+                        "api_key_configured": bool(p.api_key),
+                    }
+                )
+        emit_structured_records(records, output, "profiles")
+
     else:
         error_console.print(
-            f"[bold red]Error:[/bold red] Unsupported output format: '{output}'. Use 'table' or 'csv'."
+            f"[bold red]Error:[/bold red] Unsupported output format: '{output}'."
         )
         raise typer.Exit(code=1)
 

--- a/mosaico-sdk-py/src/mosaicolabs_cli/commands/sequence.py
+++ b/mosaico-sdk-py/src/mosaicolabs_cli/commands/sequence.py
@@ -9,6 +9,7 @@ from mosaicolabs_cli.utils.config import (
     OutputFormat,
     _flatten_metadata,
     console,
+    emit_structured_records,
     error_console,
 )
 from mosaicolabs_cli.utils.mosaico_profile import MosaicoProfile
@@ -148,9 +149,22 @@ def list_sequences(
 
         console.print(table)
 
-    else:
+    elif output == OutputFormat.CSV:
         for name, created, ts_min, ts_max, _ in rows:
             print(f"{name},{ts_min},{ts_max}")
+
+    else:
+        records = [
+            {
+                "locator": name,
+                "created_timestamp": created,
+                "timestamp_ns_min": ts_min,
+                "timestamp_ns_max": ts_max,
+                "user_metadata": metadata,
+            }
+            for name, created, ts_min, ts_max, metadata in rows
+        ]
+        emit_structured_records(records, output, "sequences")
 
 
 @app.command(name="stat")

--- a/mosaico-sdk-py/src/mosaicolabs_cli/commands/topic.py
+++ b/mosaico-sdk-py/src/mosaicolabs_cli/commands/topic.py
@@ -11,6 +11,7 @@ from mosaicolabs_cli.utils.config import (
     OutputFormat,
     _flatten_metadata,
     console,
+    emit_structured_records,
     error_console,
 )
 from mosaicolabs_cli.utils.mosaico_profile import MosaicoProfile
@@ -133,9 +134,20 @@ def list_topics(
 
         console.print(table)
 
-    else:
+    elif output == OutputFormat.CSV:
         for locator_str, ts_min, ts_max in rows:
             print(f"{locator_str},{ts_min},{ts_max}")
+
+    else:
+        records = [
+            {
+                "locator": locator,
+                "timestamp_ns_min": ts_min,
+                "timestamp_ns_max": ts_max,
+            }
+            for locator, ts_min, ts_max in rows
+        ]
+        emit_structured_records(records, output, "topics")
 
 
 @app.command(name="stat")

--- a/mosaico-sdk-py/src/mosaicolabs_cli/main.py
+++ b/mosaico-sdk-py/src/mosaicolabs_cli/main.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import typer
 
-from mosaicolabs_cli.commands import extension, profile, sequence, topic
+from mosaicolabs_cli.commands import doctor, extension, profile, sequence, topic
 from mosaicolabs_cli.commands.extension import MosaicoRouter
 from mosaicolabs_cli.utils.env import MosaicoEnv
 from mosaicolabs_cli.utils.mosaico_profile import MosaicoProfile
@@ -51,6 +51,7 @@ def main_callback(
 app.add_typer(profile.app, name="profile", help="Manage connection profiles.")
 app.add_typer(sequence.app, name="sequence", help="Manage and list sequences.")
 app.add_typer(topic.app, name="topic", help="Manage and list topics.")
+app.command(name="doctor")(doctor.doctor)
 app.add_typer(
     extension.app,
     name="extension",

--- a/mosaico-sdk-py/src/mosaicolabs_cli/utils/config.py
+++ b/mosaico-sdk-py/src/mosaicolabs_cli/utils/config.py
@@ -1,5 +1,7 @@
 import os
+import stat
 import sys
+import tempfile
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -72,6 +74,47 @@ def serialize_to_toml(data: dict) -> str:
             lines.append(f"{key} = {val_str}")
         lines.append("")
     return "\n".join(lines)
+
+
+def write_config(data: dict, path: Optional[Path] = None) -> Path:
+    """Atomically write configuration with owner-only access on POSIX systems."""
+    if path is None:
+        path = get_config_path()
+
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    temporary_path: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as temporary_file:
+            temporary_file.write(serialize_to_toml(data))
+            temporary_path = Path(temporary_file.name)
+
+        if os.name == "posix":
+            temporary_path.chmod(0o600)
+        temporary_path.replace(path)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+
+    return path
+
+
+def config_permissions(path: Optional[Path] = None) -> Optional[int]:
+    """Return POSIX permission bits for an existing config file."""
+    if os.name != "posix":
+        return None
+
+    if path is None:
+        path = get_config_path()
+    if not path.exists():
+        return None
+
+    return stat.S_IMODE(path.stat().st_mode)
 
 
 def _flatten_metadata(data: Dict[str, Any], prefix: str = "") -> List[str]:

--- a/mosaico-sdk-py/src/mosaicolabs_cli/utils/config.py
+++ b/mosaico-sdk-py/src/mosaicolabs_cli/utils/config.py
@@ -1,3 +1,4 @@
+import json
 import os
 import stat
 import sys
@@ -28,6 +29,8 @@ DEFAULT_CONFIG_PATH = Path.home() / DEFAULT_CONFIG_FOLDER / DEFAULT_CONFIG_FILEN
 class OutputFormat(str, Enum):
     TABLE = "table"
     CSV = "csv"
+    JSON = "json"
+    JSONL = "jsonl"
 
 
 def get_config_path() -> Path:
@@ -115,6 +118,20 @@ def config_permissions(path: Optional[Path] = None) -> Optional[int]:
         return None
 
     return stat.S_IMODE(path.stat().st_mode)
+
+
+def emit_structured_records(
+    records: List[Dict[str, Any]], output: OutputFormat, collection: str
+) -> None:
+    """Emit stable JSON or JSON Lines records without terminal decoration."""
+    if output == OutputFormat.JSON:
+        print(json.dumps({"schema_version": 1, collection: records}, sort_keys=True))
+        return
+    if output == OutputFormat.JSONL:
+        for record in records:
+            print(json.dumps(record, sort_keys=True))
+        return
+    raise ValueError(f"Unsupported structured output format: {output}")
 
 
 def _flatten_metadata(data: Dict[str, Any], prefix: str = "") -> List[str]:

--- a/mosaico-sdk-py/src/testing/unit/cli/test_config.py
+++ b/mosaico-sdk-py/src/testing/unit/cli/test_config.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from mosaicolabs_cli.utils.config import (
@@ -5,6 +7,7 @@ from mosaicolabs_cli.utils.config import (
     get_config_path,
     load_config,
     serialize_to_toml,
+    write_config,
 )
 
 
@@ -68,6 +71,30 @@ class TestLoadConfig:
         path.write_text("this is [[[not valid toml")
         with pytest.raises(typer.Exit):
             load_config(path)
+
+
+class TestWriteConfig:
+    def test_creates_parent_and_round_trips(self, tmp_path):
+        path = tmp_path / "nested" / "config.toml"
+        write_config({"dev": {"host": "localhost"}}, path)
+        assert load_config(path)["dev"]["host"] == "localhost"
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permissions only")
+    def test_restricts_file_permissions(self, tmp_path):
+        path = tmp_path / "config.toml"
+        write_config({"dev": {"host": "localhost"}}, path)
+        assert path.stat().st_mode & 0o777 == 0o600
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permissions only")
+    def test_restricts_permissions_when_replacing_existing_file(self, tmp_path):
+        path = tmp_path / "config.toml"
+        path.write_text('[old]\nhost = "old"\n')
+        path.chmod(0o644)
+
+        write_config({"new": {"host": "new"}}, path)
+
+        assert path.stat().st_mode & 0o777 == 0o600
+        assert "[new]" in path.read_text()
 
 
 class TestGetConfigPath:

--- a/mosaico-sdk-py/src/testing/unit/cli/test_doctor.py
+++ b/mosaico-sdk-py/src/testing/unit/cli/test_doctor.py
@@ -1,0 +1,83 @@
+import json
+import os
+
+import pytest
+from typer.testing import CliRunner
+
+from mosaicolabs_cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def config_file(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setenv("MOSAICO_CONFIG_PATH", str(config_path))
+    return config_path
+
+
+def _add_profile(config_file):
+    result = runner.invoke(
+        app,
+        [
+            "profile",
+            "add",
+            "dev",
+            "--no-interactive",
+            "--host",
+            "localhost",
+        ],
+    )
+    assert result.exit_code == 0
+    assert config_file.exists()
+
+
+class TestDoctor:
+    def test_json_output_is_redacted(self, config_file):
+        result = runner.invoke(
+            app,
+            [
+                "profile",
+                "add",
+                "dev",
+                "--no-interactive",
+                "--host",
+                "localhost",
+                "--api-key",
+                "very-secret",
+            ],
+        )
+        assert result.exit_code == 0
+
+        result = runner.invoke(app, ["doctor", "--no-network", "--output", "json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["schema_version"] == 1
+        assert payload["profile"]["api_key_configured"] is True
+        assert "very-secret" not in result.output
+
+    def test_missing_profile_is_an_error(self, config_file):
+        result = runner.invoke(app, ["doctor", "--no-network", "--output", "json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["status"] == "error"
+        assert any(check["name"] == "profile" for check in payload["checks"])
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permissions only")
+    def test_profile_write_restricts_permissions(self, config_file):
+        _add_profile(config_file)
+        assert config_file.stat().st_mode & 0o777 == 0o600
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permissions only")
+    def test_insecure_permissions_are_reported(self, config_file):
+        _add_profile(config_file)
+        config_file.chmod(0o644)
+
+        result = runner.invoke(app, ["doctor", "--no-network", "--output", "json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["status"] == "warning"
+        assert any(
+            check["name"] == "config_permissions" and check["status"] == "warning"
+            for check in payload["checks"]
+        )

--- a/mosaico-sdk-py/src/testing/unit/cli/test_extension.py
+++ b/mosaico-sdk-py/src/testing/unit/cli/test_extension.py
@@ -1,3 +1,4 @@
+import json
 import stat
 from pathlib import Path
 
@@ -92,6 +93,14 @@ class TestExtensionLsCommand:
         result = runner.invoke(app, ["extension", "ls"])
         assert result.exit_code == 0
         assert "No external extensions" in result.output
+
+    def test_ls_no_extensions_json(self, fake_path, monkeypatch, tmp_path):
+        config = tmp_path / "cfg.toml"
+        config.write_text('[dev]\nhost = "localhost"\ndefault = true\n')
+        monkeypatch.setenv("MOSAICO_CONFIG_PATH", str(config))
+        result = runner.invoke(app, ["extension", "ls", "--output", "json"])
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {"schema_version": 1, "extensions": []}
 
     def test_ls_with_extensions(self, fake_path, monkeypatch, tmp_path):
         config = tmp_path / "cfg.toml"

--- a/mosaico-sdk-py/src/testing/unit/cli/test_main.py
+++ b/mosaico-sdk-py/src/testing/unit/cli/test_main.py
@@ -19,6 +19,7 @@ class TestAppEntrypoint:
         assert "profile" in result.output
         assert "sequence" in result.output
         assert "topic" in result.output
+        assert "doctor" in result.output
         assert "extension" in result.output
 
     def test_unknown_command(self, monkeypatch, tmp_path):

--- a/mosaico-sdk-py/src/testing/unit/cli/test_profile_command.py
+++ b/mosaico-sdk-py/src/testing/unit/cli/test_profile_command.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from typer.testing import CliRunner
 
@@ -189,6 +191,11 @@ class TestProfileList:
         assert result.exit_code == 0
         assert "No profiles" in result.output
 
+    def test_list_empty_json(self, config_file):
+        result = runner.invoke(app, ["profile", "ls", "--output", "json"])
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {"schema_version": 1, "profiles": []}
+
     def test_list_with_profiles(self, config_file):
         runner.invoke(
             app,
@@ -204,6 +211,27 @@ class TestProfileList:
         result = runner.invoke(app, ["profile", "ls"])
         assert result.exit_code == 0
         assert "myprofile" in result.output
+
+    def test_list_json_is_machine_readable_and_redacted(self, config_file):
+        runner.invoke(
+            app,
+            [
+                "profile",
+                "add",
+                "machine",
+                "--no-interactive",
+                "--host",
+                "example.com",
+                "--api-key",
+                "secret-value",
+            ],
+        )
+        result = runner.invoke(app, ["profile", "ls", "--output", "json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["schema_version"] == 1
+        assert payload["profiles"][0]["api_key_configured"] is True
+        assert "secret-value" not in result.output
 
 
 class TestProfileDefault:


### PR DESCRIPTION
Implements most of the CLI improvements outlined in #699:

- Improve how configuration is handled and updated (make profile changes atomic at FS level)
- Add a mosaico doctor command to diagnose and troubleshoot connetion and configuration issues (for humans and agents alike)
- Add guidance for agents: global AGENTS.md + markdown files specific for the CLI, eventually we'll cover the whole repo with appropriate instructions