### PR TITLE
feat(py): rework ROS bridge config, metadata handling, dry-run, and type registry scoping

### DIFF
--- a/mosaico-sdk-py/src/mosaicolabs/examples/ros_injection/reconstruct_rosbags.py
+++ b/mosaico-sdk-py/src/mosaicolabs/examples/ros_injection/reconstruct_rosbags.py
@@ -45,6 +45,15 @@ def main():
             # start_timestamp_ns=,
             # end_timestamp_ns=,
             overwrite=True,
+            custom_msgs=[
+                (
+                    "isaac_ros_nova_interfaces/msg/EncoderTicks",
+                    Path(
+                        "/Users/fdicorato/workspace/Projects/mosaicolabs/assets/nvidia/messages/isaac_ros_nova_interfaces/"
+                    ),
+                    ROS_DISTRO,
+                )
+            ],
         )
 
         # --- Execution ---

--- a/mosaico-sdk-py/src/mosaicolabs/examples/ros_injection/reconstruct_rosbags.py
+++ b/mosaico-sdk-py/src/mosaicolabs/examples/ros_injection/reconstruct_rosbags.py
@@ -45,15 +45,6 @@ def main():
             # start_timestamp_ns=,
             # end_timestamp_ns=,
             overwrite=True,
-            custom_msgs=[
-                (
-                    "isaac_ros_nova_interfaces/msg/EncoderTicks",
-                    Path(
-                        "/Users/fdicorato/workspace/Projects/mosaicolabs/assets/nvidia/messages/isaac_ros_nova_interfaces/"
-                    ),
-                    ROS_DISTRO,
-                )
-            ],
         )
 
         # --- Execution ---

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/base_session_writer.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/base_session_writer.py
@@ -98,6 +98,8 @@ class _BaseSessionWriter(ABC):
         """Tag for inspecting if the writer is used in a 'with' context"""
         self._logger: Logger = logger
         """The logger for the writer"""
+        self._last_err: Optional[str] = None
+        """The last error message, if any, or None if no error has occurred."""
 
     @abstractmethod
     def _on_context_enter(self):
@@ -216,6 +218,7 @@ class _BaseSessionWriter(ABC):
 
             # Last thing to do: DO NOT SET BEFORE!
             self._status = SessionStatus.Error
+            self._last_err = str(out_exc)
 
             if exc_type is None and out_exc is not None:
                 self._logger.error(
@@ -323,6 +326,7 @@ class _BaseSessionWriter(ABC):
             except Exception as e:
                 # _do_action raised: re-raise
                 self._status = SessionStatus.Error  # Sets status to Error
+                self._last_err = str(e)
                 raise _make_exception(
                     f"Error sending 'finalize' action for session {self._locator}, sequence '{self._name}'. Server state may be inconsistent.",
                     e,
@@ -370,8 +374,10 @@ class _BaseSessionWriter(ABC):
                 self._logger.info(
                     f"Session {self._locator}, sequence '{self._name}' aborted successfully."
                 )
-                self._status = SessionStatus.Error
+                self._status = SessionStatus.Null  # Reset status after deletion
             except Exception as e:
+                self._status = SessionStatus.Error
+                self._last_err = str(e)
                 raise _make_exception(
                     f"Error sending 'abort' for session {self._locator}, sequence '{self._name}'.",
                     e,

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/sequence_writer.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/sequence_writer.py
@@ -192,8 +192,10 @@ class SequenceWriter(_BaseSessionWriter):
                     expected_type=None,
                 )
                 self._logger.info(f"Sequence '{self._name}' deleted successfully.")
-                self._status = SequenceStatus.Error
+                self._status = SequenceStatus.Null  # Reset status after deletion
             except Exception as e:
+                self._status = SequenceStatus.Error
+                self._last_err = str(e)
                 raise _make_exception(
                     f"Error sending 'delete' for sequence '{self._name}'.",
                     e,

--- a/mosaico-sdk-py/src/mosaicolabs/handlers/topic_writer.py
+++ b/mosaico-sdk-py/src/mosaicolabs/handlers/topic_writer.py
@@ -110,6 +110,7 @@ class TopicWriter:
         self._status: TopicWriterStatus = TopicWriterStatus.Active
         """The status of the writer"""
         self._last_err: Optional[str] = None
+        """The last error message, if any, or None if no error has occurred."""
 
     @classmethod
     def _create(

--- a/mosaico-sdk-py/src/mosaicolabs/protocols/ros2msg.py
+++ b/mosaico-sdk-py/src/mosaicolabs/protocols/ros2msg.py
@@ -56,7 +56,7 @@ def _typesdict_to_schema(typesdict: Typesdict, msgtype: str) -> pa.StructType:
     """
     # Extract msgtype from Typesdict since we need to create the pyarrow struct of that particular part
     _, fields_def = typesdict[msgtype]
-    pyarrow_fields: list[pa.field] = []
+    pyarrow_fields: list[pa.Field] = []
 
     for field_name, field_desc in fields_def:
         # field_def example for simple types:   ("x"               , (Nodetype.BASE    , ("float64", 0)                 ))

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/__init__.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/__init__.py
@@ -1,7 +1,10 @@
 # This will register the adapters in the factory
 # This will register the data ontology in the mosaico Data Ontology
 from . import adapters as adapters
-from .adapter_base import ROSAdapterBase as ROSAdapterBase
+from .adapter_base import (
+    ROSAdapterBase as ROSAdapterBase,
+    RosSchemaMetadata as RosSchemaMetadata,
+)
 from .data_ontology import (
     BatteryState as BatteryState,
     FrameTransform as FrameTransform,
@@ -13,7 +16,6 @@ from .injector import (
     ROSInjectionConfig as ROSInjectionConfig,
 )
 from .loader import (
-    LoaderErrorPolicy as LoaderErrorPolicy,
     MosaicoLoader as MosaicoLoader,
     ROSLoader as ROSLoader,
 )

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapter_base.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapter_base.py
@@ -108,7 +108,7 @@ class RosSchemaMetadata:
     @classmethod
     def from_dict(cls, metadata: Optional[dict]) -> "RosSchemaMetadata":
         """
-        Rehydrates a `RosSchemaMetadata` from a plain metadata dict, e.g. the return value of
+        Creates a `RosSchemaMetadata` from a plain metadata dict, e.g. the return value of
         `ROSAdapterBase.schema_metadata()`. Any keys outside the `_ros_` namespace are ignored.
 
         Args:

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapter_base.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapter_base.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Generic, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Generic,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from rosbags.typesys.store import Typestore
 
@@ -14,6 +24,74 @@ from mosaicolabs.models.core import Message, Serializable
 from .ros_message import ROSMessage
 
 T = TypeVar("T", bound=Serializable)
+
+
+class RosSchemaMetadata:
+    """
+    Encapsulates Mosaico's reserved ``_ros_`` topic-metadata namespace in a single place.
+
+    Every topic ingested by the ROS bridge carries ROS-specific bookkeeping (original
+    ``msgtype``, raw ``msgdef``, extracted ``enums``) plus bridge-internal fields (e.g. the
+    source bag file) under one reserved key, so that:
+
+    * The literal string ``"_ros_"`` exists in exactly one place (:attr:`KEY`), instead of
+      being duplicated across adapters, loaders, and the injector.
+    * Callers build up this namespace incrementally via :meth:`update` without ever touching
+      the wrapping dict shape by hand, which is what previously caused bugs (e.g. accidentally
+      overwriting the whole ``_ros_`` block instead of merging into it).
+
+    Example:
+        ```python
+        meta = RosSchemaMetadata(msgtype="sensor_msgs/msg/Imu").update(source_file="a.mcap")
+        topic_metadata = meta.merge_into(user_supplied_metadata)
+        # topic_metadata == {..., "_ros_": {"msgtype": "sensor_msgs/msg/Imu", "source_file": "a.mcap"}}
+        ```
+    """
+
+    KEY: ClassVar[str] = "_ros_"
+    """The reserved metadata key. Adapters/loaders/the injector should reference this
+    constant rather than the literal string, so the namespace can be renamed in one place."""
+
+    def __init__(self, **fields: Any):
+        self.fields: dict = dict(fields)
+
+    def update(self, **fields: Any) -> "RosSchemaMetadata":
+        """Merges additional fields into this block, in place. Returns `self` for chaining."""
+        self.fields.update(fields)
+        return self
+
+    def to_dict(self) -> dict:
+        """Wraps the current fields under the reserved key, e.g. `{"_ros_": {...}}`."""
+        return {self.KEY: dict(self.fields)}
+
+    def merge_into(self, metadata: dict) -> dict:
+        """
+        Merges this block into an existing metadata dict's `_ros_` namespace, creating it
+        if absent. Mutates and returns `metadata`.
+        """
+        metadata.setdefault(self.KEY, {}).update(self.fields)
+        return metadata
+
+    @classmethod
+    def extract(cls, metadata: Optional[dict]) -> dict:
+        """Reads the `_ros_` block out of a metadata dict (e.g. a topic's `user_metadata`),
+        or `{}` if absent."""
+        return dict((metadata or {}).get(cls.KEY) or {})
+
+    @classmethod
+    def from_dict(cls, metadata: Optional[dict]) -> "RosSchemaMetadata":
+        """
+        Rehydrates a `RosSchemaMetadata` from a plain metadata dict, e.g. the return value of
+        `ROSAdapterBase.schema_metadata()`. Any keys outside the `_ros_` namespace are ignored.
+
+        Args:
+            metadata (Optional[dict]): A metadata dict, typically `{"_ros_": {...}}` or `None`.
+
+        Returns:
+            RosSchemaMetadata: A new instance seeded with the extracted `_ros_` fields
+                (empty if `metadata` is `None` or carries no `_ros_` block).
+        """
+        return cls(**cls.extract(metadata))
 
 
 class ROSAdapterBase(ABC, Generic[T]):
@@ -80,7 +158,7 @@ class ROSAdapterBase(ABC, Generic[T]):
             Exception: If translation fails due to missing fields, type mismatches, or other errors.
         """
         if ros_msg.data_field is None:
-            raise Exception(f"'data' attribute is None for topic {ros_msg.topic}")
+            raise Exception(f"'data' payload is `None` for topic {ros_msg.topic}.")
 
         try:
             return Message(
@@ -255,7 +333,7 @@ class ROSAdapterBase(ABC, Generic[T]):
         if not cls.is_rosmsg_type_valid(ros_msg_type):
             return None
 
-        out_dict = {}
+        ros_meta = RosSchemaMetadata(msgtype=ros_msg_type)
 
         # Check that ros_msg_type exists in typestore
         msg_def = typestore.fielddefs.get(ros_msg_type)
@@ -263,16 +341,14 @@ class ROSAdapterBase(ABC, Generic[T]):
         # Extract ENUM associated to ros_msg_type and adding it to the out dict (if available in typestore)
         if msg_def:
             enum_list, _ = msg_def
-            out_dict["enums"] = {name: val for name, _, val in enum_list}
-            out_dict["msgdef"], _ = typestore.generate_msgdef(
-                ros_msg_type, ros_version=ros_version
+            msgdef, _ = typestore.generate_msgdef(ros_msg_type, ros_version=ros_version)
+            ros_meta.update(
+                enums={name: val for name, _, val in enum_list},
+                msgdef=msgdef,
+                msgtype=ros_msg_type,
             )
 
-        out_dict["msgtype"] = ros_msg_type
-
-        ms_metadata = {"_ros_": out_dict}
-
-        return ms_metadata
+        return ros_meta.to_dict()
 
     @classmethod
     def ontology_data_type(cls) -> Type[T]:

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapter_base.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapter_base.py
@@ -56,26 +56,53 @@ class RosSchemaMetadata:
         self.fields: dict = dict(fields)
 
     def update(self, **fields: Any) -> "RosSchemaMetadata":
-        """Merges additional fields into this block, in place. Returns `self` for chaining."""
+        """
+        Merges additional fields into this block, in place. Returns `self` for chaining.
+
+        Args:
+            **fields (Any): Additional fields to merge.
+
+        Returns:
+            RosSchemaMetadata: The updated metadata instance.
+        """
         self.fields.update(fields)
         return self
 
     def to_dict(self) -> dict:
-        """Wraps the current fields under the reserved key, e.g. `{"_ros_": {...}}`."""
+        """
+        Wraps the current fields under the reserved key, e.g. `{"_ros_": {...}}`.
+
+        Returns:
+            dict: A dictionary containing the `_ros_` block with the current fields.
+        """
         return {self.KEY: dict(self.fields)}
 
     def merge_into(self, metadata: dict) -> dict:
         """
         Merges this block into an existing metadata dict's `_ros_` namespace, creating it
         if absent. Mutates and returns `metadata`.
+
+        Args:
+            metadata (dict): The existing metadata dict to merge into.
+
+        Returns:
+            dict: The updated metadata dict with the `_ros_` block merged in.
         """
         metadata.setdefault(self.KEY, {}).update(self.fields)
         return metadata
 
     @classmethod
     def extract(cls, metadata: Optional[dict]) -> dict:
-        """Reads the `_ros_` block out of a metadata dict (e.g. a topic's `user_metadata`),
-        or `{}` if absent."""
+        """
+        Reads the `_ros_` block out of a metadata dict (e.g. a topic's `user_metadata`),
+        or `{}` if absent.
+
+        Args:
+            metadata (Optional[dict]): A metadata dict, typically `{"_ros_": {...}}` or `None`.
+
+        Returns:
+            dict: The extracted `_ros_` block, or an empty dict if not present.
+        """
         return dict((metadata or {}).get(cls.KEY) or {})
 
     @classmethod
@@ -345,7 +372,6 @@ class ROSAdapterBase(ABC, Generic[T]):
             ros_meta.update(
                 enums={name: val for name, _, val in enum_list},
                 msgdef=msgdef,
-                msgtype=ros_msg_type,
             )
 
         return ros_meta.to_dict()

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/unmodeled.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/adapters/unmodeled.py
@@ -60,7 +60,11 @@ def pack_unmodeled(
         elif node_type == Nodetype.NAME and isinstance(content, str):
             msgtype = content
             RosNestedObjectType = typestore.types[msgtype]
-
+            if field_name not in raw_data:
+                raise KeyError(
+                    f"Expected field `{field_name}` in raw_data but it was not found. Schema and raw_data must match exactly."
+                    f" `raw_data` keys: {list(raw_data.keys())}; `msg_def` keys: {[f[0] for f in msg_def]}."
+                )
             raw_data[field_name] = RosNestedObjectType(
                 **pack_unmodeled(
                     raw_data[field_name],
@@ -68,7 +72,6 @@ def pack_unmodeled(
                     typestore,
                 )
             )
-
         elif node_type in (Nodetype.SEQUENCE, Nodetype.ARRAY):
             # Check that raw_data[field_name] is a list
             if not isinstance(raw_data[field_name], list):
@@ -114,12 +117,12 @@ def pack_unmodeled(
 
             else:
                 raise TypeError(
-                    f"Parameter {field_name} of type Sequence/Array containes unexpected inner NodeType {item_node_type}"
+                    f"Parameter `{field_name}` of type Sequence/Array containes unexpected inner NodeType {item_node_type}"
                 )
 
         else:
             raise TypeError(
-                f"Unsupported field definition for '{field_name}': "
+                f"Unsupported field definition for `{field_name}`: "
                 f"node type {node_type!r} with content {content!r}"
             )
 
@@ -207,9 +210,22 @@ class UnmodeledAdapter(ROSAdapterBase[T], Generic[T]):
         # Filling the data
         rosbag_msgdef = typestore.get_msgdef(resolved_rosmsg_type)
 
-        return RosUnmodeled(
-            **pack_unmodeled(unmodeled_data.raw_data, rosbag_msgdef.fields, typestore)
-        )
+        try:
+            return RosUnmodeled(
+                **pack_unmodeled(
+                    unmodeled_data.raw_data, rosbag_msgdef.fields, typestore
+                )
+            )
+        except KeyError as ke:
+            raise KeyError(
+                "Error occurred while creating ROS message. It is probably due to a schema mismatch or a partially adapted message type."
+                f" Please check if the adapter for the msgtype `{resolved_rosmsg_type}` does implement the `to_ros()` method."
+                f" Inner err: {ke}"
+            ) from ke
+        except Exception as e:
+            raise RuntimeError(
+                f"Unexpected error occurred while creating ROS message: {e}"
+            ) from e
 
     @classmethod
     def schema_metadata(

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/helpers.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/helpers.py
@@ -15,6 +15,8 @@ from rosbags.interfaces import TopicInfo
 from mosaicolabs import SequenceHandler, TopicHandler
 from mosaicolabs.logging_config import get_logger
 
+from .adapter_base import RosSchemaMetadata
+
 # Set the hierarchical logger
 logger = get_logger(__name__)
 
@@ -68,7 +70,7 @@ def _extract_ros_metadata(t_handler: TopicHandler) -> Dict[str, Any]:
     Raises:
         TypeError: When the topic's ``_ros_`` metadata carries malformed metadata.
     """
-    ros_metadata = t_handler.user_metadata.get("_ros_")
+    ros_metadata = RosSchemaMetadata.extract(t_handler.user_metadata)
 
     if not ros_metadata:
         return {}

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
@@ -30,7 +30,8 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple, Type, Union
 
 from rich.live import Live
-from rosbags.typesys import Stores
+from rosbags.typesys import Stores, get_typestore
+from rosbags.typesys.store import Typestore
 
 from mosaicolabs.comm.mosaico_client import MosaicoClient
 from mosaicolabs.enum import (
@@ -313,13 +314,13 @@ class RosbagInjector:
         Args:
             config (ROSInjectionConfig): The fully resolved configuration object.
         """
-        self.cfg = config
+        self._cfg = config
         # Create the single "source of truth" for the terminal
         from rich.console import Console
 
-        self.console = Console(stderr=True)
+        self._console = Console(stderr=True)
         setup_sdk_logging(
-            level=self.cfg.log_level.upper(), pretty=True, console=self.console
+            level=self._cfg.log_level.upper(), pretty=True, console=self._console
         )
 
         # Set of topics to skip (e.g., no adapter found), allowing O(1) fast-fail in the loop.
@@ -327,20 +328,23 @@ class RosbagInjector:
         self._malformed_message_counts: Dict[str, int] = (
             dict()
         )  # Tracks malformed message counts per topic
+        self._typestore: Typestore = get_typestore(self._cfg.ros_distro or Stores.EMPTY)
         self._loader: Optional[ROSLoader] = None
 
-    def _register_custom_types(self):
-        """
-        Loads custom ROS message definitions into the global `ROSTypeRegistry`.
+        # Register custom ROS messages to the local typestore
+        self._typestore_custom_msgtypes()
 
-        This enables the loader to correctly deserialize proprietary message types
-        found within the bag file.
+    def _typestore_custom_msgtypes(self):
         """
-        if not self.cfg.custom_msgs:
+        Registers any custom ROS message definitions provided in ``cfg.custom_msgs``,
+        and then registers the custom message definitions to the typestore.
+        """
+        if not self._cfg.custom_msgs:
             return
 
+        # Register Global Types (Registry Pattern)
         logger.info("Registering custom message definitions...")
-        for package, path, store in self.cfg.custom_msgs:
+        for package, path, store in self._cfg.custom_msgs:
             try:
                 ROSTypeRegistry.register_directory(
                     package_name=package, dir_path=path, store=store
@@ -348,6 +352,26 @@ class RosbagInjector:
                 logger.debug(f"Registered package '{package}' from '{path}'")
             except Exception as e:
                 logger.error(f"Failed to register custom msgs at '{path}': '{e}'")
+
+        self._register_definitions()
+
+    def _register_definitions(self):
+        """Safe registration wrapper."""
+        from rosbags.typesys import get_types_from_msg
+
+        custom_types = ROSTypeRegistry.get_types(self._cfg.ros_distro)
+        if not custom_types:
+            return
+
+        logger.info(
+            f"Registering {list(custom_types.keys())} definitions to typestore..."
+        )
+        for msg_type, msg_def in custom_types.items():
+            try:
+                add_types = get_types_from_msg(msg_def, msg_type)
+                self._typestore.register(add_types)
+            except Exception as e:
+                logger.warning(f"Failed to register type '{msg_type}': '{e}'")
 
     def _get_default_adapter(self, msg_type: str) -> Optional[Type[ROSAdapterBase]]:
         """
@@ -365,10 +389,10 @@ class RosbagInjector:
     def _open_or_get_loader(self) -> ROSLoader:
         if self._loader is None:
             self._loader = ROSLoader(
-                file_path=self.cfg.file_path,
-                topics=self.cfg.topics,
-                typestore_name=self.cfg.ros_distro or Stores.EMPTY,
-                serialization_formats=self.cfg.serialization_formats,
+                file_path=self._cfg.file_path,
+                topics=self._cfg.topics,
+                typestore=self._typestore,
+                serialization_formats=self._cfg.serialization_formats,
             )
 
         return self._loader
@@ -384,11 +408,11 @@ class RosbagInjector:
         """
         from rich.table import Table
 
-        logger.info(f"[DRY RUN] Opening bag: '{self.cfg.file_path}'")
+        logger.info(f"[DRY RUN] Opening bag: '{self._cfg.file_path}'")
 
         with self._open_or_get_loader() as ros_loader:
             table = Table(
-                title=f"Dry Run: '{self.cfg.file_path.name}' -> sequence '{self.cfg.sequence_name}'"
+                title=f"Dry Run: '{self._cfg.file_path.name}' -> sequence '{self._cfg.sequence_name}'"
             )
             table.add_column("Topic")
             table.add_column("Status")
@@ -396,7 +420,7 @@ class RosbagInjector:
             table.add_column("Messages", justify="right")
 
             for topic in ros_loader.topics:
-                adapter = (self.cfg.adapter_overrides or {}).get(
+                adapter = (self._cfg.adapter_overrides or {}).get(
                     topic
                 ) or ros_loader.resolve_adapter(topic)
                 table.add_row(
@@ -414,17 +438,17 @@ class RosbagInjector:
                     "-",
                 )
 
-            self.console.print(table)
+            self._console.print(table)
 
             accepted = set(ros_loader.topics)
-            unused_topic_metadata = set(self.cfg.topic_metadata or {}) - accepted
+            unused_topic_metadata = set(self._cfg.topic_metadata or {}) - accepted
             if unused_topic_metadata:
                 logger.warning(
                     f"'topic_metadata' entries for topics that would NOT be ingested "
                     f"(filtered out or unresolved): {sorted(unused_topic_metadata)}"
                 )
 
-            self.console.print(
+            self._console.print(
                 f"[bold]{len(accepted)}[/bold] topic(s) would be ingested, "
                 f"[bold]{len(ros_loader.rejected_topics)}[/bold] rejected. "
                 "No connection to the Mosaico server was made."
@@ -448,26 +472,23 @@ class RosbagInjector:
                 `KeyboardInterrupt` is the only exception handled silently, to allow a clean
                 shutdown on user interrupt.
         """
-        # 1. Prepare Registry
-        self._register_custom_types()
-
-        if self.cfg.dry_run:
+        if self._cfg.dry_run:
             self._dry_run_report()
             return
 
-        logger.info(f"Connecting to Mosaico at '{self.cfg.host}:{self.cfg.port}'...")
+        logger.info(f"Connecting to Mosaico at '{self._cfg.host}:{self._cfg.port}'...")
 
         try:
             # Context: Mosaico Client (Network Connection)
             with MosaicoClient.connect(
-                host=self.cfg.host,
-                port=self.cfg.port,
-                api_key=self.cfg.mosaico_api_key,
-                enable_tls=self.cfg.enable_tls,
-                tls_cert_path=self.cfg.tls_cert_path,
+                host=self._cfg.host,
+                port=self._cfg.port,
+                api_key=self._cfg.mosaico_api_key,
+                enable_tls=self._cfg.enable_tls,
+                tls_cert_path=self._cfg.tls_cert_path,
             ) as mclient:
                 # Context: ROS Loader (File Access)
-                logger.info(f"Opening bag: '{self.cfg.file_path}'")
+                logger.info(f"Opening bag: '{self._cfg.file_path}'")
 
                 with self._open_or_get_loader() as ros_loader:
                     # Setup Progress UI
@@ -485,25 +506,25 @@ class RosbagInjector:
                     # typical single-operator workflow; avoid running concurrent injections against
                     # the same sequence name until the server offers an atomic create-or-update.
                     if (
-                        mclient.sequence_exists(self.cfg.sequence_name)
-                        and self.cfg.update_if_exists
+                        mclient.sequence_exists(self._cfg.sequence_name)
+                        and self._cfg.update_if_exists
                     ):
                         logger.info(
-                            f"Sequence '{self.cfg.sequence_name}' already exists. Updating instead of creating a new one."
+                            f"Sequence '{self._cfg.sequence_name}' already exists. Updating instead of creating a new one."
                         )
                         # Context: Sequence Updadeter (Server Transaction)
                         seq_writer = mclient.sequence_update(
-                            sequence_name=self.cfg.sequence_name,
-                            on_error=self.cfg.on_error,
+                            sequence_name=self._cfg.sequence_name,
+                            on_error=self._cfg.on_error,
                         )
                     else:
                         # NOTE: this will raise an error if the sequence already
                         # exists and `update_sequence` is False
                         # Context: Sequence Writer (Server Transaction)
                         seq_writer = mclient.sequence_create(
-                            sequence_name=self.cfg.sequence_name,
-                            metadata=self.cfg.metadata,
-                            on_error=self.cfg.on_error,
+                            sequence_name=self._cfg.sequence_name,
+                            metadata=self._cfg.metadata,
+                            on_error=self._cfg.on_error,
                         )
 
                     with seq_writer:
@@ -512,29 +533,29 @@ class RosbagInjector:
                         # Main Processing Loop
                         # By passing self.console, any 'logger.info' calls inside
                         # this loop will print cleanly ABOVE the progress bars.
-                        with Live(ui.progress, console=self.console):
+                        with Live(ui.progress, console=self._console):
                             for ros_msg, exc in ros_loader:
                                 self._process_message(ros_msg, exc, seq_writer, ui)
 
                 if seq_writer.session_status == SessionStatus.Error:
                     raise RuntimeError(
                         f"`SequenceWriter` returned a `SequenceStatus.Error` status for "
-                        f"sequence '{self.cfg.sequence_name}'. Upload might have failed!"
+                        f"sequence '{self._cfg.sequence_name}'. Upload might have failed!"
                     )
 
                 logger.info("Sequence upload completed successfully.")
 
                 # Retrieve the sequence info
-                seq_handler = mclient.sequence_handler(self.cfg.sequence_name)
+                seq_handler = mclient.sequence_handler(self._cfg.sequence_name)
                 if seq_handler is None:
                     raise RuntimeError(
-                        f"Oops, Something bad happened: Sequence '{self.cfg.sequence_name}' "
+                        f"Oops, Something bad happened: Sequence '{self._cfg.sequence_name}' "
                         "not found on remote server. This should not happen..."
                     )
 
                 # --- Final Statistics Report ---
                 self._print_summary(
-                    original_size=self.cfg.file_path.stat().st_size,
+                    original_size=self._cfg.file_path.stat().st_size,
                     remote_size=seq_handler.total_size_bytes,
                 )
 
@@ -565,7 +586,7 @@ class RosbagInjector:
             ):
                 table.add_row(topic, str(count))
 
-            self.console.print(table)
+            self._console.print(table)
 
         if remote_size == 0:
             logger.warning("No data was written; cannot calculate compression ratio.")
@@ -585,7 +606,7 @@ class RosbagInjector:
             f"Space Saved:    [bold green]{savings:.1f}%[/bold green]"
         )
 
-        self.console.print(
+        self._console.print(
             Panel(
                 summary_text,
                 title="[bold]Injection Summary[/bold]",
@@ -597,10 +618,10 @@ class RosbagInjector:
         )
 
     def _get_topic_on_error(self, topic: str) -> TopicLevelErrorPolicy:
-        if isinstance(self.cfg.topics_on_error, dict):
-            return self.cfg.topics_on_error.get(topic, _DEFAULT_TOPIC_ON_ERROR)
-        elif isinstance(self.cfg.topics_on_error, TopicLevelErrorPolicy):
-            return self.cfg.topics_on_error
+        if isinstance(self._cfg.topics_on_error, dict):
+            return self._cfg.topics_on_error.get(topic, _DEFAULT_TOPIC_ON_ERROR)
+        elif isinstance(self._cfg.topics_on_error, TopicLevelErrorPolicy):
+            return self._cfg.topics_on_error
 
         return _DEFAULT_TOPIC_ON_ERROR
 
@@ -655,7 +676,7 @@ class RosbagInjector:
             return
 
         # --- Adapter Resolution ---
-        adapter = (self.cfg.adapter_overrides or {}).get(
+        adapter = (self._cfg.adapter_overrides or {}).get(
             ros_msg.topic
         ) or self._loader.resolve_adapter(ros_msg.topic)
 
@@ -673,7 +694,7 @@ class RosbagInjector:
         # Should theoretically not be None if exists returned True
         if twriter is None:
             # --- Schema metadata Resolution ---
-            ros_version = 1 if self.cfg.ros_distro is Stores.ROS1_NOETIC else 2
+            ros_version = 1 if self._cfg.ros_distro is Stores.ROS1_NOETIC else 2
             ros_meta = RosSchemaMetadata.from_dict(
                 adapter.schema_metadata(
                     self._loader._typestore, ros_msg.msg_type, ros_version
@@ -684,12 +705,12 @@ class RosbagInjector:
             # later updates to the same sequence (e.g. multi-part recordings or merged
             # reprocessing results), since sequence metadata cannot be changed once the
             # sequence has been ingested.
-            ros_meta.update(source_file=self.cfg.file_path.name)
+            ros_meta.update(source_file=self._cfg.file_path.name)
 
             # Start from the user-supplied per-topic metadata, then layer the bridge-computed
             # `_ros_` block on top: `_ros_` is reserved and always wins on conflict, every
             # other key is fully user-owned.
-            metadata = dict((self.cfg.topic_metadata or {}).get(ros_msg.topic, {}))
+            metadata = dict((self._cfg.topic_metadata or {}).get(ros_msg.topic, {}))
             metadata.update(ros_meta.to_dict())
 
             # Register new topic on server

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
@@ -23,8 +23,9 @@ Typical usage as a library:
 
 import argparse
 import json
+import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple, Type, Union
 
@@ -33,16 +34,17 @@ from rosbags.typesys import Stores
 
 from mosaicolabs.comm.mosaico_client import MosaicoClient
 from mosaicolabs.enum import (
-    SequenceStatus,
     SerializationFormat,
     SessionLevelErrorPolicy,
     TopicLevelErrorPolicy,
     TopicWriterStatus,
 )
+from mosaicolabs.enum.session_status import SessionStatus
 from mosaicolabs.handlers.base_session_writer import AnySessionWriter
 from mosaicolabs.logging_config import get_logger, setup_sdk_logging
 
-from .loader import LoaderErrorPolicy, ProgressManager, ROSLoader
+from .adapter_base import RosSchemaMetadata
+from .loader import ProgressManager, ROSLoader
 from .registry import ROSTypeRegistry
 from .ros_bridge import ROSAdapterBase, ROSBridge
 from .ros_message import ROSMessage
@@ -127,9 +129,53 @@ class ROSInjectionConfig:
     The name of the sequence to create.
     """
 
-    metadata: dict
+    metadata: dict = field(default_factory=dict)
     """
     Metadata to associate with the sequence.
+    """
+
+    topic_metadata: Optional[Dict[str, dict]] = None
+    """
+    A mapping of exact topic name to metadata to associate with that topic, merged into the
+    metadata computed from the message schema and the source bag file (see `_process_message`).
+    User-supplied values take precedence over the auto-computed ones on key conflicts.
+
+    Only applied to topics that end up being ingested; entries for topics excluded by `topics`
+    filtering are simply unused. Default: None.
+    """
+
+    update_if_exists: bool = False
+    """
+    Controls what happens when a sequence named `sequence_name` already exists on the server.
+
+    If `True`, the injector appends this bag's topics to the existing sequence instead of
+    creating a new one. Use this both when a ROS recording is split across multiple bag files
+    that should all land in the same sequence, and when re-ingesting a derived/reprocessed bag
+    (e.g. offline estimation results) whose topics should be merged into a sequence that was
+    already ingested from the original recording.
+
+    If `False` (default), the injector creates a new sequence and raises an error if a sequence
+    with the same name already exists.
+
+    Each topic's metadata records the source bag file it was ingested from (see
+    `schema_metadata` handling in `_process_message`), so which bag file contributed which
+    topics remains traceable even after multiple updates to the same sequence.
+
+    Caveat: existence is checked and then acted upon in two separate steps (not atomically),
+    so running concurrent injections against the same `sequence_name` can race. Avoid
+    concurrent ingestion into the same sequence name.
+
+    Caveat: resuming after a crash is NOT idempotent. `session_writer.get_topic_writer()`
+    (see `_process_message`) only consults an in-memory cache scoped to the current process's
+    session (`_BaseSessionWriter._topic_writers`); it has no knowledge of topics created by a
+    previous, crashed run. So re-running the same bag with `update_if_exists=True` after a
+    crash will call `topic_create` again for topics that were already fully ingested before
+    the crash, which the server is expected to reject as duplicates (behavior not covered by
+    SDK-level tests as of this writing). There is currently no dedup against the topics already
+    present in the target sequence (available server-side via `MosaicoClient.sequence_handler(
+    sequence_name).topics`, the same mechanism `MosaicoLoader` already uses) before calling
+    `topic_create`. A safe resume would need to check that list first and skip topics already
+    present, rather than only checking the local per-process cache.
     """
 
     host: str = "localhost"
@@ -217,6 +263,13 @@ class ROSInjectionConfig:
     enable_tls: bool = False
     """Enable the TLS commmunication protocol. Defaults to False"""
 
+    dry_run: bool = False
+    """
+    If `True`, resolves and reports which topics would be ingested (and with which adapter),
+    which topics would be rejected (and why), and which `topic_metadata` entries would be
+    unused, without connecting to the Mosaico server or writing any data. Default: False.
+    """
+
 
 # --- Main Injector Class ---
 
@@ -270,7 +323,9 @@ class RosbagInjector:
 
         # Set of topics to skip (e.g., no adapter found), allowing O(1) fast-fail in the loop.
         self._ignored_topics: Set[str] = set()
-
+        self._malformed_message_counts: Dict[str, int] = (
+            dict()
+        )  # Tracks malformed message counts per topic
         self._loader: Optional[ROSLoader] = None
 
     def _register_custom_types(self):
@@ -312,11 +367,67 @@ class RosbagInjector:
                 file_path=self.cfg.file_path,
                 topics=self.cfg.topics,
                 typestore_name=self.cfg.ros_distro or Stores.EMPTY,
-                error_policy=LoaderErrorPolicy.IGNORE,
                 serialization_formats=self.cfg.serialization_formats,
             )
 
         return self._loader
+
+    def _dry_run_report(self):
+        """
+        Resolves the bag's topics against the current configuration and prints a report
+        of what would be ingested, without connecting to the Mosaico server or writing data.
+
+        Reports, per topic: acceptance status, resolved adapter (or rejection reason), and
+        message count. Also flags any `topic_metadata` entry that doesn't match an accepted
+        topic (e.g. because it was excluded by `topics` filtering or misspelled).
+        """
+        from rich.table import Table
+
+        logger.info(f"[DRY RUN] Opening bag: '{self.cfg.file_path}'")
+
+        with self._open_or_get_loader() as ros_loader:
+            table = Table(
+                title=f"Dry Run: '{self.cfg.file_path.name}' -> sequence '{self.cfg.sequence_name}'"
+            )
+            table.add_column("Topic")
+            table.add_column("Status")
+            table.add_column("Adapter / Reason")
+            table.add_column("Messages", justify="right")
+
+            for topic in ros_loader.topics:
+                adapter = (self.cfg.adapter_overrides or {}).get(
+                    topic
+                ) or ros_loader.resolve_adapter(topic)
+                table.add_row(
+                    topic,
+                    "[bright_green]Accepted",
+                    adapter.__name__ if adapter else "?",
+                    str(ros_loader.msg_count(topic)),
+                )
+
+            for topic, status in ros_loader.rejected_topics:
+                table.add_row(
+                    topic,
+                    f"[{status.display_color()}]{status.value}",
+                    "-",
+                    "-",
+                )
+
+            self.console.print(table)
+
+            accepted = set(ros_loader.topics)
+            unused_topic_metadata = set(self.cfg.topic_metadata or {}) - accepted
+            if unused_topic_metadata:
+                logger.warning(
+                    f"'topic_metadata' entries for topics that would NOT be ingested "
+                    f"(filtered out or unresolved): {sorted(unused_topic_metadata)}"
+                )
+
+            self.console.print(
+                f"[bold]{len(accepted)}[/bold] topic(s) would be ingested, "
+                f"[bold]{len(ros_loader.rejected_topics)}[/bold] rejected. "
+                "No connection to the Mosaico server was made."
+            )
 
     def run(self):
         """
@@ -325,9 +436,23 @@ class RosbagInjector:
         This method establishes the necessary contexts (Network Client, File Loader, Server Writer)
         and executes the processing loop. It handles graceful shutdowns in case of
         user interrupts and provides a summary report upon completion.
+
+        If `self.cfg.dry_run` is `True`, delegates to `_dry_run_report()` and returns
+        without connecting to the server.
+
+        Raises:
+            Exception: Any fatal error encountered during connection, loading, or upload is
+                logged and then re-raised, so callers can detect failure (e.g. `try`/`except`
+                around `run()`, or a non-zero process exit code from the CLI entry point).
+                `KeyboardInterrupt` is the only exception handled silently, to allow a clean
+                shutdown on user interrupt.
         """
         # 1. Prepare Registry
         self._register_custom_types()
+
+        if self.cfg.dry_run:
+            self._dry_run_report()
+            return
 
         logger.info(f"Connecting to Mosaico at '{self.cfg.host}:{self.cfg.port}'...")
 
@@ -347,13 +472,39 @@ class RosbagInjector:
                     # Setup Progress UI
                     ui = ProgressManager(ros_loader)
                     ui.setup()
+                    # Handle sequence creation or update based on existence and user preference
+                    # NOTE: `update_if_exists` covers two scenarios: a ROS recording split across
+                    # multiple bags that should all land in the same sequence, and a derived/
+                    # reprocessed bag whose topics should be merged into an already-ingested
+                    # sequence. Should the sequence not exist yet, a new one is created regardless.
+                    # CAVEAT: `sequence_exists()` followed by `sequence_create()`/`sequence_update()`
+                    # is a check-then-act race: if two ingestions target the same `sequence_name`
+                    # concurrently, both could observe "does not exist" and both attempt to create
+                    # it, or one could update a sequence the other is still creating. Fine for the
+                    # typical single-operator workflow; avoid running concurrent injections against
+                    # the same sequence name until the server offers an atomic create-or-update.
+                    if (
+                        mclient.sequence_exists(self.cfg.sequence_name)
+                        and self.cfg.update_if_exists
+                    ):
+                        logger.info(
+                            f"Sequence '{self.cfg.sequence_name}' already exists. Updating instead of creating a new one."
+                        )
+                        # Context: Sequence Updadeter (Server Transaction)
+                        seq_writer = mclient.sequence_update(
+                            sequence_name=self.cfg.sequence_name,
+                            on_error=self.cfg.on_error,
+                        )
+                    else:
+                        # NOTE: this will raise an error if the sequence already
+                        # exists and `update_sequence` is False
+                        # Context: Sequence Writer (Server Transaction)
+                        seq_writer = mclient.sequence_create(
+                            sequence_name=self.cfg.sequence_name,
+                            metadata=self.cfg.metadata,
+                            on_error=self.cfg.on_error,
+                        )
 
-                    # Context: Sequence Writer (Server Transaction)
-                    seq_writer = mclient.sequence_create(
-                        sequence_name=self.cfg.sequence_name,
-                        metadata=self.cfg.metadata,
-                        on_error=self.cfg.on_error,
-                    )
                     with seq_writer:
                         logger.info("Starting upload...")
 
@@ -364,33 +515,34 @@ class RosbagInjector:
                             for ros_msg, exc in ros_loader:
                                 self._process_message(ros_msg, exc, seq_writer, ui)
 
-                if seq_writer.status == SequenceStatus.Error:
-                    logger.error(
-                        "`SequenceWriter` returned a `SequenceStatus.Error` status. Upload might have failed!"
+                if seq_writer.session_status == SessionStatus.Error:
+                    raise RuntimeError(
+                        f"`SequenceWriter` returned a `SequenceStatus.Error` status for "
+                        f"sequence '{self.cfg.sequence_name}'. Upload might have failed!"
                     )
-                    return
 
                 logger.info("Sequence upload completed successfully.")
 
                 # Retrieve the sequence info
                 seq_handler = mclient.sequence_handler(self.cfg.sequence_name)
-                if seq_handler is not None:
-                    # --- Final Statistics Report ---
-                    self._print_summary(
-                        original_size=self.cfg.file_path.stat().st_size,
-                        remote_size=seq_handler.total_size_bytes,
+                if seq_handler is None:
+                    raise RuntimeError(
+                        f"Oops, Something bad happened: Sequence '{self.cfg.sequence_name}' "
+                        "not found on remote server. This should not happen..."
                     )
-                else:
-                    logger.error(
-                        f"Oops, Something bad happened: Sequence '{self.cfg.sequence_name}' not found on remote server. This should not happen..."
-                    )
+
+                # --- Final Statistics Report ---
+                self._print_summary(
+                    original_size=self.cfg.file_path.stat().st_size,
+                    remote_size=seq_handler.total_size_bytes,
+                )
 
         except KeyboardInterrupt:
             logger.warning("Operation cancelled by user. Shutting down...")
             return
         except Exception as e:
-            logger.exception(f"Fatal error during injection: '{e}'")
-            return
+            logger.exception(f"Fatal error during ingestion: '{e}'")
+            raise
 
     def _print_summary(self, original_size: int, remote_size: int):
         """
@@ -399,6 +551,21 @@ class RosbagInjector:
         Outputs the original file size, the remote sequence size, the compression ratio,
         and the percentage of disk space saved.
         """
+        if self._malformed_message_counts:
+            from rich.table import Table
+
+            table = Table(
+                title="[bold yellow]Malformed Messages (Skipped)[/bold yellow]"
+            )
+            table.add_column("Topic")
+            table.add_column("Skipped Messages", justify="right")
+            for topic, count in sorted(
+                self._malformed_message_counts.items(), key=lambda kv: -kv[1]
+            ):
+                table.add_row(topic, str(count))
+
+            self.console.print(table)
+
         if remote_size == 0:
             logger.warning("No data was written; cannot calculate compression ratio.")
             return
@@ -440,7 +607,7 @@ class RosbagInjector:
         self,
         ros_msg: ROSMessage,
         exc: Optional[Exception],
-        seq_writer: AnySessionWriter,
+        session_writer: AnySessionWriter,
         ui: ProgressManager,
     ):
         """
@@ -452,11 +619,17 @@ class RosbagInjector:
         3. **Resolve**: Locates the appropriate Mosaico Adapter for the message type.
         4. **Stream**: Obtains or creates a `TopicWriter` for the specific topic.
         5. **Adapt & Push**: Translates the ROS dictionary into a Mosaico object and pushes it to the server buffer.
+
+        Args:
+            ros_msg (ROSMessage): The ROS message to process.
+            exc (Optional[Exception]): Any exception raised during deserialization.
+            session_writer (AnySessionWriter): The active session writer for the sequence.
+            ui (ProgressManager): The progress manager for updating the UI.
         """
 
         if self._loader is None:
             raise RuntimeError(
-                "Impossible to process messages if ROSLoader is not instanciated first"
+                "Impossible to process messages if ROSLoader is not instantiated first"
             )
 
         # --- Filter Check ---
@@ -467,8 +640,17 @@ class RosbagInjector:
         # --- Integrity Check ---
         # If the loader yielded an exception or empty data, mark as error
         if exc or not ros_msg.data_field:
-            ui.update_status(ros_msg.topic, "Deserialization Error.", "red")
+            logger.warning(
+                f"Skipping message on topic '{ros_msg.topic}' due to error: '{exc}'"
+            )
+            ui.update_status(
+                ros_msg.topic, "Message-related Error. Check the logs.", "red"
+            )
             ui.advance_global()
+            # Update the malformed message count for this topic
+            self._malformed_message_counts[ros_msg.topic] = (
+                self._malformed_message_counts.get(ros_msg.topic, 0) + 1
+            )
             return
 
         # --- Adapter Resolution ---
@@ -477,27 +659,42 @@ class RosbagInjector:
         ) or self._loader.resolve_adapter(ros_msg.topic)
 
         if adapter is None:
-            # If no adapter exists, blacklist this topic to prevent future lookups
+            # This should never happen, but we handle it gracefully
+            # Blacklist this topic to prevent future lookups
             self._ignored_topics.add(ros_msg.topic)
-            ui.update_status(ros_msg.topic, "No Adapter", "yellow")
+            ui.update_status(ros_msg.topic, "Unable to adapt.", "red")
             ui.advance_global()
             return
 
         # Retrieve the writer from SequenceWriter local cache or create new one on server
-        twriter = seq_writer.get_topic_writer(ros_msg.topic)
+        twriter = session_writer.get_topic_writer(ros_msg.topic)
 
         # Should theoretically not be None if exists returned True
         if twriter is None:
             # --- Schema metadata Resolution ---
             ros_version = 1 if self.cfg.ros_distro is Stores.ROS1_NOETIC else 2
-            schema_metadata = adapter.schema_metadata(
-                self._loader._typestore, ros_msg.msg_type, ros_version
+            ros_meta = RosSchemaMetadata.from_dict(
+                adapter.schema_metadata(
+                    self._loader._typestore, ros_msg.msg_type, ros_version
+                )
             )
+            # Record which bag file introduced this topic, inside the reserved `_ros_`
+            # namespace. This lets the source of each topic remain traceable even after
+            # later updates to the same sequence (e.g. multi-part recordings or merged
+            # reprocessing results), since sequence metadata cannot be changed once the
+            # sequence has been ingested.
+            ros_meta.update(source_file=self.cfg.file_path.name)
+
+            # Start from the user-supplied per-topic metadata, then layer the bridge-computed
+            # `_ros_` block on top: `_ros_` is reserved and always wins on conflict, every
+            # other key is fully user-owned.
+            metadata = dict((self.cfg.topic_metadata or {}).get(ros_msg.topic, {}))
+            metadata.update(ros_meta.to_dict())
 
             # Register new topic on server
-            twriter = seq_writer.topic_create(
+            twriter = session_writer.topic_create(
                 topic_name=ros_msg.topic,
-                metadata=schema_metadata or {},
+                metadata=metadata,
                 ontology_type=adapter.ontology_data_type(),
                 on_error=self._get_topic_on_error(ros_msg.topic),
             )
@@ -528,35 +725,39 @@ class RosbagInjector:
 # --- CLI Entry Point ---
 
 
-def _parse_metadata_arg(metadata_input: Optional[str]) -> dict:
+def _parse_json_arg(arg_input: Optional[str], arg_name: str = "Metadata") -> dict:
     """
-    Parses the CLI metadata argument.
+    Parses a CLI argument that may be a raw JSON string or a path to a JSON file.
 
     Supports two formats:
     1. A raw JSON string: '{"driver": "John"}'
     2. A path to a JSON file: './configs/meta.json'
 
+    Args:
+        arg_input (Optional[str]): The raw CLI argument value.
+        arg_name (str): Human-readable name of the argument, used in log/error messages.
+
     Returns:
-        dict: The parsed metadata, or empty dict on failure.
+        dict: The parsed JSON object, or empty dict if `arg_input` is falsy.
     """
-    if not metadata_input:
+    if not arg_input:
         return {}
 
     # Attempt JSON Parse
     try:
-        data = json.loads(metadata_input)
-        logger.info("Metadata parsed successfully from JSON string.")
+        data = json.loads(arg_input)
+        logger.info(f"{arg_name} parsed successfully from JSON string.")
         return data
     except json.JSONDecodeError:
         pass  # Not a valid JSON string, proceed to check file
 
     # Attempt File Read
-    file_path = Path(metadata_input)
+    file_path = Path(arg_input)
     if file_path.is_file():
         try:
             with open(file_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            logger.info(f"Metadata loaded successfully from file: '{file_path}'")
+            logger.info(f"{arg_name} loaded successfully from file: '{file_path}'")
             return data
         except json.JSONDecodeError as e:
             logger.error(
@@ -564,12 +765,12 @@ def _parse_metadata_arg(metadata_input: Optional[str]) -> dict:
             )
             sys.exit(1)
         except Exception as e:
-            logger.error(f"Error reading metadata file '{file_path}': '{e}'")
+            logger.error(f"Error reading {arg_name.lower()} file '{file_path}': '{e}'")
             sys.exit(1)
 
     # Failure
     logger.error(
-        f"Metadata argument is neither a valid JSON string nor a valid file path: '{metadata_input}'"
+        f"{arg_name} argument is neither a valid JSON string nor a valid file path: '{arg_input}'"
     )
     sys.exit(1)
 
@@ -584,6 +785,23 @@ def ros_injector():
     # Required Arguments
     parser.add_argument("bag_path", type=Path, help="Path to .mcap or .db3 file")
     parser.add_argument("--name", "-n", required=True, help="Target Sequence Name")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Resolve topics/adapters/rejections and print a report, without connecting "
+            "to the Mosaico server or writing any data."
+        ),
+    )
+    parser.add_argument(
+        "--update-if-exists",
+        action="store_true",
+        help=(
+            "If a sequence named --name already exists, append this bag's topics to it "
+            "instead of raising an error (e.g. for multi-part bags or merging reprocessed "
+            "results into an already-ingested sequence)."
+        ),
+    )
 
     # Connection Arguments
     parser.add_argument("--host", default="localhost", help="Mosaico Server Host")
@@ -610,6 +828,14 @@ def ros_injector():
         "--metadata",
         help="JSON string or path to JSON file containing sequence metadata",
     )
+    parser.add_argument(
+        "--topic-metadata",
+        help=(
+            "JSON string or path to JSON file containing a mapping of exact topic name to "
+            'metadata, e.g. \'{"/imu": {"unit": "rad/s"}}\'. Only applied to topics that are '
+            "actually ingested (see --topics)."
+        ),
+    )
 
     # Advanced Arguments
     parser.add_argument(
@@ -624,7 +850,11 @@ def ros_injector():
     parser.add_argument(
         "--api-key",
         default=None,
-        help="Mosaico API-Key",
+        help=(
+            "Mosaico API-Key. Prefer setting the MOSAICO_API_KEY environment variable "
+            "instead, to avoid leaking the key via shell history or the process list "
+            "(e.g. `ps aux`); --api-key takes precedence if both are set."
+        ),
     )
 
     # Advanced Arguments
@@ -658,26 +888,39 @@ def ros_injector():
     )
 
     # Parse metadata
-    user_metadata = _parse_metadata_arg(args.metadata)
+    user_metadata = _parse_json_arg(args.metadata, arg_name="Metadata")
     # Inject traceability metadata
     user_metadata.update({"rosbag_injection": args.bag_path.name})
+    user_topic_metadata = _parse_json_arg(
+        args.topic_metadata, arg_name="Topic metadata"
+    )
 
     config = ROSInjectionConfig(
         file_path=args.bag_path,
         sequence_name=args.name,
         metadata=user_metadata,
+        topic_metadata=user_topic_metadata or None,
+        update_if_exists=args.update_if_exists,
+        dry_run=args.dry_run,
         host=args.host,
         port=args.port,
         topics=args.topics,
         ros_distro=selected_distro,
         log_level=args.log,
         tls_cert_path=args.tls_cert,
-        mosaico_api_key=args.api_key,
+        mosaico_api_key=args.api_key or os.environ.get("MOSAICO_API_KEY"),
     )
 
     # --- Execution ---
     injector = RosbagInjector(config)
-    injector.run()
+    try:
+        injector.run()
+    except KeyboardInterrupt:
+        sys.exit(130)
+    except Exception:
+        # Already logged with a full traceback inside run(); exit non-zero so
+        # calling scripts/CI can detect the failure.
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
@@ -519,12 +519,6 @@ class RosbagInjector:
                     # multiple bags that should all land in the same sequence, and a derived/
                     # reprocessed bag whose topics should be merged into an already-ingested
                     # sequence. Should the sequence not exist yet, a new one is created regardless.
-                    # CAVEAT: `sequence_exists()` followed by `sequence_create()`/`sequence_update()`
-                    # is a check-then-act race: if two ingestions target the same `sequence_name`
-                    # concurrently, both could observe "does not exist" and both attempt to create
-                    # it, or one could update a sequence the other is still creating. Fine for the
-                    # typical single-operator workflow; avoid running concurrent injections against
-                    # the same sequence name until the server offers an atomic create-or-update.
                     if (
                         mclient.sequence_exists(self._cfg.sequence_name)
                         and self._cfg.update_if_exists

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
@@ -44,10 +44,11 @@ from mosaicolabs.handlers.base_session_writer import AnySessionWriter
 from mosaicolabs.logging_config import get_logger, setup_sdk_logging
 
 from .adapter_base import RosSchemaMetadata
-from .loader import ProgressManager, ROSLoader
+from .loader import ROSLoader
 from .registry import ROSTypeRegistry
 from .ros_bridge import ROSAdapterBase, ROSBridge
 from .ros_message import ROSMessage
+from .ui import ProgressManager
 
 # Set the hierarchical logger
 logger = get_logger(__name__)

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
@@ -84,6 +84,8 @@ class ROSInjectionConfig:
             Set to a [`TopicLevelErrorPolicy`][mosaicolabs.enum.TopicLevelErrorPolicy] to apply the same policy to all topics.
             Set to a `Dict[str, TopicLevelErrorPolicy]` to apply different policies to different (subset of) topics.
         custom_msgs (Optional[List[Tuple]]): List of custom .msg definitions to register before loading.
+        registry (Optional[ROSTypeRegistry]): Registry to register `custom_msgs` into; a private
+            one is created if `None`. Pass a shared instance to reuse definitions across runs.
         topics (Optional[List[str]]): List of topic patterns used to filter available topics.
             Supports shell-style glob patterns (e.g., ["/cam/\\*", "\\*camera_info"]).
             Patterns starting with "!" are treated as exclusions (e.g., ["\\!/cam/debug\\*"]).
@@ -219,6 +221,18 @@ class ROSInjectionConfig:
     package_name = "my_robot_msgs"; path = path/to/Location.msg; store = Stores.ROS2_HUMBLE (e.g.) or None
 
     See [`rosbags.typesys.Stores`](https://ternaris.gitlab.io/rosbags/topics/typesys.html#type-stores).
+
+    Registered into `registry` (or a fresh, private `ROSTypeRegistry` if `registry` is
+    `None`) before the loader's `Typestore` is built.
+    """
+
+    registry: Optional[ROSTypeRegistry] = None
+    """
+    The `ROSTypeRegistry` instance to register `custom_msgs` into and to pull existing
+    definitions from. If `None` (default), a fresh, private instance is created for this
+    injector alone — so its custom types can never leak into another injector/extractor
+    run in the same process. Pass the *same* `ROSTypeRegistry` instance across multiple
+    configs to deliberately share a centrally pre-registered set of definitions between them.
     """
 
     topics: Optional[List[str]] = None
@@ -331,27 +345,33 @@ class RosbagInjector:
         self._typestore: Typestore = get_typestore(self._cfg.ros_distro or Stores.EMPTY)
         self._loader: Optional[ROSLoader] = None
 
+        # Own a private registry by default, so this injector's custom types can never
+        # leak into another injector/extractor run in the same process. Pass the same
+        # `ROSTypeRegistry` instance via `cfg.registry` to deliberately share definitions
+        # across multiple runs (e.g. a centralized setup routine).
+        self._registry: ROSTypeRegistry = self._cfg.registry or ROSTypeRegistry()
+
         # Register custom ROS messages to the local typestore
         self._typestore_custom_msgtypes()
 
     def _typestore_custom_msgtypes(self):
         """
-        Registers any custom ROS message definitions provided in ``cfg.custom_msgs``,
-        and then registers the custom message definitions to the typestore.
+        Registers any custom ROS message definitions provided in ``cfg.custom_msgs``
+        into ``self._registry``, then pulls every definition currently registered there
+        (including ones registered elsewhere on a *shared* `cfg.registry` instance) into
+        the local typestore. Safe to always run: `self._registry` is either private to
+        this injector, or an instance the caller explicitly chose to share.
         """
-        if not self._cfg.custom_msgs:
-            return
-
-        # Register Global Types (Registry Pattern)
-        logger.info("Registering custom message definitions...")
-        for package, path, store in self._cfg.custom_msgs:
-            try:
-                ROSTypeRegistry.register_directory(
-                    package_name=package, dir_path=path, store=store
-                )
-                logger.debug(f"Registered package '{package}' from '{path}'")
-            except Exception as e:
-                logger.error(f"Failed to register custom msgs at '{path}': '{e}'")
+        if self._cfg.custom_msgs:
+            logger.info("Registering custom message definitions...")
+            for package, path, store in self._cfg.custom_msgs:
+                try:
+                    self._registry.register_directory(
+                        package_name=package, dir_path=path, store=store
+                    )
+                    logger.debug(f"Registered package '{package}' from '{path}'")
+                except Exception as e:
+                    logger.error(f"Failed to register custom msgs at '{path}': '{e}'")
 
         self._register_definitions()
 
@@ -359,7 +379,7 @@ class RosbagInjector:
         """Safe registration wrapper."""
         from rosbags.typesys import get_types_from_msg
 
-        custom_types = ROSTypeRegistry.get_types(self._cfg.ros_distro)
+        custom_types = self._registry.get_types(self._cfg.ros_distro)
         if not custom_types:
             return
 

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/injector.py
@@ -411,7 +411,7 @@ class RosbagInjector:
             self._loader = ROSLoader(
                 file_path=self._cfg.file_path,
                 topics=self._cfg.topics,
-                typestore=self._typestore,
+                typestore_or_distro=self._typestore,
                 serialization_formats=self._cfg.serialization_formats,
             )
 

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
@@ -15,7 +15,7 @@ from typing import (
 
 from rosbags.highlevel import AnyReader
 from rosbags.interfaces import Connection, TopicInfo
-from rosbags.typesys import Stores, get_types_from_msg, get_typestore
+from rosbags.typesys import get_types_from_msg
 from rosbags.typesys.store import Typestore
 
 from mosaicolabs import (
@@ -41,7 +41,6 @@ from .helpers import (
     _to_dict,
     _validate_sequence,
 )
-from .registry import ROSTypeRegistry
 from .ros_bridge import ROSBridge, ROSMessage
 
 # Set the hierarchical logger
@@ -262,9 +261,8 @@ class ROSLoader(_BaseROSTopicResolver):
     def __init__(
         self,
         file_path: Union[str, Path],
+        typestore: Typestore,
         topics: Optional[Union[str, List[str]]] = None,
-        typestore_name: Stores = Stores.EMPTY,
-        custom_types: Optional[Dict[str, Union[str, Path]]] = None,
         serialization_formats: Optional[Dict[str, SerializationFormat]] = None,
     ):
         """
@@ -298,11 +296,9 @@ class ROSLoader(_BaseROSTopicResolver):
 
         Args:
             file_path (Union[str, Path]): Path to the bag file or directory.
+            typestore (Typestore): The typestore to use for message type resolution.
             topics (Optional[Union[str, List[str]]]): A single topic name, a list of names, or glob patterns. Patterns are evaluated in ORDER (gitignore-like semantics).
                 If None, all available topics are loaded.
-            typestore_name (Stores): The target ROS distribution for default message schemas.
-                See [`rosbags.typesys.Stores`](https://ternaris.gitlab.io/rosbags/topics/typesys.html#type-stores).
-            custom_types (Optional[Dict[str, Union[str, Path]]]): Local overrides for message definitions (type_name: path/to/msg).
             serialization_formats (Optional[Dict[str, SerializationFormat]]): Maps a ROS message type string (e.g. `sensor_msgs/msg/CustomPointCloud2`)
                 to the [`SerializationFormat`][mosaicolabs.enum.serialization_format.SerializationFormat]
                 used when synthesizing an [`Unmodeled`][mosaicolabs.models.core.unmodeled.Unmodeled]
@@ -314,31 +310,23 @@ class ROSLoader(_BaseROSTopicResolver):
             container_type=dict[str, TopicInfo]
         )  # Initialize the base class to set up topic resolution state
         self._file_path = Path(file_path)
-        self._validate_file()
+        """The path to the bag file or directory."""
 
         # Configuration
         self._requested_topics = [topics] if isinstance(topics, str) else topics
-        self._typestore = get_typestore(typestore_name)
+        """The user-specified topic filter(s) to apply when resolving topics."""
+        self._typestore: Typestore = typestore
+        """The typestore used for message type resolution."""
         self._serialization_formats: Dict[str, SerializationFormat] = (
             serialization_formats or {}
         )
+        """Mapping of ROS message types to their desired serialization format for Unmodeled ontologies."""
 
         # State
         self._reader: Optional[AnyReader] = None
+        """The underlying `rosbags` reader instance, lazily initialized."""
         self._connections: List[Connection] = []
-
-        # Register Global Types (Registry Pattern)
-        global_types = ROSTypeRegistry.get_types(typestore_name)
-        if global_types:
-            self._register_definitions(global_types)
-
-        # Register Local Overrides
-        if custom_types:
-            # Resolve paths to strings immediately
-            resolved = {
-                k: ROSTypeRegistry._resolve_source(v) for k, v in custom_types.items()
-            }
-            self._register_definitions(resolved)
+        """The list of resolved connections (topics) that will be iterated over."""
 
     def _validate_file(self):
         if not self._file_path.exists():
@@ -347,17 +335,6 @@ class ROSLoader(_BaseROSTopicResolver):
             raise ValueError(
                 f"Unsupported format '{self._file_path.suffix}'. Supported: {self.ACCEPTED_EXTENSIONS}"
             )
-
-    def _register_definitions(self, types_map: Dict[str, str]):
-        """Safe registration wrapper."""
-        from rosbags.typesys import get_types_from_msg
-
-        for msg_type, msg_def in types_map.items():
-            try:
-                add_types = get_types_from_msg(msg_def, msg_type)
-                self._typestore.register(add_types)
-            except Exception as e:
-                logger.warning(f"Failed to register type '{msg_type}': '{e}'")
 
     def _resolve_connections(self):
         """
@@ -371,6 +348,7 @@ class ROSLoader(_BaseROSTopicResolver):
             return
 
         try:
+            self._validate_file()
             self._reader = AnyReader(
                 [self._file_path], default_typestore=self._typestore
             )
@@ -690,21 +668,21 @@ class MosaicoLoader(_BaseROSTopicResolver):
             container_type=list[str]
         )  # Initialize the base class to set up topic resolution state
 
-        self.client = m_client
+        self._client = m_client
         """The MosaicoClient used to fetch sequence data and metadata."""
-        self.typestore: Typestore = typestore
+        self._typestore: Typestore = typestore
         """The ROS typestore containing the registered ROS messages. Used for adapter resolution."""
-        self.sequence_name = sequence_name
+        self._sequence_name = sequence_name
         """The name of the Mosaico sequence to load."""
-        self.topic_glob_pattern = topics
+        self._topic_glob_pattern = topics
         """Optional list of topic-name filter patterns (glob-style, ``!``-prefixed for exclusions)."""
-        self.start_timestamp_ns = start_timestamp_ns
+        self._start_timestamp_ns = start_timestamp_ns
         """Lower bound for the time window (nanoseconds). Clipped to the sequence minimum if out of range."""
-        self.end_timestamp_ns = end_timestamp_ns
+        self._end_timestamp_ns = end_timestamp_ns
         """Upper bound for the time window (nanoseconds). Clipped to the sequence maximum if out of range."""
-        self.seq_handler: Optional[SequenceHandler] = None
+        self._seq_handler: Optional[SequenceHandler] = None
         """The mosaico sequence handler, lazily initialized on first access."""
-        self.streamer: Optional[SequenceDataStreamer] = None
+        self._streamer: Optional[SequenceDataStreamer] = None
         """The mosaico sequence streamer, lazily initialized on first access. Provides an iterator over the sequence messages."""
 
         # Additional rejection buckets for Mosaico-specific reasons
@@ -820,7 +798,7 @@ class MosaicoLoader(_BaseROSTopicResolver):
 
     def _register_msgtype(self, msgtype: str, msgdef: Optional[str]):
         """Registers ``msgtype`` in the typestore using ``msgdef``, unless already present."""
-        if msgtype in self.typestore.types:
+        if msgtype in self._typestore.types:
             return
 
         if msgdef is None:
@@ -828,7 +806,7 @@ class MosaicoLoader(_BaseROSTopicResolver):
             return
 
         add_types = get_types_from_msg(msgdef, msgtype)
-        self.typestore.register(add_types)
+        self._typestore.register(add_types)
 
     def _get_or_create_adapter(
         self, t_handler: TopicHandler
@@ -910,45 +888,45 @@ class MosaicoLoader(_BaseROSTopicResolver):
            returned by :meth:`__iter__`.
 
         """
-        if self.seq_handler is not None:
-            return self.seq_handler
+        if self._seq_handler is not None:
+            return self._seq_handler
 
         # Get requested sequence + validation
-        self.seq_handler = self.client.sequence_handler(
-            sequence_name=self.sequence_name
+        self._seq_handler = self._client.sequence_handler(
+            sequence_name=self._sequence_name
         )
 
         # Check sequence exists
-        if not _validate_sequence(self.seq_handler):
+        if not _validate_sequence(self._seq_handler):
             raise (
                 ValueError(
-                    f"Your requested sequence '{self.sequence_name}' could not be found!"
+                    f"Your requested sequence '{self._sequence_name}' could not be found!"
                 )
             )
 
         # Get all topics from sequence handler
-        self._resolved_topics = self.seq_handler.topics
+        self._resolved_topics = self._seq_handler.topics
 
         # Clipping requested start/end timestamp to start/end sequence timestamp if existing
-        self.start_timestamp_ns, self.end_timestamp_ns = _clip_timestamp(
-            self.start_timestamp_ns,
-            self.end_timestamp_ns,
-            self.seq_handler.timestamp_ns_min,
-            self.seq_handler.timestamp_ns_max,
+        self._start_timestamp_ns, self._end_timestamp_ns = _clip_timestamp(
+            self._start_timestamp_ns,
+            self._end_timestamp_ns,
+            self._seq_handler.timestamp_ns_min,
+            self._seq_handler.timestamp_ns_max,
         )
 
         matched_topics = _filter_topics_from_list(
-            self.seq_handler.topics, self.topic_glob_pattern
+            self._seq_handler.topics, self._topic_glob_pattern
         )
 
         # Filter topics
-        for t_name in self.seq_handler.topics:
+        for t_name in self._seq_handler.topics:
             # 1) Filter if topic has not been requested
             if t_name not in matched_topics:
                 self._filtered_topics.append(t_name)
                 continue
 
-            t_handler = self.seq_handler.get_topic_handler(t_name)
+            t_handler = self._seq_handler.get_topic_handler(t_name)
 
             # 2) Filter if Mosaico adapter cannot be deduced topic's adapter
             try:
@@ -967,7 +945,7 @@ class MosaicoLoader(_BaseROSTopicResolver):
                 continue
 
             # 3) check that rosmsg_type (either from metadata or default adapter) is present within typestore
-            if self.typestore.types.get(rosmsg_type) is None:
+            if self._typestore.types.get(rosmsg_type) is None:
                 logger.warning(
                     f"Skipping topic '{t_name}': '{rosmsg_type}' not present in ROS typestore."
                 )
@@ -988,13 +966,13 @@ class MosaicoLoader(_BaseROSTopicResolver):
             )
 
         # Resolving streamer only with accepted topics
-        self.streamer = self.seq_handler.get_data_streamer(
+        self._streamer = self._seq_handler.get_data_streamer(
             topics=self._accepted_topics,
-            start_timestamp_ns=self.start_timestamp_ns,
-            end_timestamp_ns=self.end_timestamp_ns,
+            start_timestamp_ns=self._start_timestamp_ns,
+            end_timestamp_ns=self._end_timestamp_ns,
         )
 
-        return self.seq_handler
+        return self._seq_handler
 
     # --- Properties ---
     def msg_count(self, topic: Optional[str] = None) -> int:
@@ -1011,7 +989,7 @@ class MosaicoLoader(_BaseROSTopicResolver):
         """
         self._resolve_sequence()
 
-        if not self.streamer:
+        if not self._streamer:
             raise Exception(
                 "Impossible to start streaming: SequenceDataStreamer is not initialised. Did you forget calling _resolve_sequence()?"
             )
@@ -1027,7 +1005,7 @@ class MosaicoLoader(_BaseROSTopicResolver):
             filter(
                 None,
                 (
-                    self.streamer._topic_readers[topic].msg_count
+                    self._streamer._topic_readers[topic].msg_count
                     for topic in topics_to_count
                 ),
             )
@@ -1118,12 +1096,12 @@ class MosaicoLoader(_BaseROSTopicResolver):
     def __iter__(self):
         self._resolve_sequence()
 
-        if not self.streamer:
+        if not self._streamer:
             raise Exception(
                 "Impossible to start streaming: SequenceDataStreamer is not initialised. Did you forget calling _resolve_sequence()?"
             )
 
-        return self.streamer
+        return self._streamer
 
     def close(self):
         """
@@ -1131,10 +1109,10 @@ class MosaicoLoader(_BaseROSTopicResolver):
         """
 
         # This handles also streamer closing
-        if self.seq_handler:
-            self.seq_handler.close()
-            self.seq_handler = None
-            self.streamer = None
+        if self._seq_handler:
+            self._seq_handler.close()
+            self._seq_handler = None
+            self._streamer = None
 
     def __enter__(self):
         """Context manager support."""

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional, Protocol, Tuple, Union
@@ -29,7 +30,7 @@ from mosaicolabs.ros_bridge.adapters.unmodeled import UnmodeledAdapter
 
 from ..models.core.serializable import _compute_schema_fingerprint
 from ..protocols.ros2msg import convert_ros2msg
-from .adapter_base import ROSAdapterBase
+from .adapter_base import ROSAdapterBase, RosSchemaMetadata
 from .helpers import (
     _class_name_from_ros_msgtype,
     _clip_timestamp,
@@ -85,33 +86,6 @@ class TopicStatus(Enum):
         return _colors.get(self, "bright_red")
 
 
-class LoaderErrorPolicy(Enum):
-    """
-    Defines the strategy for handling deserialization failures during bag playback.
-
-    In heterogeneous datasets, it is common to encounter corrupted messages or missing
-    type definitions for specific topics. This policy allows the user to balance
-    system robustness against data integrity.
-
-    Attributes:
-        IGNORE: Silently skips any message that fails to deserialize. The pipeline continues
-            uninterrupted without any log output.
-        LOG_WARN: (Default) Logs a warning containing the topic name and error details, then
-            skips the message and continues.
-        RAISE: Immediately halts execution and raises the exception. Best used for critical
-            data ingestion where missing even a single record is unacceptable.
-    """
-
-    IGNORE = "ignore"
-    """Silently skips any message that fails to deserialize."""
-
-    LOG_WARN = "log_warn"
-    """Logs a warning containing the topic name and error details, then skips the message and continues."""
-
-    RAISE = "raise"
-    """Immediately halts execution and raises the exception. Best used for critical data ingestion where missing even a single record is unacceptable."""
-
-
 class Loader(Protocol):
     """
     Structural protocol for data loaders consumed by :class:`ProgressManager`.
@@ -140,6 +114,141 @@ class Loader(Protocol):
         """This should return the total number of messages in the passed
         topic if not None. Otherwise returns all messages in all topics"""
         ...
+
+
+# --- Shared Topic Resolution/Rejection Bookkeeping ---
+
+
+class _BaseROSTopicResolver(ABC):
+    """
+    Shared topic classification and adapter-resolution logic for :class:`ROSLoader`
+    (bag file source) and :class:`MosaicoLoader` (Mosaico sequence source).
+
+    Both loaders classify every topic of their underlying data source into one of:
+    **accepted** (adapter resolved, passes the user's `topics` filter), **filtered**
+    (excluded by the user's `topics` filter), or **unresolved** (no Mosaico adapter
+    could be resolved) — plus any source-specific rejection reasons (see
+    :meth:`_extra_rejected_topics`). This base class implements the properties that
+    only need to read those buckets, so each subclass only has to populate them via
+    its own `_ensure_resolved()` (which performs the actual, source-specific
+    resolution: opening the bag file, or querying the Mosaico sequence).
+
+    Subclasses are expected to set, during `_ensure_resolved()`:
+
+    * `_resolved_topics`: **all** topic names in the source (dict or list; only
+      the keys/elements are read by this base class).
+    * `_accepted_topics`: topic names that passed filtering and adapter resolution.
+    * `_unresolved_adapter_topics`: topic names with no resolvable Mosaico adapter.
+    * `_filtered_topics`: topic names excluded by the user's `topics` filter.
+    * `_topic_cached_adapters`: `Dict[str, Type[ROSAdapterBase]]` mapping accepted
+      topic names to their resolved adapter.
+    """
+
+    _resolved_topics: Any
+    _accepted_topics: Any
+    _unresolved_adapter_topics: Any
+    _filtered_topics: Any
+    _topic_cached_adapters: Dict[str, type]
+
+    @abstractmethod
+    def _ensure_resolved(self) -> None:
+        """Lazily triggers the source-specific resolution, populating the topic buckets."""
+
+    def _extra_rejected_topics(self) -> List[Tuple[str, "TopicStatus"]]:
+        """
+        Hook for source-specific rejection reasons beyond FILTERED/UNRESOLVED_ADAPTED
+        (e.g. :class:`MosaicoLoader`'s `NOT_IN_TYPESTORE`/`MALFORMED_METADATA`).
+
+        Returns:
+            List[Tuple[str, TopicStatus]]: Additional `(topic_name, status)` rejections.
+                Empty by default.
+        """
+        return []
+
+    @property
+    def topics(self) -> List[str]:
+        """
+        Retrieves the list of accepted topic names that will be processed.
+
+        Returns:
+            List[str]: A list of topic names currently matched and scheduled for loading.
+        """
+        self._ensure_resolved()
+        return list(self._accepted_topics)
+
+    @property
+    def resolved_topics(self) -> List[str]:
+        """
+        Retrieves the list of **all** the canonical topic names in the underlying source.
+        This property does not account for topics filtered out or not-adapted: it returns everything.
+
+        Returns:
+            List[str]: A list of all topic names contained within the source.
+        """
+        self._ensure_resolved()
+        return list(self._resolved_topics)
+
+    @property
+    def unresolved_adapted_topics(self) -> List[str]:
+        """
+        Retrieves the list of topic names that are **skipped** due to unavailable Mosaico adapter.
+
+        Returns:
+            List[str]: A list of topics with unresolved adapter to translate them into/from Mosaico Ontology.
+        """
+        self._ensure_resolved()
+        return list(self._unresolved_adapter_topics)
+
+    @property
+    def filtered_topics(self) -> List[str]:
+        """
+        Retrieves the list of topic names that are **skipped** due to the user filter.
+
+        Returns:
+            List[str]: The list of topics filtered by the user. Empty if no filter is provided.
+        """
+        self._ensure_resolved()
+        return list(self._filtered_topics)
+
+    @property
+    def rejected_topics(self) -> List[Tuple[str, "TopicStatus"]]:
+        """
+        Retrieves every rejected topic together with the reason it was rejected.
+
+        Returns:
+            List[Tuple[str, TopicStatus]]: `(topic_name, status)` pairs for every topic
+                excluded from `topics`, combining `filtered_topics`, `unresolved_adapted_topics`,
+                and any source-specific rejections from `_extra_rejected_topics()`.
+        """
+        self._ensure_resolved()
+
+        rejected: List[Tuple[str, TopicStatus]] = [
+            (t, TopicStatus.FILTERED) for t in self.filtered_topics
+        ]
+        rejected += [
+            (t, TopicStatus.UNRESOLVED_ADAPTED) for t in self.unresolved_adapted_topics
+        ]
+        rejected += self._extra_rejected_topics()
+        return rejected
+
+    def resolve_adapter(self, topic_name: str) -> Optional[type]:
+        """
+        Returns the resolved adapter for an accepted topic.
+
+        Args:
+            topic_name (str): The topic name whose adapter should be resolved.
+                Must be one of the accepted topics produced by `_ensure_resolved()`.
+
+        Returns:
+            Optional[Type[ROSAdapterBase]]: The resolved adapter type, or `None` if the
+                topic is not among the accepted topics.
+        """
+        self._ensure_resolved()
+
+        if topic_name not in self._accepted_topics:
+            return None
+
+        return self._topic_cached_adapters.get(topic_name)
 
 
 # --- UI / Progress Helper ---
@@ -241,7 +350,7 @@ class ProgressManager:
             self.progress.advance(self.global_task)
 
 
-class ROSLoader:
+class ROSLoader(_BaseROSTopicResolver):
     """
     Unified loader for reading and deserializing ROS 1 (.bag) and ROS 2 (.mcap, .db3) data.
 
@@ -271,7 +380,6 @@ class ROSLoader:
         file_path: Union[str, Path],
         topics: Optional[Union[str, List[str]]] = None,
         typestore_name: Stores = Stores.EMPTY,
-        error_policy: LoaderErrorPolicy = LoaderErrorPolicy.LOG_WARN,
         custom_types: Optional[Dict[str, Union[str, Path]]] = None,
         serialization_formats: Optional[Dict[str, SerializationFormat]] = None,
     ):
@@ -286,14 +394,13 @@ class ROSLoader:
             ```python
             from rosbags.typesys import Stores
             from mosaicolabs.enum.serialization_format import SerializationFormat
-            from mosaicolabs.ros_bridge import ROSLoader, LoaderErrorPolicy
+            from mosaicolabs.ros_bridge import ROSLoader
 
             # Initialize to read only IMU and GPS data from an MCAP file
             with ROSLoader(
                 file_path="mission_01.mcap",
                 topics=["/imu*", "/gps/fix"],
                 typestore_name=Stores.ROS2_HUMBLE,
-                error_policy=LoaderErrorPolicy.RAISE,
                 # Non-adapted (Unmodeled) messages of this type will be
                 # serialized as Ragged instead of the Default format
                 serialization_formats={
@@ -311,7 +418,6 @@ class ROSLoader:
                 If None, all available topics are loaded.
             typestore_name (Stores): The target ROS distribution for default message schemas.
                 See [`rosbags.typesys.Stores`](https://ternaris.gitlab.io/rosbags/topics/typesys.html#type-stores).
-            error_policy (LoaderErrorPolicy): How to handle errors during message iteration.
             custom_types (Optional[Dict[str, Union[str, Path]]]): Local overrides for message definitions (type_name: path/to/msg).
             serialization_formats (Optional[Dict[str, SerializationFormat]]): Maps a ROS message type string (e.g. `sensor_msgs/msg/CustomPointCloud2`)
                 to the [`SerializationFormat`][mosaicolabs.enum.serialization_format.SerializationFormat]
@@ -326,7 +432,6 @@ class ROSLoader:
         # Configuration
         self._requested_topics = [topics] if isinstance(topics, str) else topics
         self._typestore = get_typestore(typestore_name)
-        self._error_policy = error_policy
         self._serialization_formats: Dict[str, SerializationFormat] = (
             serialization_formats or {}
         )
@@ -582,88 +687,9 @@ class ROSLoader:
             )
         return self._reader.duration
 
-    @property
-    def topics(self) -> List[str]:
-        """
-        Retrieves the list of accepted topic names that will be processed.
-
-        This property returns the result of the "Smart Filtering" process which consists in:
-        1) resolving any glob patterns (e.g., `/camera/*`) provided at initialization and comparing with the ones contained within the rosbags
-        2) excluding all remaining topics that do not have an Adapter that allow the translation to a Mosaico Ontology
-
-        Example:
-            ```python
-            with ROSLoader(file_path="data.mcap", topics=["/sensors/*"]) as loader:
-                # If the bag contains /sensors/imu and /sensors/gps,
-                # this property returns ['/sensors/imu', '/sensors/gps']
-                print(f"Loading topics: {loader.topics}")
-            ```
-
-        Returns:
-            List[str]: A list of topic names currently matched and scheduled for loading.
-        """
+    def _ensure_resolved(self) -> None:
+        """Lazily opens the bag file and resolves topics (see `_resolve_connections`)."""
         self._resolve_connections()
-        return list(self._accepted_topics.keys())
-
-    @property
-    def resolved_topics(self) -> List[str]:
-        """
-        Retrieves the list of **all** the canonical topic names **that are in the rosbag**.
-        This property does not account for topics filtered out or not-adapted: it returns everything.
-
-        Example:
-            ```python
-            with ROSLoader(file_path="data.mcap", topics=["/sensors/*"]) as loader:
-                # If the bag contains /sensors/imu, /sensors/gps and /base/camera,
-                # this property returns all: ['/sensors/imu', '/sensors/gps', '/base/camera']
-                print(f"Loading resolved topics: {loader.resolved_topics}")
-            ```
-
-        Returns:
-            List[str]: A list of all topic names contained within the rosbag.
-        """
-        self._resolve_connections()
-        return list(self._resolved_topics.keys())
-
-    @property
-    def unresolved_adapted_topics(self) -> List[str]:
-        """
-        Retrieves the list of topic names that are **skipped** due to unavailable Mosaico adapter.
-
-        Example:
-            ```python
-            with ROSLoader(file_path="data.mcap") as loader:
-                # If the bag contains /sensors/imu and /sensors/custom_gps and the user
-                # did not provide an adapter for /sensors/custom_gps or the bag file
-                # does not contain their message definition this property
-                # returns ['/sensors/custom_gps']
-                print(f"Unresolved adapter for topics: {loader.unresolved_adapted_topics}")
-            ```
-
-        Returns:
-            List[str]: A list of topic with unresolved adapter to translate them into Mosaico Ontology.
-        """
-        self._resolve_connections()
-        return list(self._unresolved_adapter_topics.keys())
-
-    @property
-    def filtered_topics(self) -> List[str]:
-        """
-        Retrieves the list of topic names that are **skipped** due to the user filter.
-
-        Example:
-            ```python
-            with ROSLoader(file_path="data.mcap", topics="*imu*") as loader:
-                # If the bag contains /sensors/imu and /sensors/custom_gps and the user
-                # filtered for the topics containing `imu` this property returns ['/sensors/custom_gps ']
-                print(f"Filtered topics: {loader.filtered_topics}")
-            ```
-
-        Returns:
-            List[str]: The list of topics filtered by the user. Empty if no filter is provided.
-        """
-        self._resolve_connections()
-        return list(self._filtered_topics.keys())
 
     @property
     def msg_types(self) -> List[str | None]:
@@ -688,45 +714,7 @@ class ROSLoader:
         self._resolve_connections()
         return [val.msgtype for val in self._accepted_topics.values()]
 
-    @property
-    def rejected_topics(self) -> List[Tuple[str, TopicStatus]]:
-
-        rejected_topics: List[Tuple[str, TopicStatus]] = []
-        self._resolve_connections()
-
-        # Filtered
-        for t_filtered in self.filtered_topics:
-            rejected_topics.append((t_filtered, TopicStatus.FILTERED))
-
-        # Adapter unresolved
-        for t_unresolved_adapter in self._unresolved_adapter_topics:
-            rejected_topics.append(
-                (t_unresolved_adapter, TopicStatus.UNRESOLVED_ADAPTED)
-            )
-
-        return rejected_topics
-
     # --- Core Logic ---
-
-    def resolve_adapter(self, topic_name: str) -> Optional[type[ROSAdapterBase]]:
-        """
-        Returns the resolve adapter for accepted topic.
-
-        Args:
-            topic_name (str): The topic name whose adapter should be resolved.
-                Must be one of the accepted topics produced by :meth:`_resolve_connections`.
-
-        Returns:
-            Optional[Type[ROSAdapterBase]]: The ROS->Mosaico adapter type obtained during :meth:`_resolve_connections`.
-                Adapter is resolved through the rosmsg_type within Mosaico topic metadata
-                (if available) or getting the default adapter associated to the topic's ontology.
-        """
-        self._resolve_connections()
-
-        if topic_name not in self._accepted_topics:
-            return None
-
-        return self._topic_cached_adapters.get(topic_name)
 
     def __iter__(self) -> Generator[Tuple[ROSMessage, Optional[Exception]], None, None]:
         """
@@ -770,7 +758,6 @@ class ROSLoader:
                 )
 
             except Exception as e:
-                self._handle_error(connection.topic, connection.msgtype, e)
                 yield (
                     ROSMessage(
                         bag_timestamp_ns=bag_timestamp_ns,
@@ -780,15 +767,6 @@ class ROSLoader:
                     ),
                     e,
                 )
-
-    def _handle_error(self, topic: str, msg_type: str, exc: Exception):
-        msg = f"Deserialization error on {topic} ({msg_type}): {exc}"
-
-        if self._error_policy == LoaderErrorPolicy.RAISE:
-            raise ValueError(msg) from exc
-        elif self._error_policy == LoaderErrorPolicy.LOG_WARN:
-            logger.warning(msg)
-        # If IGNORE, do nothing
 
     def close(self):
         """
@@ -807,7 +785,7 @@ class ROSLoader:
         self.close()
 
 
-class MosaicoLoader:
+class MosaicoLoader(_BaseROSTopicResolver):
     """
     Lazy data loader that streams messages from a Mosaico sequence.
 
@@ -858,7 +836,7 @@ class MosaicoLoader:
             str
         ] = []  # The actual topics matched after globbing
 
-        self._unresolved_adapted_topics: list[
+        self._unresolved_adapter_topics: list[
             str
         ] = []  # The topics whose ontology type is not resolved (neither adapted nor message defition available)
 
@@ -1057,7 +1035,7 @@ class MosaicoLoader:
                 logger.warning(
                     f"Skipping topic {t_name}: not-adapted ontology {t_handler.ontology_tag}."
                 )
-                self._unresolved_adapted_topics.append(t_name)
+                self._unresolved_adapter_topics.append(t_name)
                 continue
 
             # 3) check that rosmsg_type (either from metadata or default adapter) is present within typestore
@@ -1075,7 +1053,7 @@ class MosaicoLoader:
             self._accepted_topics.append(t_name)
 
             self._topic_ros_metadata.update(
-                {t_name: t_handler.user_metadata.get("_ros_")}
+                {t_name: RosSchemaMetadata.extract(t_handler.user_metadata)}
             )
             self._topic_cached_adapters.update({t_name: adapter})
 
@@ -1150,54 +1128,19 @@ class MosaicoLoader:
 
         return 0
 
-    @property
-    def topics(self) -> List[str]:
-        """
-        Returns the list of topic names resolved after applying the topic filter.
-
-        Triggers lazy initialization on first access.
-
-        Returns:
-            List[str]: Filtered topic names available in the sequence.
-        """
+    def _ensure_resolved(self) -> None:
+        """Lazily resolves the sequence, its topics, and their adapters (see `_resolve_sequence`)."""
         self._resolve_sequence()
 
-        return self._accepted_topics
-
-    @property
-    def resolved_topics(self) -> List[str]:
-        """
-        Retrieves the list of **all** the canonical topic names **that are in the sequence**.
-
-        This property does not account for topics filtered out or not-adapted: it returns everything.
-
-        Returns:
-            List[str]: A list of *all* topic names present within the requested sequence.
-        """
-        self._resolve_sequence()
-        return self._resolved_topics
-
-    @property
-    def unresolved_adapted_topics(self) -> List[str]:
-        """
-        Retrieves the list of topic names that are **skipped** due to unresolved Mosaico adapter.
-
-        Returns:
-            List[str]: A list of topic with unresolved adapter to translate them into ROS messages.
-        """
-        self._resolve_sequence()
-        return self._unresolved_adapted_topics
-
-    @property
-    def filtered_topics(self) -> List[str]:
-        """
-        Retrieves the list of topic names that are **skipped** due to the user filter.
-
-        Returns:
-            List[str]: The list of topics filtered by the user. Empty if no filter is provided.
-        """
-        self._resolve_sequence()
-        return self._filtered_topics
+    def _extra_rejected_topics(self) -> List[Tuple[str, TopicStatus]]:
+        """Adds the Mosaico-specific rejection reasons on top of FILTERED/UNRESOLVED_ADAPTED."""
+        rejected: List[Tuple[str, TopicStatus]] = [
+            (t, TopicStatus.NOT_IN_TYPESTORE) for t in self._unregistered_topics
+        ]
+        rejected += [
+            (t, TopicStatus.MALFORMED_METADATA) for t in self._malformed_metadata_topics
+        ]
+        return rejected
 
     @property
     def msg_types(self) -> List[str | None]:
@@ -1221,32 +1164,6 @@ class MosaicoLoader:
             else None
             for topic in self._accepted_topics
         ]
-
-    @property
-    def rejected_topics(self) -> List[Tuple[str, TopicStatus]]:
-
-        rejected_topics: List[Tuple[str, TopicStatus]] = []
-        self._resolve_sequence()
-
-        # Filtered
-        for t_filtered in self.filtered_topics:
-            rejected_topics.append((t_filtered, TopicStatus.FILTERED))
-
-        # Adapter not found
-        for t_unresolved_adapter in self._unresolved_adapted_topics:
-            rejected_topics.append(
-                (t_unresolved_adapter, TopicStatus.UNRESOLVED_ADAPTED)
-            )
-
-        # Not found in typestore
-        for t_unregistered in self._unregistered_topics:
-            rejected_topics.append((t_unregistered, TopicStatus.NOT_IN_TYPESTORE))
-
-        # Metadata malformed
-        for t_unregistered in self._malformed_metadata_topics:
-            rejected_topics.append((t_unregistered, TopicStatus.MALFORMED_METADATA))
-
-        return rejected_topics
 
     # --- Core Logic ---
 
@@ -1272,26 +1189,6 @@ class MosaicoLoader:
         self._resolve_sequence()
 
         return (self._topic_ros_metadata.get(topic_name) or {}).get("msgtype")
-
-    def resolve_adapter(self, topic_name: str) -> Optional[type[ROSAdapterBase]]:
-        """
-        Returns the resolve adapter for accepted topic.
-
-        Args:
-            topic_name (str): The topic name whose adapter should be resolved.
-                Must be one of the accepted topics produced by :meth:`_resolve_sequence`.
-
-        Returns:
-            Optional[Type[ROSAdapterBase]]: The Mosaico->ROS adapter type obtained during :meth:`_resolve_sequence`.
-                Adapter is resolved through the rosmsg_type within Mosaico topic metadata
-                (if available) or getting the default adapter associated to the topic's ontology.
-        """
-        self._resolve_sequence()
-
-        if topic_name not in self._accepted_topics:
-            return None
-
-        return self._topic_cached_adapters.get(topic_name)
 
     def __iter__(self):
         self._resolve_sequence()

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
@@ -15,7 +15,7 @@ from typing import (
 
 from rosbags.highlevel import AnyReader
 from rosbags.interfaces import Connection, TopicInfo
-from rosbags.typesys import get_types_from_msg
+from rosbags.typesys import Stores, get_types_from_msg, get_typestore
 from rosbags.typesys.store import Typestore
 
 from mosaicolabs import (
@@ -264,12 +264,12 @@ class ROSLoader(_BaseROSTopicResolver):
     def __init__(
         self,
         file_path: Union[str, Path],
-        typestore: Typestore,
+        typestore_or_distro: Typestore | Stores,
         topics: Optional[Union[str, List[str]]] = None,
         serialization_formats: Optional[Dict[str, SerializationFormat]] = None,
     ):
         """
-        Initializes the loader against a caller-supplied, already-resolved `Typestore`.
+        Initializes the ROSbag loader against a caller-supplied `Typestore` or ROS distro.
 
         `ROSLoader` performs no `ROSTypeRegistry` lookups itself — pass in a `Typestore`
         that already has any custom `.msg` definitions registered (e.g. via
@@ -279,7 +279,7 @@ class ROSLoader(_BaseROSTopicResolver):
 
         Example:
             ```python
-            from rosbags.typesys import Stores, get_typestore
+            from rosbags.typesys import Stores
             from mosaicolabs.enum.serialization_format import SerializationFormat
             from mosaicolabs.ros_bridge import ROSLoader
 
@@ -287,7 +287,7 @@ class ROSLoader(_BaseROSTopicResolver):
             with ROSLoader(
                 file_path="mission_01.mcap",
                 topics=["/imu*", "/gps/fix"],
-                typestore=get_typestore(Stores.ROS2_HUMBLE),
+                typestore_or_distro=Stores.ROS2_HUMBLE,
                 # Non-adapted (Unmodeled) messages of this type will be
                 # serialized as Ragged instead of the Default format
                 serialization_formats={
@@ -301,7 +301,7 @@ class ROSLoader(_BaseROSTopicResolver):
 
         Args:
             file_path (Union[str, Path]): Path to the bag file or directory.
-            typestore (Typestore): The typestore to use for message type resolution.
+            typestore_or_distro (Typestore | Stores): The typestore or ROS distro to use for message type resolution.
             topics (Optional[Union[str, List[str]]]): A single topic name, a list of names, or glob patterns. Patterns are evaluated in ORDER (gitignore-like semantics).
                 If None, all available topics are loaded.
             serialization_formats (Optional[Dict[str, SerializationFormat]]): Maps a ROS message type string (e.g. `sensor_msgs/msg/CustomPointCloud2`)
@@ -320,7 +320,11 @@ class ROSLoader(_BaseROSTopicResolver):
         # Configuration
         self._requested_topics = [topics] if isinstance(topics, str) else topics
         """The user-specified topic filter(s) to apply when resolving topics."""
-        self._typestore: Typestore = typestore
+        self._typestore: Typestore = (
+            typestore_or_distro
+            if isinstance(typestore_or_distro, Typestore)
+            else get_typestore(typestore_or_distro)
+        )
         """The typestore used for message type resolution."""
         self._serialization_formats: Dict[str, SerializationFormat] = (
             serialization_formats or {}
@@ -647,27 +651,63 @@ class MosaicoLoader(_BaseROSTopicResolver):
     Conforms to the :class:`Loader` protocol, making it usable with
     :class:`ProgressManager` for live progress reporting.
 
-    Args:
-        m_client (MosaicoClient): An open :class:`MosaicoClient` connection.
-        typestore (Typestore): The ROS typestore containing the registered ROS messages.
-        sequence_name (str): Name of the Mosaico sequence to load.
-        topics (Optional[Union[str, List[str]]]): Optional topic-name filter patterns (glob-style, ``!``-prefixed for
-            exclusions). ``None`` loads all topics.
-        start_timestamp_ns (Optional[int]): Lower bound for the time window (nanoseconds). Clipped
-            to the sequence minimum if out of range.
-        end_timestamp_ns (Optional[int]): Upper bound for the time window (nanoseconds). Clipped to
-            the sequence maximum if out of range.
+    Note: `MosaicoLoader` does not itself consult the [`ROSTypeRegistry`][mosaicolabs.ros_bridge.ROSTypeRegistry].
+        Resolving `ros_distro`/`custom_msgs` into a concrete `Typestore` (including any custom
+        `.msg` registration) is the caller's responsibility — [`ROSSequenceExtractor`][mosaicolabs.ros_bridge.ROSSequenceExtractor]
+        does this internally before constructing a `MosaicoLoader`.
     """
 
     def __init__(
         self,
         m_client: MosaicoClient,
-        typestore: Typestore,
+        typestore_or_distro: Typestore | Stores,
         sequence_name: str,
         topics: Optional[List[str]] = None,
         start_timestamp_ns: Optional[int] = None,
         end_timestamp_ns: Optional[int] = None,
     ):
+        """
+        Initializes the loader against a Mosaico sequence, using a caller-supplied
+        `Typestore` or ROS distro to resolve adapters and ROS message types.
+
+        `MosaicoLoader` performs no `ROSTypeRegistry` lookups itself — pass in a `Typestore`
+        that already has any custom `.msg` definitions registered (e.g. via
+        `get_typestore(ros_distro)` plus `Typestore.register(...)`, or the `Typestore`
+        that `ROSSequenceExtractor` builds internally from `ROSExtractorConfig.ros_distro`/
+        `custom_msgs`), needed when a topic's `_ros_.msgdef` isn't available to auto-register
+        the type (e.g. the sequence wasn't ingested from a ROS bag in the first place).
+
+        Example:
+            ```python
+            from rosbags.typesys import Stores
+            from mosaicolabs import MosaicoClient
+            from mosaicolabs.ros_bridge import MosaicoLoader
+
+            with MosaicoClient.connect("localhost", 6726) as client:
+                # Stream only IMU and GPS topics back out of a sequence
+                with MosaicoLoader(
+                    m_client=client,
+                    typestore_or_distro=Stores.ROS2_HUMBLE,
+                    sequence_name="on_track_experiment",
+                    topics=["/imu*", "/gps/fix"],
+                ) as loader:
+                    for topic, ms_msg in loader:
+                        print(f"Read {topic} @ {ms_msg.timestamp_ns}")
+            ```
+
+        Args:
+            m_client (MosaicoClient): An open :class:`MosaicoClient` connection.
+            typestore_or_distro (Typestore | Stores): A pre-built `Typestore` (e.g. one
+                already carrying custom `.msg` registrations), or a `Stores` distro to
+                resolve a fresh, empty typestore for via `get_typestore()`.
+            sequence_name (str): Name of the Mosaico sequence to load.
+            topics (Optional[Union[str, List[str]]]): Optional topic-name filter patterns (glob-style, ``!``-prefixed for
+                exclusions). ``None`` loads all topics.
+            start_timestamp_ns (Optional[int]): Lower bound for the time window (nanoseconds). Clipped
+                to the sequence minimum if out of range.
+            end_timestamp_ns (Optional[int]): Upper bound for the time window (nanoseconds). Clipped to
+                the sequence maximum if out of range.
+        """
 
         super().__init__(
             container_type=list[str]
@@ -675,7 +715,11 @@ class MosaicoLoader(_BaseROSTopicResolver):
 
         self._client = m_client
         """The MosaicoClient used to fetch sequence data and metadata."""
-        self._typestore: Typestore = typestore
+        self._typestore: Typestore = (
+            typestore_or_distro
+            if isinstance(typestore_or_distro, Typestore)
+            else get_typestore(typestore_or_distro)
+        )
         """The ROS typestore containing the registered ROS messages. Used for adapter resolution."""
         self._sequence_name = sequence_name
         """The name of the Mosaico sequence to load."""

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
@@ -238,15 +238,18 @@ class ROSLoader(_BaseROSTopicResolver):
     Unified loader for reading and deserializing ROS 1 (.bag) and ROS 2 (.mcap, .db3) data.
 
     The `ROSLoader` acts as a resource manager that abstracts the underlying `rosbags` library.
-    It provides a standardized Pythonic interface for filtering topics, managing custom message
-    registries, and streaming data into the Mosaico adaptation pipeline.
+    It provides a standardized Pythonic interface for filtering topics and streaming data
+    into the Mosaico adaptation pipeline, against a caller-supplied `Typestore`.
 
+    Note: `ROSLoader` does not itself consult the [`ROSTypeRegistry`][mosaicolabs.ros_bridge.ROSTypeRegistry].
+        Resolving `ros_distro`/`custom_msgs` into a concrete `Typestore` (including any custom
+        `.msg` registration) is the caller's responsibility — [`RosbagInjector`][mosaicolabs.ros_bridge.RosbagInjector]
+        does this internally before constructing a `ROSLoader`.
 
     ### Key Features
     * **Multi-Format Support**: Automatically detects and handles ROS 1 and ROS 2 bag containers.
     * **Semantic Filtering**: Supports glob-style patterns (e.g., `/sensors/*`, `*camera_info`) to include relevant data channels,
         with `!`-prefixed patterns for exclusion (e.g., `!/sensors/debug*`). Patterns are evaluated in ORDER (gitignore-like semantics).
-    * **Dynamic Schema Resolution**: Integrates with the [`ROSTypeRegistry`][mosaicolabs.ros_bridge.ROSTypeRegistry] to resolve proprietary message types on-the-fly.
     * **Configurable Serialization**: Non-adapted message types can be assigned a specific
         [`SerializationFormat`][mosaicolabs.enum.serialization_format.SerializationFormat] via `serialization_formats`,
         overriding the `SerializationFormat.Default` used otherwise.
@@ -266,15 +269,17 @@ class ROSLoader(_BaseROSTopicResolver):
         serialization_formats: Optional[Dict[str, SerializationFormat]] = None,
     ):
         """
-        Initializes the loader and prepares the type registry.
+        Initializes the loader against a caller-supplied, already-resolved `Typestore`.
 
-        Upon initialization, the loader merges the global definitions from the
-        [`ROSTypeRegistry`][mosaicolabs.ros_bridge.ROSTypeRegistry]
-        with any `custom_types` provided specifically for this session.
+        `ROSLoader` performs no `ROSTypeRegistry` lookups itself — pass in a `Typestore`
+        that already has any custom `.msg` definitions registered (e.g. via
+        `get_typestore(ros_distro)` plus `Typestore.register(...)`, or the `Typestore`
+        that `RosbagInjector` builds internally from `ROSInjectionConfig.ros_distro`/
+        `custom_msgs`).
 
         Example:
             ```python
-            from rosbags.typesys import Stores
+            from rosbags.typesys import Stores, get_typestore
             from mosaicolabs.enum.serialization_format import SerializationFormat
             from mosaicolabs.ros_bridge import ROSLoader
 
@@ -282,7 +287,7 @@ class ROSLoader(_BaseROSTopicResolver):
             with ROSLoader(
                 file_path="mission_01.mcap",
                 topics=["/imu*", "/gps/fix"],
-                typestore_name=Stores.ROS2_HUMBLE,
+                typestore=get_typestore(Stores.ROS2_HUMBLE),
                 # Non-adapted (Unmodeled) messages of this type will be
                 # serialized as Ragged instead of the Default format
                 serialization_formats={
@@ -548,7 +553,7 @@ class ROSLoader(_BaseROSTopicResolver):
 
         Example:
             ```python
-            with ROSLoader(file_path="data.mcap") as loader:
+            with ROSLoader(file_path="data.mcap", typestore=get_typestore(Stores.EMPTY)) as loader:
                 for topic, msg_type in zip(loader.topics, loader.msg_types):
                     print(f"Topic {topic} requires schema: {msg_type}")
             ```

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
@@ -214,7 +214,7 @@ class _BaseROSTopicResolver(ABC):
         rejected += self._extra_rejected_topics()
         return rejected
 
-    def resolve_adapter(self, topic_name: str) -> Optional[type]:
+    def resolve_adapter(self, topic_name: str) -> Optional[type[ROSAdapterBase]]:
         """
         Returns the resolved adapter for an accepted topic.
 

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
@@ -8,21 +8,11 @@ from typing import (
     Iterable,
     List,
     Optional,
-    Protocol,
     Tuple,
     Type,
     Union,
 )
 
-from rich.progress import (
-    BarColumn,
-    MofNCompleteColumn,
-    Progress,
-    TaskID,
-    TextColumn,
-    TimeElapsedColumn,
-    TimeRemainingColumn,
-)
 from rosbags.highlevel import AnyReader
 from rosbags.interfaces import Connection, TopicInfo
 from rosbags.typesys import Stores, get_types_from_msg, get_typestore
@@ -95,36 +85,6 @@ class TopicStatus(Enum):
             TopicStatus.MALFORMED_METADATA: "red1",
         }
         return _colors.get(self, "bright_red")
-
-
-class Loader(Protocol):
-    """
-    Structural protocol for data loaders consumed by :class:`ProgressManager`.
-
-    Both :class:`ROSLoader` and :class:`MosaicoLoader` satisfy this protocol,
-    allowing :class:`ProgressManager` to set up progress bars without depending
-    on a concrete loader class.
-    """
-
-    @property
-    def topics(self) -> List[str]:
-        """This should return the Mosaico compatible topics of the loaded data as strings"""
-        ...
-
-    @property
-    def resolved_topics(self) -> List[str]:
-        """This should return **all** the topics of the loaded data as strings"""
-        ...
-
-    @property
-    def rejected_topics(self) -> List[Tuple[str, TopicStatus]]:
-        """This should return a list of tuples containing all the rejected topic names, and the rejection reason (topic_name, topic_status)"""
-        ...
-
-    def msg_count(self, topic: Optional[str] = None) -> int:
-        """This should return the total number of messages in the passed
-        topic if not None. Otherwise returns all messages in all topics"""
-        ...
 
 
 # --- Shared Topic Resolution/Rejection Bookkeeping ---
@@ -272,105 +232,6 @@ class _BaseROSTopicResolver(ABC):
             return None
 
         return self._topic_cached_adapters.get(topic_name)
-
-
-# --- UI / Progress Helper ---
-
-
-class ProgressManager:
-    """
-    Visual management system for loader tracking.
-
-    This class decouples the UI presentation logic from the data processing pipeline.
-    It utilizes the `rich` library to provide real-time feedback through progress bars,
-    tracking individual topic throughput and aggregate global progress.
-
-
-    Methods:
-        setup(): Initializes the progress tracking tasks by querying message counts from the loader.
-        update_status(topic, status, style): Modifies the label of a specific topic bar.
-        advance_global(): Increments the master progress bar without affecting individual topic bars.
-        advance_all(topic): Increments both the specific topic task and the global master task.
-    """
-
-    def __init__(self, loader: Loader):
-        """
-        Initialize the progress manager.
-
-        Args:
-            loader (Loader): The initialized data loader. Used to query total
-                                message counts for setting up progress bars.
-        """
-        self.loader = loader
-        self.progress = Progress(
-            TextColumn("[bold cyan]{task.fields[name]}"),
-            BarColumn(),
-            MofNCompleteColumn(),
-            "[progress.percentage]{task.percentage:>3.1f}%",
-            "•",
-            TimeRemainingColumn(),
-            "•",
-            TimeElapsedColumn(),
-            expand=True,
-        )
-        self.tasks: Dict[str, TaskID] = {}
-        self.global_task: Optional[TaskID] = None
-
-    def setup(self):
-        """
-        Calculates totals and creates the visual progress tasks.
-        Must be called before the main processing loop starts.
-        """
-        # Create individual progress bars for each topic but count only the accepted ones
-        for topic_name in self.loader.resolved_topics:
-            if topic_name in self.loader.topics:
-                count = self.loader.msg_count(topic_name)
-            else:
-                count = None
-
-            self.tasks[topic_name] = self.progress.add_task(
-                "", total=count, name=topic_name
-            )
-
-        # Rejected topics (with rejected reason) are highlighted
-        for topic_name, topic_status in self.loader.rejected_topics:
-            self.update_status(
-                topic_name, topic_status.value, topic_status.display_color()
-            )
-
-        # Create a master progress bar for the aggregate total of the accepted topics
-        total_msgs = sum(self.loader.msg_count(t) for t in self.loader.topics)
-        self.global_task = self.progress.add_task(
-            "Total", total=total_msgs, name="Total Upload"
-        )
-
-    def update_status(self, topic: str, status: str, style: str = "white"):
-        """
-        Updates the text description of a specific topic's progress bar.
-        Useful for indicating errors or skipped topics (e.g. "[red]Unresolved Adapter").
-
-        Args:
-            topic (str): The topic name.
-            status (str): The status message to display.
-            style (str): The rich style string (e.g., 'red', 'bold yellow').
-        """
-        if topic in self.tasks:
-            self.progress.update(
-                self.tasks[topic],
-                name=f"[{style}]{topic}: {status}",
-            )
-
-    def advance_global(self):
-        """Advances only the global progress bar (used when skipping messages)."""
-        if self.global_task is not None:
-            self.progress.advance(self.global_task)
-
-    def advance_all(self, topic: str):
-        """Advances both the specific topic's bar and the global bar."""
-        if topic in self.tasks:
-            self.progress.advance(self.tasks[topic])
-        if self.global_task is not None:
-            self.progress.advance(self.global_task)
 
 
 class ROSLoader(_BaseROSTopicResolver):

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
@@ -557,7 +557,7 @@ class ROSLoader(_BaseROSTopicResolver):
 
         Example:
             ```python
-            with ROSLoader(file_path="data.mcap", typestore=get_typestore(Stores.EMPTY)) as loader:
+            with ROSLoader(file_path="data.mcap", typestore_or_distro=get_typestore(Stores.EMPTY)) as loader:
                 for topic, msg_type in zip(loader.topics, loader.msg_types):
                     print(f"Topic {topic} requires schema: {msg_type}")
             ```

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/loader.py
@@ -1,7 +1,18 @@
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Optional, Protocol, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Protocol,
+    Tuple,
+    Type,
+    Union,
+)
 
 from rich.progress import (
     BarColumn,
@@ -148,7 +159,19 @@ class _BaseROSTopicResolver(ABC):
     _accepted_topics: Any
     _unresolved_adapter_topics: Any
     _filtered_topics: Any
-    _topic_cached_adapters: Dict[str, type]
+    _topic_cached_adapters: Dict[str, Type[ROSAdapterBase]]
+
+    def __init__(self, container_type: Type[Iterable]):
+        self._resolved_topics = container_type()
+        """The full set of canonical topic names in the underlying source (dict or list; only the keys/elements are read by this base class)."""
+        self._accepted_topics = container_type()
+        """The set of topic names that passed filtering and adapter resolution (dict or list; only the keys/elements are read by this base class)."""
+        self._unresolved_adapter_topics = container_type()
+        """The set of topic names that have no resolvable Mosaico adapter (dict or list; only the keys/elements are read by this base class)."""
+        self._filtered_topics = container_type()
+        """The set of topic names that are excluded by the user's `topics` filter (dict or list; only the keys/elements are read by this base class)."""
+        self._topic_cached_adapters: dict[str, type[ROSAdapterBase]] = {}
+        """Dictionary mapping accepted topic names to their resolved Mosaico adapter class."""
 
     @abstractmethod
     def _ensure_resolved(self) -> None:
@@ -426,6 +449,9 @@ class ROSLoader(_BaseROSTopicResolver):
                 adapter. Message types not present in this mapping default to `SerializationFormat.Default`.
         """
 
+        super().__init__(
+            container_type=dict[str, TopicInfo]
+        )  # Initialize the base class to set up topic resolution state
         self._file_path = Path(file_path)
         self._validate_file()
 
@@ -439,25 +465,6 @@ class ROSLoader(_BaseROSTopicResolver):
         # State
         self._reader: Optional[AnyReader] = None
         self._connections: List[Connection] = []
-        self._resolved_topics: Dict[
-            str, TopicInfo
-        ] = {}  # The full topics set contained in the rosbag
-
-        self._accepted_topics: Dict[
-            str, TopicInfo
-        ] = {}  # The actual topics matched after globbing
-
-        self._unresolved_adapter_topics: Dict[
-            str, TopicInfo
-        ] = {}  # The topics whose ontology type is not resolved (neither adapted nor message defition available)
-
-        self._filtered_topics: Dict[
-            str, TopicInfo
-        ] = {}  # The topics which message type are filtered by user
-
-        self._topic_cached_adapters: dict[
-            str, type[ROSAdapterBase]
-        ] = {}  # Dictionary containing a map from moisaco accepted topics to mosaico adapter
 
         # Register Global Types (Registry Pattern)
         global_types = ROSTypeRegistry.get_types(typestore_name)
@@ -818,45 +825,42 @@ class MosaicoLoader(_BaseROSTopicResolver):
         end_timestamp_ns: Optional[int] = None,
     ):
 
+        super().__init__(
+            container_type=list[str]
+        )  # Initialize the base class to set up topic resolution state
+
         self.client = m_client
+        """The MosaicoClient used to fetch sequence data and metadata."""
         self.typestore: Typestore = typestore
+        """The ROS typestore containing the registered ROS messages. Used for adapter resolution."""
         self.sequence_name = sequence_name
+        """The name of the Mosaico sequence to load."""
         self.topic_glob_pattern = topics
+        """Optional list of topic-name filter patterns (glob-style, ``!``-prefixed for exclusions)."""
         self.start_timestamp_ns = start_timestamp_ns
+        """Lower bound for the time window (nanoseconds). Clipped to the sequence minimum if out of range."""
         self.end_timestamp_ns = end_timestamp_ns
-
+        """Upper bound for the time window (nanoseconds). Clipped to the sequence maximum if out of range."""
         self.seq_handler: Optional[SequenceHandler] = None
+        """The mosaico sequence handler, lazily initialized on first access."""
         self.streamer: Optional[SequenceDataStreamer] = None
+        """The mosaico sequence streamer, lazily initialized on first access. Provides an iterator over the sequence messages."""
 
-        self._resolved_topics: list[
-            str
-        ] = []  # The full topics set contained in the sequence
-
-        self._accepted_topics: list[
-            str
-        ] = []  # The actual topics matched after globbing
-
-        self._unresolved_adapter_topics: list[
-            str
-        ] = []  # The topics whose ontology type is not resolved (neither adapted nor message defition available)
-
-        self._unregistered_topics: list[
-            str
-        ] = []  # The topics whose message type is not present within the typestore
-
-        self._malformed_metadata_topics: list[
-            str
-        ] = []  # The topics whose '_ros_' metadata is malformed
-
-        self._filtered_topics: list[str] = []  # The topics filtered by user
-
-        self._topic_ros_metadata: dict[
-            str, Any
-        ] = {}  # Dictionary containing a map from moisaco accepted topics to ros specific metadata (extracted from Mosaico topics)
-
-        self._topic_cached_adapters: dict[
-            str, type[ROSAdapterBase]
-        ] = {}  # Dictionary containing a map from moisaco accepted topics to mosaico adapter
+        # Additional rejection buckets for Mosaico-specific reasons
+        self._unregistered_topics: list[str] = []
+        """
+        The topics whose message type is not present within the typestore.
+        These topics are rejected because their ROS message type cannot be deserialized without a registered schema.
+        """
+        self._malformed_metadata_topics: list[str] = []
+        """
+        The topics whose '_ros_' metadata is malformed.
+        These topics are rejected because their metadata does not contain the required 'msgtype' or 'msgdef' fields.
+        """
+        self._topic_ros_metadata: dict[str, Any] = {}
+        """Dictionary containing a map from Mosaico accepted topics to their extracted ROS metadata (from '_ros_' field)."""
+        self._topic_cached_adapters: dict[str, type[ROSAdapterBase]] = {}
+        """Dictionary containing a map from Mosaico accepted topics to their resolved Mosaico adapter class."""
 
     def _get_or_create_adapter(
         self, t_handler: TopicHandler
@@ -1027,13 +1031,13 @@ class MosaicoLoader(_BaseROSTopicResolver):
             except TypeError:
                 self._malformed_metadata_topics.append(t_name)
                 logger.warning(
-                    f"Skipping topic {t_name}: malformed metadata {t_handler.user_metadata}."
+                    f"Skipping topic '{t_name}': malformed metadata {t_handler.user_metadata}."
                 )
                 continue
 
             if not adapter:
                 logger.warning(
-                    f"Skipping topic {t_name}: not-adapted ontology {t_handler.ontology_tag}."
+                    f"Skipping topic '{t_name}': not-adapted ontology '{t_handler.ontology_tag}'."
                 )
                 self._unresolved_adapter_topics.append(t_name)
                 continue
@@ -1044,7 +1048,7 @@ class MosaicoLoader(_BaseROSTopicResolver):
 
             if self.typestore.types.get(rosmsg_type) is None:
                 logger.warning(
-                    f"Skipping topic {t_name}: {rosmsg_type} not present in ROS typestore."
+                    f"Skipping topic '{t_name}': '{rosmsg_type}' not present in ROS typestore."
                 )
                 self._unregistered_topics.append(t_name)
                 continue

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/registry.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/registry.py
@@ -1,19 +1,23 @@
 """
 ROS Message Type Registry.
 
-This module provides the central configuration point for the ROS Bridge.
-It implements a **Context-Aware Singleton Registry** that manages custom message definitions.
+This module provides a small, self-contained registry of custom ROS message
+definitions, used by [`RosbagInjector`][mosaicolabs.ros_bridge.RosbagInjector] and
+[`ROSSequenceExtractor`][mosaicolabs.ros_bridge.ROSSequenceExtractor] to build the
+`Typestore` they hand to their respective loader.
 
 ROS message definitions (`.msg`) are not self-contained; they depend on the specific
 ROS distribution (e.g., `std_msgs/Header` differs between ROS 1 and ROS 2).
-A naive global registry causes conflicts when analyzing data from mixed sources.
 
-This registry stores definitions in "Profiles" ([`rosbags.typesys.Stores`](https://ternaris.gitlab.io/rosbags/topics/typesys.html#type-stores)).
+Each `ROSTypeRegistry` instance stores definitions in "Profiles" ([`rosbags.typesys.Stores`](https://ternaris.gitlab.io/rosbags/topics/typesys.html#type-stores)).
 1.  **GLOBAL Profile**: Definitions shared across all versions (e.g., simple custom types).
 2.  **Scoped Profiles**: Definitions valid only for a specific typestore (e.g., `Stores.ROS1_NOETIC`).
 
-When a `ROSDataLoader` is initialized, it requests a merged view of the Global + Scoped
-definitions relevant to its specific data file.
+`RosbagInjector`/`ROSSequenceExtractor` each own a private, freshly-created instance by
+default — so registering custom types for one run never leaks into another. To share
+definitions across multiple injector/extractor runs (e.g. a centralized setup routine
+covering hundreds of proprietary types), construct one `ROSTypeRegistry()` yourself and
+pass that same instance to every config's `registry` field.
 """
 
 from collections import defaultdict
@@ -30,15 +34,23 @@ logger = get_logger(__name__)
 
 class ROSTypeRegistry:
     """
-    A context-aware singleton registry for custom ROS message definitions.
+    A context-aware registry for custom ROS message definitions.
 
     ROS message definitions (`.msg`) are not self-contained; they often vary between
     distributions (e.g., `std_msgs/Header` has different fields in ROS 1 Noetic vs. ROS 2 Humble).
-    The `ROSTypeRegistry` resolves this by implementing a **Context-Aware Singleton** that
-    organizes schemas into "Profiles" ([`rosbags.typesys.Stores`](https://ternaris.gitlab.io/rosbags/topics/typesys.html#type-stores)).
+    `ROSTypeRegistry` resolves this by organizing schemas into "Profiles"
+    ([`rosbags.typesys.Stores`](https://ternaris.gitlab.io/rosbags/topics/typesys.html#type-stores)).
+
+    Each instance is independent. By default, [`RosbagInjector`][mosaicolabs.ros_bridge.RosbagInjector]
+    and [`ROSSequenceExtractor`][mosaicolabs.ros_bridge.ROSSequenceExtractor] each construct
+    their own private instance, so one run's custom types can never leak into another's
+    in the same process. To deliberately share a set of definitions across many runs,
+    construct a single instance and pass it explicitly wherever it should apply (e.g. via
+    each config's `registry` field) — that explicit passing is the only way definitions
+    become visible outside the instance they were registered on.
 
     ### Why Use a Registry?
-    * **Conflict Resolution**: Prevents name collisions when processing data from mixed ROS 1 and ROS 2 sources in the same environment.
+    * **Conflict Resolution**: Keeps custom types registered for one injector/extractor run from silently affecting another's, even within the same process.
     * **Proprietary Support**: Allows the system to ingest non-standard messages (e.g., custom robot state or specialized sensor payloads).
     * **Cascading Logic**: Implements an "Overlay" mechanism where global definitions provide a baseline, and distribution-specific definitions provide high-precision overrides.
 
@@ -48,35 +60,37 @@ class ROSTypeRegistry:
             and the second level maps the **Message Type** to its raw **Definition String**.
     """
 
-    # Internal storage.
-    # Key: Store Name (e.g. "GLOBAL", "ros2_foxy")
-    # Value: Dict[MsgType, Definition]
-    _registry: Dict[str, Dict[str, str]] = defaultdict(dict)
+    def __init__(self):
+        # Internal storage.
+        # Key: Store Name (e.g. "GLOBAL", "ros2_foxy")
+        # Value: Dict[MsgType, Definition]
+        self._registry: Dict[str, Dict[str, str]] = defaultdict(dict)
 
-    @classmethod
     def register(
-        cls,
+        self,
         msg_type: str,
         source: Union[str, Path],
         store: Optional[Union[Stores, str]] = None,
     ):
         """
-        Registers a single custom message type into the registry.
+        Registers a single custom message type into this registry instance.
 
         This is the primary method for adding individual schema definitions. The `source`
         can be a physical file path or a raw string containing the ROS `.msg` syntax.
 
         Example:
             ```python
+            registry = ROSTypeRegistry()
+
             # Register a proprietary battery message for a specific distro
-            ROSTypeRegistry.register(
+            registry.register(
                 msg_type="limo_msgs/msg/BatteryState",
                 source=Path("./msgs/BatteryState.msg"),
                 store=Stores.ROS2_HUMBLE
             )
 
             # Register a simple custom type globally using a raw string
-            ROSTypeRegistry.register(
+            registry.register(
                 msg_type="custom_msgs/msg/SimpleFlag",
                 source="bool flag_active\\nstring label"
             )
@@ -86,7 +100,7 @@ class ROSTypeRegistry:
             msg_type (str): The canonical ROS type name (e.g., "package/msg/TypeName").
             source (Union[str, Path]): A `Path` object to a `.msg` file or a raw text string of the definition.
             store (Optional[Union[Stores, str]]): The target scope. If `None`, the definition is stored in the **GLOBAL** profile
-                and becomes available to all loaders regardless of their distribution.
+                and becomes available regardless of the distribution requested via `get_types()`.
 
         Raises:
             FileNotFoundError: If `source` is a `Path` that does not exist on the filesystem.
@@ -94,7 +108,7 @@ class ROSTypeRegistry:
         """
         try:
             # Resolve input to raw text string
-            definition = cls._resolve_source(source)
+            definition = self._resolve_source(source)
 
             # Determine the registry key (Profile)
             # Convert enum to string if necessary to ensure consistent keys
@@ -102,7 +116,7 @@ class ROSTypeRegistry:
 
             # Store definition
             # Overwrites existing definition if the same type is registered twice in the same scope
-            cls._registry[key][msg_type] = definition
+            self._registry[key][msg_type] = definition
 
             logger.debug(f"Registered custom type '{msg_type}' for scope: '{key}'")
 
@@ -110,9 +124,8 @@ class ROSTypeRegistry:
             logger.error(f"Failed to register type '{msg_type}': '{e}'")
             raise
 
-    @classmethod
     def register_directory(
-        cls,
+        self,
         package_name: str,
         dir_path: Union[str, Path],
         store: Optional[Union[Stores, str]] = None,
@@ -127,7 +140,8 @@ class ROSTypeRegistry:
         Example:
             ```python
             # Register all messages in a local workspace for ROS1
-            ROSTypeRegistry.register_directory(
+            registry = ROSTypeRegistry()
+            registry.register_directory(
                 package_name="robot_logic",
                 dir_path="./src/robot_logic/msg",
                 store=Stores.ROS1_NOETIC
@@ -154,14 +168,13 @@ class ROSTypeRegistry:
             # filename "MyData.msg" -> type "MyData"
             type_name = f"{package_name}/msg/{msg_file.stem}"
 
-            cls.register(type_name, msg_file, store=store)
+            self.register(type_name, msg_file, store=store)
             count += 1
 
         if count == 0:
             logger.warning(f"No .msg files found in '{path}'.")
 
-    @classmethod
-    def get_types(cls, store: Optional[Union[Stores, str]]) -> Dict[str, str]:
+    def get_types(self, store: Optional[Union[Stores, str]]) -> Dict[str, str]:
         """
         Retrieves a merged view of message definitions for a specific distribution.
 
@@ -182,27 +195,26 @@ class ROSTypeRegistry:
         """
         # Start with Global defaults
         # We use .copy() to ensure we don't accidentally mutate the registry itself
-        merged = cls._registry["GLOBAL"].copy()
+        merged = self._registry["GLOBAL"].copy()
 
         if store:
             store_key = str(store)
             # Override
-            if store_key in cls._registry:
-                specific_types = cls._registry[store_key]
+            if store_key in self._registry:
+                specific_types = self._registry[store_key]
                 # Update merges keys, overwriting globals if duplicates exist
                 merged.update(specific_types)
 
         return merged
 
-    @classmethod
-    def reset(cls):
+    def reset(self):
         """
-        Completely clears the singleton registry.
+        Completely clears this registry instance.
 
         This is primarily used for **Unit Testing** and CI/CD pipelines to ensure
         total isolation between different test cases.
         """
-        cls._registry.clear()
+        self._registry.clear()
 
     @staticmethod
     def _resolve_source(source: Union[str, Path]) -> str:

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/ros_message.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/ros_message.py
@@ -148,8 +148,7 @@ class ROSMessage:
             standard nested Python dictionary.
         const_data (Dict[str, Any]): The message constants (e.g. `uint8 STATUS_FIX=0`)
             declared at the top level of the message, keyed by their `UPPER_CASE` name.
-        header (Optional[ROSHeader]): An automatically parsed `ROSHeader` if the
-            `data_field` payload contains a valid header field.
+        header (Optional[ROSHeader]): The message payload header, if present.
     """
 
     def __init__(
@@ -160,6 +159,16 @@ class ROSMessage:
         data: Optional[Dict[str, Any]],
         const_data: Optional[Dict[str, Any]] = None,
     ):
+        """
+        Initializes a new ROSMessage instance.
+
+        Args:
+            bag_timestamp_ns (int): The timestamp (in nanoseconds) when the message was written to the rosbag.
+            topic (str): The topic string of the message source.
+            msg_type (str): The message ROS type string.
+            data (Optional[Dict[str, Any]]): The message payload, converted into a standard nested Python dictionary.
+            const_data (Optional[Dict[str, Any]]): The message's top-level constants, keyed by their `UPPER_CASE` name.
+        """
         self.bag_timestamp_ns = bag_timestamp_ns
         self.topic = topic
         self.msg_type = msg_type

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
@@ -18,7 +18,7 @@ import argparse
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Type, Union
 
 from rich.live import Live
 from rosbags.interfaces import Connection
@@ -29,6 +29,7 @@ from rosbags.typesys.store import Typestore
 
 from mosaicolabs import Message, MosaicoClient
 from mosaicolabs.logging_config import get_logger, setup_sdk_logging
+from mosaicolabs.ros_bridge.adapter_base import ROSAdapterBase
 from mosaicolabs.ros_bridge.loader import MosaicoLoader
 from mosaicolabs.ros_bridge.qos import get_qos_for_topic
 from mosaicolabs.ros_bridge.registry import ROSTypeRegistry
@@ -174,6 +175,17 @@ class ROSSequenceExtractor:
         self.accepted_connections: dict[str, Connection] = {}
         self.typestore: Typestore = get_typestore(self.cfg.ros_distro or Stores.EMPTY)
         self.mosaico_loader: Optional[MosaicoLoader] = None
+
+        # Register custom ROS messages to ROSTypeRegistry
+        self._register_custom_types()
+
+        # Register all ROS messages to typestore
+        custom_types = ROSTypeRegistry.get_types(self.cfg.ros_distro)
+        if custom_types:
+            logger.info(
+                f"Registering {list(custom_types.keys())} definitions to typestore..."
+            )
+            self._register_definitions(custom_types)
 
     def _register_custom_types(self):
         """
@@ -404,7 +416,14 @@ class ROSSequenceExtractor:
 
         ui.advance_all(t_name)
 
-    def _encode_ros_message(self, adapter, ms_msg, ros_msg_type, t_name, ui):
+    def _encode_ros_message(
+        self,
+        adapter: Type[ROSAdapterBase],
+        ms_msg: Message,
+        ros_msg_type: Optional[str],
+        t_name: str,
+        ui: ProgressManager,
+    ):
         try:
             return adapter.to_ros(ms_msg, self.typestore, ros_msg_type)
         except TypeError as e:
@@ -471,14 +490,6 @@ class ROSSequenceExtractor:
                 tls_cert_path=self.cfg.tls_cert_path,
             ) as mclient:
                 logger.info(f"Writing bag '{self.cfg.rosbag_path}'")
-
-                # Register custom ROS messages to ROSTypeRegistry
-                self._register_custom_types()
-
-                # Register all ROS messages to typestore
-                custom_types = ROSTypeRegistry.get_types(self.cfg.ros_distro)
-                if custom_types:
-                    self._register_definitions(custom_types)
 
                 # Creating the bagwriter
                 with self._open_or_get_mosaicoloader(mclient) as ms_loader:

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
@@ -29,9 +29,10 @@ from rosbags.typesys.store import Typestore
 
 from mosaicolabs import Message, MosaicoClient
 from mosaicolabs.logging_config import get_logger, setup_sdk_logging
-from mosaicolabs.ros_bridge.loader import MosaicoLoader, ProgressManager
+from mosaicolabs.ros_bridge.loader import MosaicoLoader
 from mosaicolabs.ros_bridge.qos import get_qos_for_topic
 from mosaicolabs.ros_bridge.registry import ROSTypeRegistry
+from mosaicolabs.ros_bridge.ui import ProgressManager
 
 # Set the hierarchical logger
 logger = get_logger(__name__)

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
@@ -91,6 +91,20 @@ class ROSExtractorConfig:
     package_name = "my_robot_msgs"; path = path/to/Location.msg; store = Stores.ROS2_HUMBLE (e.g.) or None
 
     See [`rosbags.typesys.Stores`](https://ternaris.gitlab.io/rosbags/topics/typesys.html#type-stores).
+
+    Registered into `registry` (or a fresh, private `ROSTypeRegistry` if `registry` is
+    `None`) before the loader's `Typestore` is built. Needed when encoding an ontology
+    value back to a ROS message whose `msgdef` isn't recoverable from the topic's own
+    `_ros_` metadata (e.g. the sequence wasn't ingested from a ROS bag in the first place).
+    """
+
+    registry: Optional[ROSTypeRegistry] = None
+    """
+    The `ROSTypeRegistry` instance to register `custom_msgs` into and to pull existing
+    definitions from. If `None` (default), a fresh, private instance is created for this
+    extractor alone — so its custom types can never leak into another injector/extractor
+    run in the same process. Pass the *same* `ROSTypeRegistry` instance across multiple
+    configs to deliberately share a centrally pre-registered set of definitions between them.
     """
 
     topics: Optional[list[str]] = None
@@ -184,27 +198,33 @@ class ROSSequenceExtractor:
         self.typestore: Typestore = get_typestore(self.cfg.ros_distro or Stores.EMPTY)
         self.mosaico_loader: Optional[MosaicoLoader] = None
 
+        # Own a private registry by default, so this extractor's custom types can never
+        # leak into another injector/extractor run in the same process. Pass the same
+        # `ROSTypeRegistry` instance via `cfg.registry` to deliberately share definitions
+        # across multiple runs (e.g. a centralized setup routine).
+        self._registry: ROSTypeRegistry = self.cfg.registry or ROSTypeRegistry()
+
         # Register custom ROS messages to the local typestore
         self._typestore_custom_msgtypes()
 
     def _typestore_custom_msgtypes(self):
         """
-        Registers any custom ROS message definitions provided in ``cfg.custom_msgs``,
-        and then registers the custom message definitions to the typestore.
+        Registers any custom ROS message definitions provided in ``cfg.custom_msgs``
+        into ``self._registry``, then pulls every definition currently registered there
+        (including ones registered elsewhere on a *shared* `cfg.registry` instance) into
+        the local typestore. Safe to always run: `self._registry` is either private to
+        this extractor, or an instance the caller explicitly chose to share.
         """
-        if not self.cfg.custom_msgs:
-            return
-
-        # Register Global Types (Registry Pattern)
-        logger.info("Registering custom message definitions...")
-        for package, path, store in self.cfg.custom_msgs:
-            try:
-                ROSTypeRegistry.register_directory(
-                    package_name=package, dir_path=path, store=store
-                )
-                logger.debug(f"Registered package '{package}' from '{path}'")
-            except Exception as e:
-                logger.error(f"Failed to register custom msgs at '{path}': '{e}'")
+        if self.cfg.custom_msgs:
+            logger.info("Registering custom message definitions...")
+            for package, path, store in self.cfg.custom_msgs:
+                try:
+                    self._registry.register_directory(
+                        package_name=package, dir_path=path, store=store
+                    )
+                    logger.debug(f"Registered package '{package}' from '{path}'")
+                except Exception as e:
+                    logger.error(f"Failed to register custom msgs at '{path}': '{e}'")
 
         self._register_definitions()
 
@@ -212,7 +232,7 @@ class ROSSequenceExtractor:
         """Safe registration wrapper."""
         from rosbags.typesys import get_types_from_msg
 
-        custom_types = ROSTypeRegistry.get_types(self.cfg.ros_distro)
+        custom_types = self._registry.get_types(self.cfg.ros_distro)
         if not custom_types:
             return
 

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
@@ -176,23 +176,13 @@ class ROSSequenceExtractor:
         self.typestore: Typestore = get_typestore(self.cfg.ros_distro or Stores.EMPTY)
         self.mosaico_loader: Optional[MosaicoLoader] = None
 
-        # Register custom ROS messages to ROSTypeRegistry
-        self._register_custom_types()
+        # Register custom ROS messages to the local typestore
+        self._typestore_custom_msgtypes()
 
-        # Register all ROS messages to typestore
-        custom_types = ROSTypeRegistry.get_types(self.cfg.ros_distro)
-        if custom_types:
-            logger.info(
-                f"Registering {list(custom_types.keys())} definitions to typestore..."
-            )
-            self._register_definitions(custom_types)
-
-    def _register_custom_types(self):
+    def _typestore_custom_msgtypes(self):
         """
-        Loads custom ROS message definitions into the global `ROSTypeRegistry`.
-
-        This enables the extractor to correctly deserialize proprietary message types
-        found within the bag file.
+        Registers any custom ROS message definitions provided in ``cfg.custom_msgs``,
+        and then registers the custom message definitions to the typestore.
         """
         if not self.cfg.custom_msgs:
             return
@@ -208,11 +198,20 @@ class ROSSequenceExtractor:
             except Exception as e:
                 logger.error(f"Failed to register custom msgs at '{path}': '{e}'")
 
-    def _register_definitions(self, types_map: dict[str, str]):
+        self._register_definitions()
+
+    def _register_definitions(self):
         """Safe registration wrapper."""
         from rosbags.typesys import get_types_from_msg
 
-        for msg_type, msg_def in types_map.items():
+        custom_types = ROSTypeRegistry.get_types(self.cfg.ros_distro)
+        if not custom_types:
+            return
+
+        logger.info(
+            f"Registering {list(custom_types.keys())} definitions to typestore..."
+        )
+        for msg_type, msg_def in custom_types.items():
             try:
                 add_types = get_types_from_msg(msg_def, msg_type)
                 self.typestore.register(add_types)

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
@@ -453,10 +453,9 @@ class ROSSequenceExtractor:
     ):
         try:
             return adapter.to_ros(ms_msg, self.typestore, ros_msg_type)
-        except TypeError as e:
+        except (TypeError, NotImplementedError) as e:
             return self._handle_encoding_error(
                 t_name,
-                ms_msg,
                 ui,
                 f"Could not encode to ros '{ms_msg.ontology_tag()}' type. "
                 f"Skipping the topic associated to this message. Reason: {e}",
@@ -465,7 +464,6 @@ class ROSSequenceExtractor:
         except KeyError as e:
             return self._handle_encoding_error(
                 t_name,
-                ms_msg,
                 ui,
                 f"Schema mismatch or partially adapted message type for "
                 f"'{ms_msg.ontology_tag()}'. Skipping the topic associated to this "
@@ -475,14 +473,15 @@ class ROSSequenceExtractor:
         except Exception as e:
             return self._handle_encoding_error(
                 t_name,
-                ms_msg,
                 ui,
                 f"Unexpected error while encoding '{ms_msg.ontology_tag()}' type. "
                 f"Skipping the topic associated to this message. Reason: {e}",
                 "Error occurred",
             )
 
-    def _handle_encoding_error(self, t_name, ms_msg, ui, log_message, status):
+    def _handle_encoding_error(
+        self, t_name: str, ui: ProgressManager, log_message: str, status: str
+    ):
         self.ignored_topics.add(t_name)
         logger.error(log_message)
         ui.update_status(t_name, status, style="red")

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
@@ -338,15 +338,8 @@ class ROSSequenceExtractor:
         # --- Translate Check ---
         ros_msg_type = self.mosaico_loader.resolve_rosmsg_type(t_name)
 
-        try:
-            ros_msg = adapter.to_ros(ms_msg, self.typestore, ros_msg_type)
-        except TypeError as e:
-            self.ignored_topics.add(t_name)
-            logger.warning(
-                f"Could not encode to ros '{ms_msg.ontology_tag()}' type because: {e}. Skipping the topic associated to this message"
-            )
-            ui.update_status(t_name, "Failed encoding", style="yellow")
-            ui.advance_global()
+        ros_msg = self._encode_ros_message(adapter, ms_msg, ros_msg_type, t_name, ui)
+        if ros_msg is None:
             return
 
         # --- Resolve Check ---
@@ -410,6 +403,45 @@ class ROSSequenceExtractor:
             return
 
         ui.advance_all(t_name)
+
+    def _encode_ros_message(self, adapter, ms_msg, ros_msg_type, t_name, ui):
+        try:
+            return adapter.to_ros(ms_msg, self.typestore, ros_msg_type)
+        except TypeError as e:
+            return self._handle_encoding_error(
+                t_name,
+                ms_msg,
+                ui,
+                f"Could not encode to ros '{ms_msg.ontology_tag()}' type. "
+                f"Skipping the topic associated to this message. Reason: {e}",
+                "Failed encoding",
+            )
+        except KeyError as e:
+            return self._handle_encoding_error(
+                t_name,
+                ms_msg,
+                ui,
+                f"Schema mismatch or partially adapted message type for "
+                f"'{ms_msg.ontology_tag()}'. Skipping the topic associated to this "
+                f"message. Reason: {e}",
+                "Schema mismatch",
+            )
+        except Exception as e:
+            return self._handle_encoding_error(
+                t_name,
+                ms_msg,
+                ui,
+                f"Unexpected error while encoding '{ms_msg.ontology_tag()}' type. "
+                f"Skipping the topic associated to this message. Reason: {e}",
+                "Error occurred",
+            )
+
+    def _handle_encoding_error(self, t_name, ms_msg, ui, log_message, status):
+        self.ignored_topics.add(t_name)
+        logger.error(log_message)
+        ui.update_status(t_name, status, style="red")
+        ui.advance_global()
+        return None
 
     def run(self):
         """

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/sequence_extractor.py
@@ -140,6 +140,14 @@ class ROSExtractorConfig:
     overwrite: bool = False
     """If True, delete and recreate the rosbag path if it already exists. Defaults to False."""
 
+    dry_run: bool = False
+    """
+    If `True`, connects to the Mosaico server and reports which topics would be extracted
+    (and with which adapter/ROS message type), which topics would be rejected (and why), and
+    whether the output path already exists — without writing any bag file, and without
+    deleting an existing output path even if `overwrite=True`. Default: False.
+    """
+
 
 # --- Main Deinjector Class ---
 
@@ -461,6 +469,85 @@ class ROSSequenceExtractor:
         ui.advance_global()
         return None
 
+    def _dry_run_report(self):
+        """
+        Resolves the sequence's topics against the current configuration and prints a
+        report of what would be extracted, without writing a bag file or touching the
+        output path.
+
+        Reports, per topic: acceptance status, resolved adapter and ROS message type (or
+        rejection reason), and message count. Also reports whether the target output path
+        already exists and what `run()` would do about it (fail, or delete+recreate under
+        `overwrite=True`) — without actually deleting anything.
+        """
+        from rich.table import Table
+
+        logger.info(
+            f"[DRY RUN] Connecting to Mosaico at '{self.cfg.host}:{self.cfg.port}'..."
+        )
+
+        with MosaicoClient.connect(
+            host=self.cfg.host,
+            port=self.cfg.port,
+            api_key=self.cfg.mosaico_api_key,
+            enable_tls=self.cfg.enable_tls,
+            tls_cert_path=self.cfg.tls_cert_path,
+        ) as mclient:
+            with self._open_or_get_mosaicoloader(mclient) as ms_loader:
+                table = Table(
+                    title=f"Dry Run: sequence '{self.cfg.sequence_name}' -> '{self.cfg.rosbag_path}'"
+                )
+                table.add_column("Topic")
+                table.add_column("Status")
+                table.add_column("Adapter / ROS Type / Reason")
+                table.add_column("Messages", justify="right")
+
+                for topic in ms_loader.topics:
+                    adapter = ms_loader.resolve_adapter(topic)
+                    ros_msg_type = (
+                        ms_loader.resolve_rosmsg_type(topic)
+                        or adapter.get_default_ros_msg()
+                        if adapter
+                        else None
+                    )
+                    table.add_row(
+                        topic,
+                        "[bright_green]Accepted",
+                        f"{adapter.__name__ if adapter else '?'} -> {ros_msg_type or '?'}",
+                        str(ms_loader.msg_count(topic)),
+                    )
+
+                for topic, status in ms_loader.rejected_topics:
+                    table.add_row(
+                        topic,
+                        f"[{status.display_color()}]{status.value}",
+                        "-",
+                        "-",
+                    )
+
+                self.console.print(table)
+
+                rosbag_path = self.cfg.rosbag_path / self.cfg.sequence_name
+                if rosbag_path.exists():
+                    if self.cfg.overwrite:
+                        self.console.print(
+                            f"[yellow]Output path '{rosbag_path}' already exists and would "
+                            "be deleted and recreated (overwrite=True).[/yellow]"
+                        )
+                    else:
+                        self.console.print(
+                            f"[red]Output path '{rosbag_path}' already exists and "
+                            "overwrite=False: run() would raise FileExistsError.[/red]"
+                        )
+                else:
+                    self.console.print(f"Output path '{rosbag_path}' would be created.")
+
+                self.console.print(
+                    f"[bold]{len(ms_loader.topics)}[/bold] topic(s) would be extracted, "
+                    f"[bold]{len(ms_loader.rejected_topics)}[/bold] rejected. "
+                    "No bag file was written."
+                )
+
     def run(self):
         """
         Executes the full extraction pipeline.
@@ -475,7 +562,14 @@ class ROSSequenceExtractor:
 
         Progress is displayed in real-time via a ``rich`` live progress bar.
         A ``KeyboardInterrupt`` exits cleanly with a warning log.
+
+        If `self.cfg.dry_run` is `True`, delegates to `_dry_run_report()` and returns
+        without writing a bag file or touching the output path.
         """
+
+        if self.cfg.dry_run:
+            self._dry_run_report()
+            return
 
         # Create rosbag path and check whether it already exists
         rosbag_path = self._prepare_output_path()
@@ -597,6 +691,14 @@ def ros_sequence_extractor():
         default=False,
         help="Delete and recreate the rosbag path if it already exists",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Resolve topics/adapters/rejections and print a report, without connecting "
+            "the extraction pipeline to a bag writer or touching the output path."
+        ),
+    )
 
     parser.add_argument(
         "--log",
@@ -628,6 +730,7 @@ def ros_sequence_extractor():
         start_timestamp_ns=args.start_timestamp_ns,
         end_timestamp_ns=args.end_timestamp_ns,
         overwrite=args.overwrite,
+        dry_run=args.dry_run,
     )
 
     # --- Execution ---

--- a/mosaico-sdk-py/src/mosaicolabs/ros_bridge/ui.py
+++ b/mosaico-sdk-py/src/mosaicolabs/ros_bridge/ui.py
@@ -1,0 +1,143 @@
+from typing import Dict, List, Optional, Protocol, Tuple
+
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    TaskID,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+
+from .loader import TopicStatus
+
+
+# --- Generic Protocol for ProgressManager LoaderUIAPI ---
+class LoaderUIAPI(Protocol):
+    """
+    Structural protocol for data loaders consumed by :class:`ProgressManager`.
+
+    Both :class:`ROSLoader` and :class:`MosaicoLoader` satisfy this protocol,
+    allowing :class:`ProgressManager` to set up progress bars without depending
+    on a concrete loader class.
+    """
+
+    @property
+    def topics(self) -> List[str]:
+        """This should return the Mosaico compatible topics of the loaded data as strings"""
+        ...
+
+    @property
+    def resolved_topics(self) -> List[str]:
+        """This should return **all** the topics of the loaded data as strings"""
+        ...
+
+    @property
+    def rejected_topics(self) -> List[Tuple[str, TopicStatus]]:
+        """This should return a list of tuples containing all the rejected topic names, and the rejection reason (topic_name, topic_status)"""
+        ...
+
+    def msg_count(self, topic: Optional[str] = None) -> int:
+        """This should return the total number of messages in the passed
+        topic if not None. Otherwise returns all messages in all topics"""
+        ...
+
+
+# --- UI / Progress Helper ---
+
+
+class ProgressManager:
+    """
+    Visual management system for loader tracking.
+
+    This class decouples the UI presentation logic from the data processing pipeline.
+    It utilizes the `rich` library to provide real-time feedback through progress bars,
+    tracking individual topic throughput and aggregate global progress.
+
+
+    Methods:
+        setup(): Initializes the progress tracking tasks by querying message counts from the loader.
+        update_status(topic, status, style): Modifies the label of a specific topic bar.
+        advance_global(): Increments the master progress bar without affecting individual topic bars.
+        advance_all(topic): Increments both the specific topic task and the global master task.
+    """
+
+    def __init__(self, loader: LoaderUIAPI):
+        """
+        Initialize the progress manager.
+
+        Args:
+            loader (LoaderUIAPI): The initialized data loader. Used to query total
+                                message counts for setting up progress bars.
+        """
+        self.loader = loader
+        self.progress = Progress(
+            TextColumn("[bold cyan]{task.fields[name]}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            "[progress.percentage]{task.percentage:>3.1f}%",
+            "•",
+            TimeRemainingColumn(),
+            "•",
+            TimeElapsedColumn(),
+            expand=True,
+        )
+        self.tasks: Dict[str, TaskID] = {}
+        self.global_task: Optional[TaskID] = None
+
+    def setup(self):
+        """
+        Calculates totals and creates the visual progress tasks.
+        Must be called before the main processing loop starts.
+        """
+        # Create individual progress bars for each topic but count only the accepted ones
+        for topic_name in self.loader.resolved_topics:
+            if topic_name in self.loader.topics:
+                count = self.loader.msg_count(topic_name)
+            else:
+                count = None
+
+            self.tasks[topic_name] = self.progress.add_task(
+                "", total=count, name=topic_name
+            )
+
+        # Rejected topics (with rejected reason) are highlighted
+        for topic_name, topic_status in self.loader.rejected_topics:
+            self.update_status(
+                topic_name, topic_status.value, topic_status.display_color()
+            )
+
+        # Create a master progress bar for the aggregate total of the accepted topics
+        total_msgs = sum(self.loader.msg_count(t) for t in self.loader.topics)
+        self.global_task = self.progress.add_task(
+            "Total", total=total_msgs, name="Total Upload"
+        )
+
+    def update_status(self, topic: str, status: str, style: str = "white"):
+        """
+        Updates the text description of a specific topic's progress bar.
+        Useful for indicating errors or skipped topics (e.g. "[red]Unresolved Adapter").
+
+        Args:
+            topic (str): The topic name.
+            status (str): The status message to display.
+            style (str): The rich style string (e.g., 'red', 'bold yellow').
+        """
+        if topic in self.tasks:
+            self.progress.update(
+                self.tasks[topic],
+                name=f"[{style}]{topic}: {status}",
+            )
+
+    def advance_global(self):
+        """Advances only the global progress bar (used when skipping messages)."""
+        if self.global_task is not None:
+            self.progress.advance(self.global_task)
+
+    def advance_all(self, topic: str):
+        """Advances both the specific topic's bar and the global bar."""
+        if topic in self.tasks:
+            self.progress.advance(self.tasks[topic])
+        if self.global_task is not None:
+            self.progress.advance(self.global_task)

--- a/mosaico-sdk-py/src/testing/integration/issues/test_sending_multi_echo_laseer_scan.py
+++ b/mosaico-sdk-py/src/testing/integration/issues/test_sending_multi_echo_laseer_scan.py
@@ -5,7 +5,6 @@ from mosaicolabs.models.futures.laser import MultiEchoLaserScan
 
 
 def test_sending_MultiEchoLaserScan(mosaico_client: MosaicoClient):
-    print(MultiEchoLaserScan.__msco_pyarrow_struct__)
     with mosaico_client:
         try:
             with mosaico_client.sequence_create(

--- a/mosaico-sdk-py/src/testing/integration/ros_bridge/test_sequence_extractor.py
+++ b/mosaico-sdk-py/src/testing/integration/ros_bridge/test_sequence_extractor.py
@@ -31,7 +31,7 @@ def override_ext_configs(
     seq_ext_config: ROSExtractorConfig,
     ros_distro: Stores,
     storage_plugin: StoragePlugin,
-) -> ROSSequenceExtractor:
+) -> ROSExtractorConfig:
     """Overrides default SequenceExtractor configs with passed ros_distro and storage_plugin"""
     seq_ext_config.ros_distro = ros_distro
     seq_ext_config.storage_plugin = storage_plugin
@@ -101,6 +101,7 @@ def test_run_data_correctness(
         ros_loader, synthetic_sequence_data_stream.items
     ):
         adapter = ROSBridge.get_default_adapter(ros_msg.msg_type)
+        assert adapter is not None
         reconstructed_ms_msg = adapter.translate(ros_msg)
 
         assert reconstructed_ms_msg.timestamp_ns == data_steam_item.msg.timestamp_ns

--- a/mosaico-sdk-py/src/testing/integration/ros_bridge/test_sequence_extractor.py
+++ b/mosaico-sdk-py/src/testing/integration/ros_bridge/test_sequence_extractor.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 from rosbags.rosbag2 import StoragePlugin
-from rosbags.typesys import Stores
+from rosbags.typesys import Stores, get_typestore
 
 from mosaicolabs.ros_bridge import ROSBridge, ROSLoader
 from mosaicolabs.ros_bridge.sequence_extractor import (
@@ -93,7 +93,9 @@ def test_run_data_correctness(
 
     rosbag_file_path = get_rosbagfile_path(default_extractor_config)
 
-    ros_loader = ROSLoader(file_path=rosbag_file_path, typestore_name=ros_distro)
+    ros_loader = ROSLoader(
+        file_path=rosbag_file_path, typestore=get_typestore(ros_distro)
+    )
 
     for (ros_msg, _), data_steam_item in zip_longest(
         ros_loader, synthetic_sequence_data_stream.items

--- a/mosaico-sdk-py/src/testing/integration/ros_bridge/test_sequence_extractor.py
+++ b/mosaico-sdk-py/src/testing/integration/ros_bridge/test_sequence_extractor.py
@@ -5,7 +5,8 @@ import pytest
 from rosbags.rosbag2 import StoragePlugin
 from rosbags.typesys import Stores, get_typestore
 
-from mosaicolabs.ros_bridge import ROSBridge, ROSLoader
+from mosaicolabs import Pose, SessionLevelErrorPolicy
+from mosaicolabs.ros_bridge import MosaicoLoader, ROSBridge, ROSLoader
 from mosaicolabs.ros_bridge.sequence_extractor import (
     ROSExtractorConfig,
     ROSSequenceExtractor,
@@ -148,3 +149,32 @@ def test_not_existing_sequence_name(default_extractor_config):
 
     with pytest.raises(ValueError):
         sequence_ext.run()
+
+
+def test_valid_msgtype(mosaico_client):
+    ros_distro = Stores.ROS2_JAZZY
+    ros_sequence_name = "ros-sequence-valid-msgtype"
+    ros_topic_name = "/car/pose"
+    topic_with_ros_metadata = {"_ros_": {"msgtype": "geometry_msgs/msg/PoseStamped"}}
+
+    with mosaico_client:
+        # Writing topic
+        with mosaico_client.sequence_create(
+            ros_sequence_name, {}, SessionLevelErrorPolicy.Delete
+        ) as s_writer:
+            s_writer.topic_create(ros_topic_name, topic_with_ros_metadata, Pose)
+
+        t_handler = mosaico_client.topic_handler(ros_sequence_name, ros_topic_name)
+
+        # Reading topic
+        mosaico_loader = MosaicoLoader(
+            mosaico_client, get_typestore(ros_distro), ros_sequence_name
+        )
+        adapter, rosmsg_type = mosaico_loader._get_or_create_adapter(t_handler)
+
+        assert adapter and adapter.ontology_data_type() is Pose
+        assert (
+            rosmsg_type is not None and rosmsg_type == "geometry_msgs/msg/PoseStamped"
+        )
+
+        mosaico_client.sequence_delete(ros_sequence_name)

--- a/mosaico-sdk-py/src/testing/integration/ros_bridge/test_sequence_extractor.py
+++ b/mosaico-sdk-py/src/testing/integration/ros_bridge/test_sequence_extractor.py
@@ -11,6 +11,7 @@ from mosaicolabs.ros_bridge.sequence_extractor import (
     ROSExtractorConfig,
     ROSSequenceExtractor,
 )
+from testing.integration.config import UPLOADED_SEQUENCE_NAME
 
 ROS_DISTRO = [
     Stores.LATEST,
@@ -84,6 +85,7 @@ def test_run_data_correctness(
     default_extractor_config,
     ros_distro,
     storage_plugin,
+    mosaico_client,
 ):
 
     overwritten_configs = override_ext_configs(
@@ -94,9 +96,16 @@ def test_run_data_correctness(
 
     rosbag_file_path = get_rosbagfile_path(default_extractor_config)
 
-    ros_loader = ROSLoader(
-        file_path=rosbag_file_path, typestore=get_typestore(ros_distro)
-    )
+    ros_loader = ROSLoader(file_path=rosbag_file_path, typestore_or_distro=ros_distro)
+
+    shandler = mosaico_client.sequence_handler(UPLOADED_SEQUENCE_NAME)
+    assert shandler is not None
+    # Assert all the topics are adapted and accepted
+    assert len(ros_loader.topics) == len(shandler.topics)
+    assert all(top in ros_loader.topics for top in shandler.topics)
+    sstreamer = shandler.get_data_streamer()
+    # All the messages are reconstructed
+    assert ros_loader.msg_count() == sstreamer.msg_count
 
     for (ros_msg, _), data_steam_item in zip_longest(
         ros_loader, synthetic_sequence_data_stream.items
@@ -107,6 +116,8 @@ def test_run_data_correctness(
 
         assert reconstructed_ms_msg.timestamp_ns == data_steam_item.msg.timestamp_ns
         assert reconstructed_ms_msg.data == data_steam_item.msg.data
+
+    mosaico_client.close()
 
 
 def test_overwrite_false_raise_on_existing_path(

--- a/mosaico-sdk-py/src/testing/testing.py
+++ b/mosaico-sdk-py/src/testing/testing.py
@@ -1,8 +1,22 @@
 import argparse
+import subprocess
 import sys
 from pathlib import Path
 
 import pytest
+
+
+def _run_ruff_checks(src_dir: Path) -> None:
+    """Run `ruff check` and `ruff format --check` on src_dir, exiting on failure."""
+    checks = [
+        ["ruff", "check", str(src_dir)],
+        ["ruff", "format", "--check", str(src_dir)],
+    ]
+    sys.stdout.write(f"Running RUFF tests in {src_dir}\n")
+    for cmd in checks:
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            sys.exit(result.returncode)
 
 
 def mosaico_testing():
@@ -58,6 +72,8 @@ def mosaico_testing():
     args = parser.parse_args()
 
     src_dir = Path(__file__).resolve().parent
+    _run_ruff_checks(src_dir.parent)
+
     pytest_args = [str(src_dir)]
 
     if args.keyword:

--- a/mosaico-sdk-py/src/testing/unit/ros_bridge/test_base_ros_topic_resolver.py
+++ b/mosaico-sdk-py/src/testing/unit/ros_bridge/test_base_ros_topic_resolver.py
@@ -1,0 +1,160 @@
+from mosaicolabs.ros_bridge.loader import TopicStatus, _BaseROSTopicResolver
+
+
+class _FakeAdapter:
+    """Stand-in for a resolved adapter type; identity is all that matters here."""
+
+
+class _FakeResolver(_BaseROSTopicResolver):
+    """
+    Minimal concrete subclass exercising the base class's bookkeeping without needing
+    a real bag file or Mosaico sequence. Storage containers are passed in as either
+    dicts (mimicking ROSLoader) or lists (mimicking MosaicoLoader), to prove the base
+    class properties work uniformly regardless of which container a subclass uses.
+    """
+
+    def __init__(
+        self,
+        resolved,
+        accepted,
+        unresolved,
+        filtered,
+        adapters,
+        extra_rejections=None,
+    ):
+        self._resolved_topics = resolved
+        self._accepted_topics = accepted
+        self._unresolved_adapter_topics = unresolved
+        self._filtered_topics = filtered
+        self._topic_cached_adapters = adapters
+        self._extra_rejections = extra_rejections or []
+        self.ensure_resolved_calls = 0
+
+    def _ensure_resolved(self) -> None:
+        self.ensure_resolved_calls += 1
+
+    def _extra_rejected_topics(self):
+        return self._extra_rejections
+
+
+def _dict_backed_resolver(**extra_rejections_kwargs):
+    adapter = _FakeAdapter()
+    return _FakeResolver(
+        resolved={"/imu": None, "/gps": None, "/debug": None},
+        accepted={"/imu": None, "/gps": None},
+        unresolved={"/debug": None},
+        filtered={},
+        adapters={"/imu": adapter, "/gps": adapter},
+        **extra_rejections_kwargs,
+    )
+
+
+def _list_backed_resolver(**extra_rejections_kwargs):
+    adapter = _FakeAdapter()
+    return _FakeResolver(
+        resolved=["/imu", "/gps", "/debug"],
+        accepted=["/imu", "/gps"],
+        unresolved=["/debug"],
+        filtered=[],
+        adapters={"/imu": adapter, "/gps": adapter},
+        **extra_rejections_kwargs,
+    )
+
+
+def test_topics_returns_accepted_keys_for_dict_backed_storage():
+    resolver = _dict_backed_resolver()
+
+    assert set(resolver.topics) == {"/imu", "/gps"}
+
+
+def test_topics_returns_accepted_items_for_list_backed_storage():
+    resolver = _list_backed_resolver()
+
+    assert set(resolver.topics) == {"/imu", "/gps"}
+
+
+def test_resolved_topics_returns_everything_regardless_of_filtering():
+    for resolver in (_dict_backed_resolver(), _list_backed_resolver()):
+        assert set(resolver.resolved_topics) == {"/imu", "/gps", "/debug"}
+
+
+def test_unresolved_adapted_topics():
+    for resolver in (_dict_backed_resolver(), _list_backed_resolver()):
+        assert list(resolver.unresolved_adapted_topics) == ["/debug"]
+
+
+def test_filtered_topics_empty_when_no_filter_applied():
+    for resolver in (_dict_backed_resolver(), _list_backed_resolver()):
+        assert resolver.filtered_topics == []
+
+
+def test_filtered_topics_reflects_excluded_topics():
+    resolver = _FakeResolver(
+        resolved={"/imu": None, "/cam": None},
+        accepted={"/imu": None},
+        unresolved={},
+        filtered={"/cam": None},
+        adapters={"/imu": _FakeAdapter()},
+    )
+
+    assert resolver.filtered_topics == ["/cam"]
+
+
+def test_rejected_topics_combines_filtered_and_unresolved():
+    resolver = _dict_backed_resolver()
+
+    rejected = dict(resolver.rejected_topics)
+
+    assert rejected == {"/debug": TopicStatus.UNRESOLVED_ADAPTED}
+
+
+def test_rejected_topics_includes_source_specific_extra_rejections():
+    resolver = _dict_backed_resolver(
+        extra_rejections=[
+            ("/malformed", TopicStatus.MALFORMED_METADATA),
+            ("/missing_type", TopicStatus.NOT_IN_TYPESTORE),
+        ]
+    )
+
+    rejected = dict(resolver.rejected_topics)
+
+    assert rejected == {
+        "/debug": TopicStatus.UNRESOLVED_ADAPTED,
+        "/malformed": TopicStatus.MALFORMED_METADATA,
+        "/missing_type": TopicStatus.NOT_IN_TYPESTORE,
+    }
+
+
+def test_resolve_adapter_returns_cached_adapter_for_accepted_topic():
+    resolver = _dict_backed_resolver()
+
+    assert resolver.resolve_adapter("/imu") is resolver._topic_cached_adapters["/imu"]
+
+
+def test_resolve_adapter_returns_none_for_rejected_topic():
+    resolver = _dict_backed_resolver()
+
+    assert resolver.resolve_adapter("/debug") is None
+
+
+def test_resolve_adapter_returns_none_for_unknown_topic():
+    resolver = _dict_backed_resolver()
+
+    assert resolver.resolve_adapter("/does-not-exist") is None
+
+
+def test_properties_trigger_ensure_resolved():
+    resolver = _dict_backed_resolver()
+    assert resolver.ensure_resolved_calls == 0
+
+    resolver.topics
+    resolver.resolved_topics
+    resolver.filtered_topics
+    resolver.unresolved_adapted_topics
+    resolver.rejected_topics
+    resolver.resolve_adapter("/imu")
+
+    # rejected_topics composes filtered_topics/unresolved_adapted_topics internally,
+    # so it triggers _ensure_resolved more than once by itself; assert it fires at
+    # least once per accessed property rather than pin an exact, implementation-tied count.
+    assert resolver.ensure_resolved_calls >= 6

--- a/mosaico-sdk-py/src/testing/unit/ros_bridge/test_injection_config.py
+++ b/mosaico-sdk-py/src/testing/unit/ros_bridge/test_injection_config.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+import pytest
+
+from mosaicolabs.enum import TopicLevelErrorPolicy
+from mosaicolabs.ros_bridge.injector import (
+    RosbagInjector,
+    ROSInjectionConfig,
+    _parse_json_arg,
+)
+
+# --- _parse_json_arg ---
+
+
+def test_parse_json_arg_empty_input_returns_empty_dict():
+    assert _parse_json_arg(None) == {}
+    assert _parse_json_arg("") == {}
+
+
+def test_parse_json_arg_parses_raw_json_string():
+    assert _parse_json_arg('{"driver": "John"}') == {"driver": "John"}
+
+
+def test_parse_json_arg_parses_json_file(tmp_path):
+    json_file = tmp_path / "metadata.json"
+    json_file.write_text('{"driver": "John"}')
+
+    assert _parse_json_arg(str(json_file)) == {"driver": "John"}
+
+
+def test_parse_json_arg_invalid_json_and_not_a_file_exits(tmp_path):
+    not_a_path = str(tmp_path / "does_not_exist.json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        _parse_json_arg(not_a_path)
+
+    assert exc_info.value.code == 1
+
+
+def test_parse_json_arg_file_with_malformed_json_exits(tmp_path):
+    json_file = tmp_path / "malformed.json"
+    json_file.write_text("{not valid json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        _parse_json_arg(str(json_file))
+
+    assert exc_info.value.code == 1
+
+
+# --- ROSInjectionConfig defaults ---
+
+
+def _make_config(**overrides) -> ROSInjectionConfig:
+    defaults = dict(file_path=Path("data.mcap"), sequence_name="seq")
+    defaults.update(overrides)
+    return ROSInjectionConfig(**defaults)
+
+
+def test_metadata_default_is_not_shared_between_instances():
+    first = _make_config()
+    second = _make_config()
+
+    assert first.metadata == {}
+    assert first.metadata is not second.metadata
+
+    first.metadata["mutated"] = True
+
+    assert "mutated" not in second.metadata
+
+
+def test_topic_metadata_defaults_to_none():
+    assert _make_config().topic_metadata is None
+
+
+def test_dry_run_defaults_to_false():
+    assert _make_config().dry_run is False
+
+
+def test_update_if_exists_defaults_to_false():
+    assert _make_config().update_if_exists is False
+
+
+# --- RosbagInjector._get_topic_on_error ---
+
+
+def _make_injector(**overrides) -> RosbagInjector:
+    return RosbagInjector(_make_config(**overrides))
+
+
+def test_get_topic_on_error_default_when_unset():
+    injector = _make_injector()
+
+    assert injector._get_topic_on_error("/imu") == TopicLevelErrorPolicy.Raise
+
+
+def test_get_topic_on_error_uniform_policy_applies_to_all_topics():
+    injector = _make_injector(topics_on_error=TopicLevelErrorPolicy.Ignore)
+
+    assert injector._get_topic_on_error("/imu") == TopicLevelErrorPolicy.Ignore
+    assert injector._get_topic_on_error("/gps") == TopicLevelErrorPolicy.Ignore
+
+
+def test_get_topic_on_error_per_topic_dict_overrides_selected_topics():
+    injector = _make_injector(topics_on_error={"/imu": TopicLevelErrorPolicy.Finalize})
+
+    assert injector._get_topic_on_error("/imu") == TopicLevelErrorPolicy.Finalize
+
+
+def test_get_topic_on_error_per_topic_dict_falls_back_to_default_for_others():
+    injector = _make_injector(topics_on_error={"/imu": TopicLevelErrorPolicy.Finalize})
+
+    assert injector._get_topic_on_error("/gps") == TopicLevelErrorPolicy.Raise

--- a/mosaico-sdk-py/src/testing/unit/ros_bridge/test_registry_scoping.py
+++ b/mosaico-sdk-py/src/testing/unit/ros_bridge/test_registry_scoping.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+
+import pytest
+from rosbags.typesys import Stores
+
+from mosaicolabs.ros_bridge.injector import RosbagInjector, ROSInjectionConfig
+from mosaicolabs.ros_bridge.registry import ROSTypeRegistry
+from mosaicolabs.ros_bridge.sequence_extractor import (
+    ROSExtractorConfig,
+    ROSSequenceExtractor,
+)
+
+_CUSTOM_MSG_TYPE = "custom_msgs/msg/MyCustomMsg"
+
+
+@pytest.fixture
+def custom_msgs_dir(tmp_path):
+    d = tmp_path / "custom_msgs"
+    d.mkdir()
+    (d / "MyCustomMsg.msg").write_text("int32 data\n")
+    return d
+
+
+def test_registry_defaults_to_a_fresh_private_instance(custom_msgs_dir):
+    """Two injectors constructed without `registry=` must not share state."""
+    inj_a = RosbagInjector(
+        ROSInjectionConfig(
+            file_path=Path("a.mcap"),
+            sequence_name="a",
+            ros_distro=Stores.LATEST,
+            custom_msgs=[("custom_msgs", custom_msgs_dir, Stores.LATEST)],
+        )
+    )
+    inj_b = RosbagInjector(
+        ROSInjectionConfig(
+            file_path=Path("b.mcap"), sequence_name="b", ros_distro=Stores.LATEST
+        )
+    )
+
+    assert inj_a._registry is not inj_b._registry
+    assert _CUSTOM_MSG_TYPE in inj_a._typestore.types
+    assert _CUSTOM_MSG_TYPE not in inj_b._typestore.types
+
+
+def test_registry_shared_across_injector_instances(custom_msgs_dir):
+    """Passing the same `registry=` instance to two injectors shares definitions."""
+    shared = ROSTypeRegistry()
+    shared.register_directory(
+        package_name="custom_msgs", dir_path=custom_msgs_dir, store=Stores.LATEST
+    )
+
+    inj_a = RosbagInjector(
+        ROSInjectionConfig(
+            file_path=Path("a.mcap"),
+            sequence_name="a",
+            ros_distro=Stores.LATEST,
+            registry=shared,
+        )
+    )
+    inj_b = RosbagInjector(
+        ROSInjectionConfig(
+            file_path=Path("b.mcap"),
+            sequence_name="b",
+            ros_distro=Stores.LATEST,
+            registry=shared,
+        )
+    )
+
+    assert inj_a._registry is shared
+    assert inj_a._registry is inj_b._registry
+    assert _CUSTOM_MSG_TYPE in inj_a._typestore.types
+    assert _CUSTOM_MSG_TYPE in inj_b._typestore.types
+
+
+def test_registry_shared_between_injector_and_extractor(custom_msgs_dir):
+    """The same `registry=` instance can be shared across an injector and an extractor."""
+    shared = ROSTypeRegistry()
+    shared.register_directory(
+        package_name="custom_msgs", dir_path=custom_msgs_dir, store=Stores.LATEST
+    )
+
+    injector = RosbagInjector(
+        ROSInjectionConfig(
+            file_path=Path("a.mcap"),
+            sequence_name="a",
+            ros_distro=Stores.LATEST,
+            registry=shared,
+        )
+    )
+    extractor = ROSSequenceExtractor(
+        ROSExtractorConfig(
+            rosbag_path=Path("out"),
+            sequence_name="a",
+            ros_distro=Stores.LATEST,
+            registry=shared,
+        )
+    )
+
+    assert _CUSTOM_MSG_TYPE in injector._typestore.types
+    assert _CUSTOM_MSG_TYPE in extractor.typestore.types
+
+
+def test_registry_instances_are_fully_independent():
+    """Registering into one ROSTypeRegistry instance must not affect another."""
+    a = ROSTypeRegistry()
+    b = ROSTypeRegistry()
+
+    a.register(msg_type="pkg/msg/OnlyOnA", source="int32 data\n")
+
+    assert "pkg/msg/OnlyOnA" in a.get_types(None)
+    assert "pkg/msg/OnlyOnA" not in b.get_types(None)

--- a/mosaico-sdk-py/src/testing/unit/ros_bridge/test_ros_schema_metadata.py
+++ b/mosaico-sdk-py/src/testing/unit/ros_bridge/test_ros_schema_metadata.py
@@ -1,0 +1,95 @@
+import pytest
+
+from mosaicolabs.ros_bridge.adapter_base import RosSchemaMetadata
+
+
+def test_to_dict_wraps_fields_under_reserved_key():
+    meta = RosSchemaMetadata(msgtype="sensor_msgs/msg/Imu")
+
+    assert meta.to_dict() == {"_ros_": {"msgtype": "sensor_msgs/msg/Imu"}}
+
+
+def test_update_merges_and_returns_self_for_chaining():
+    meta = RosSchemaMetadata(msgtype="sensor_msgs/msg/Imu")
+
+    result = meta.update(source_file="a.mcap")
+
+    assert result is meta
+    assert meta.to_dict() == {
+        "_ros_": {"msgtype": "sensor_msgs/msg/Imu", "source_file": "a.mcap"}
+    }
+
+
+def test_update_overwrites_existing_field():
+    meta = RosSchemaMetadata(source_file="a.mcap")
+
+    meta.update(source_file="b.mcap")
+
+    assert meta.to_dict() == {"_ros_": {"source_file": "b.mcap"}}
+
+
+def test_merge_into_creates_namespace_when_absent():
+    meta = RosSchemaMetadata(msgtype="sensor_msgs/msg/Imu")
+    target = {"lens": "wide-angle"}
+
+    result = meta.merge_into(target)
+
+    assert result is target
+    assert target == {
+        "lens": "wide-angle",
+        "_ros_": {"msgtype": "sensor_msgs/msg/Imu"},
+    }
+
+
+def test_merge_into_updates_existing_namespace_without_clobbering_other_keys():
+    meta = RosSchemaMetadata(source_file="a.mcap")
+    target = {"_ros_": {"msgtype": "sensor_msgs/msg/Imu"}}
+
+    meta.merge_into(target)
+
+    assert target == {
+        "_ros_": {"msgtype": "sensor_msgs/msg/Imu", "source_file": "a.mcap"}
+    }
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [None, {}, {"other_key": "value"}],
+)
+def test_extract_returns_empty_dict_when_no_ros_block(metadata):
+    assert RosSchemaMetadata.extract(metadata) == {}
+
+
+def test_extract_returns_ros_block_contents():
+    metadata = {"_ros_": {"msgtype": "sensor_msgs/msg/Imu"}, "other_key": "value"}
+
+    assert RosSchemaMetadata.extract(metadata) == {"msgtype": "sensor_msgs/msg/Imu"}
+
+
+@pytest.mark.parametrize("metadata", [None, {}, {"_ros_": {}}])
+def test_from_dict_handles_missing_or_empty_ros_block(metadata):
+    meta = RosSchemaMetadata.from_dict(metadata)
+
+    assert meta.to_dict() == {"_ros_": {}}
+
+
+def test_from_dict_round_trips_existing_ros_block():
+    original = {"_ros_": {"msgtype": "sensor_msgs/msg/Imu", "msgdef": "..."}}
+
+    meta = RosSchemaMetadata.from_dict(original)
+    meta.update(source_file="a.mcap")
+
+    assert meta.to_dict() == {
+        "_ros_": {
+            "msgtype": "sensor_msgs/msg/Imu",
+            "msgdef": "...",
+            "source_file": "a.mcap",
+        }
+    }
+    # The original dict passed in must not be mutated by from_dict/update.
+    assert original == {"_ros_": {"msgtype": "sensor_msgs/msg/Imu", "msgdef": "..."}}
+
+
+def test_key_constant_is_the_single_source_of_truth():
+    assert RosSchemaMetadata.KEY == "_ros_"
+    assert list(RosSchemaMetadata(a=1).to_dict().keys()) == [RosSchemaMetadata.KEY]

--- a/mosaico-sdk-py/src/testing/unit/ros_bridge/test_schema_metadata_from_injector.py
+++ b/mosaico-sdk-py/src/testing/unit/ros_bridge/test_schema_metadata_from_injector.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+
+from mosaicolabs.ros_bridge.injector import RosbagInjector, ROSInjectionConfig
+from mosaicolabs.ros_bridge.ros_message import ROSMessage
+
+
+class _FakeSessionWriter:
+    """These tests only exercise metadata construction, not translation/serialization."""
+
+    def __init__(self):
+        self.created_metadata: Optional[dict] = None
+
+    def get_topic_writer(self, topic: str):
+        return None
+
+    def topic_create(self, topic_name, metadata, ontology_type, on_error):
+        self.created_metadata = metadata
+
+
+class _FakeUI:
+    def update_status(self, topic, status, style):
+        pass
+
+    def advance_all(self, topic):
+        pass
+
+
+class _FakeAdapter:
+    @staticmethod
+    def schema_metadata(typestore, msg_type, ros_version) -> Optional[dict]:
+        return {"_ros_": {"msgtype": msg_type}}
+
+    @staticmethod
+    def ontology_data_type():
+        return "Null"
+
+
+class _FakeAdapterNoSchema(_FakeAdapter):
+    @staticmethod
+    def schema_metadata(typestore, msg_type, ros_version) -> Optional[dict]:
+        return None
+
+
+def _make_ros_msg(topic="/imu", msg_type="sensor_msgs/msg/Imu"):
+    return ROSMessage(
+        bag_timestamp_ns=0,
+        topic=topic,
+        msg_type=msg_type,
+        data={"x": 1},
+    )
+
+
+def _make_injector(file_path=Path("data.mcap"), **cfg_overrides):
+    cfg = ROSInjectionConfig(
+        file_path=file_path,
+        sequence_name="seq",
+        **cfg_overrides,
+    )
+    injector = RosbagInjector(cfg)
+    # A real ROSLoader isn't needed: adapter resolution goes through
+    # `adapter_overrides`, which is checked before `self._loader.resolve_adapter()`.
+    injector._loader = SimpleNamespace(_typestore=None)
+    return injector
+
+
+def _process(injector: RosbagInjector, ros_msg: ROSMessage):
+    session_writer = _FakeSessionWriter()
+    injector._process_message(ros_msg, None, session_writer, _FakeUI())
+    return session_writer.created_metadata
+
+
+def test_ros_namespace_always_wins_over_conflicting_topic_metadata():
+    injector = _make_injector(
+        adapter_overrides={"/imu": _FakeAdapter},
+        topic_metadata={
+            "/imu": {"_ros_": {"msgtype": "hacked"}, "extra": "kept"},
+        },
+    )
+
+    metadata = _process(injector, _make_ros_msg())
+    assert metadata is not None
+
+    assert metadata["_ros_"]["msgtype"] == "sensor_msgs/msg/Imu"
+    assert metadata["extra"] == "kept"
+
+
+def test_source_file_is_nested_under_ros_namespace():
+    injector = _make_injector(
+        file_path=Path("recording_01.mcap"),
+        adapter_overrides={"/imu": _FakeAdapter},
+    )
+
+    metadata = _process(injector, _make_ros_msg())
+    assert metadata is not None
+    assert metadata["_ros_"]["source_file"] == "recording_01.mcap"
+    assert "source_file" not in metadata
+
+
+def test_non_conflicting_topic_metadata_keys_are_preserved():
+    injector = _make_injector(
+        adapter_overrides={"/imu": _FakeAdapter},
+        topic_metadata={"/imu": {"vendor": "acme"}},
+    )
+
+    metadata = _process(injector, _make_ros_msg())
+    assert metadata is not None
+    assert metadata["vendor"] == "acme"
+    assert metadata["_ros_"]["msgtype"] == "sensor_msgs/msg/Imu"
+
+
+def test_topic_metadata_for_other_topics_is_not_applied():
+    injector = _make_injector(
+        adapter_overrides={"/imu": _FakeAdapter},
+        topic_metadata={"/gps": {"vendor": "acme"}},
+    )
+
+    metadata = _process(injector, _make_ros_msg(topic="/imu"))
+    assert metadata is not None
+    assert "vendor" not in metadata
+
+
+def test_missing_schema_metadata_still_produces_ros_namespace_with_source_file():
+    injector = _make_injector(adapter_overrides={"/imu": _FakeAdapterNoSchema})
+
+    metadata = _process(injector, _make_ros_msg())
+    assert metadata is not None
+    assert metadata["_ros_"] == {"source_file": "data.mcap"}
+
+
+def test_topic_metadata_dict_is_not_mutated_by_processing():
+    """Regression test: `_process_message` must not mutate the caller's `topic_metadata`
+    dict in place, since `ROSInjectionConfig` is reused across the whole run."""
+    user_topic_metadata = {"/imu": {"vendor": "acme"}}
+    injector = _make_injector(
+        adapter_overrides={"/imu": _FakeAdapter},
+        topic_metadata=user_topic_metadata,
+    )
+
+    _process(injector, _make_ros_msg())
+
+    assert user_topic_metadata == {"/imu": {"vendor": "acme"}}

--- a/mosaico-sdk-py/src/testing/unit/ros_bridge/test_typestore_registration.py
+++ b/mosaico-sdk-py/src/testing/unit/ros_bridge/test_typestore_registration.py
@@ -50,7 +50,6 @@ def test_custom_typestore_registration_injector(ros_distro: Stores):
         # use directory here
         custom_msg_file = custom_msgs_dir / "MyCustomMsg.msg"
         custom_msg_file.write_text("int32 data\n")
-        print(f"Created custom message definition at: {custom_msg_file}")
 
         inj = RosbagInjector(
             config=ROSInjectionConfig(
@@ -119,7 +118,6 @@ def test_custom_typestore_registration_extractor(ros_distro: Stores):
         # use directory here
         custom_msg_file = custom_msgs_dir / "MyCustomMsg.msg"
         custom_msg_file.write_text("int32 data\n")
-        print(f"Created custom message definition at: {custom_msg_file}")
 
         inj = ROSSequenceExtractor(
             config=ROSExtractorConfig(

--- a/mosaico-sdk-py/src/testing/unit/ros_bridge/test_typestore_registration.py
+++ b/mosaico-sdk-py/src/testing/unit/ros_bridge/test_typestore_registration.py
@@ -1,0 +1,156 @@
+import shutil
+from pathlib import Path
+
+import pytest
+from rosbags.typesys import Stores, get_typestore
+
+from mosaicolabs.ros_bridge.injector import (
+    RosbagInjector,
+    ROSInjectionConfig,
+)
+from mosaicolabs.ros_bridge.sequence_extractor import (
+    ROSExtractorConfig,
+    ROSSequenceExtractor,
+)
+
+
+@pytest.mark.parametrize(
+    "ros_distro",
+    [distro for distro in Stores],
+)
+def test_standard_typestore_registration_injector(ros_distro: Stores):
+    """
+    Test that the standard ROS message types are registered in the typestore.
+    """
+    inj = RosbagInjector(
+        config=ROSInjectionConfig(
+            file_path=Path("test.bag"),
+            sequence_name="test",
+            ros_distro=ros_distro,
+        )
+    )
+
+    assert inj._typestore is not None
+    assert inj._typestore.types.keys() == get_typestore(ros_distro).types.keys()
+
+
+@pytest.mark.parametrize(
+    "ros_distro",
+    [distro for distro in Stores],
+)
+def test_custom_typestore_registration_injector(ros_distro: Stores):
+    """
+    Test that custom ROS message types are registered in the typestore.
+    """
+    # Create a temporary directory for custom message definitions
+    custom_msgs_dir = Path("/tmp/custom_msgs")
+
+    try:
+        custom_msgs_dir.mkdir(parents=True, exist_ok=True)
+        # use directory here
+        custom_msg_file = custom_msgs_dir / "MyCustomMsg.msg"
+        custom_msg_file.write_text("int32 data\n")
+        print(f"Created custom message definition at: {custom_msg_file}")
+
+        inj = RosbagInjector(
+            config=ROSInjectionConfig(
+                file_path=Path("test.bag"),
+                sequence_name="test",
+                ros_distro=ros_distro,
+                custom_msgs=[("custom_msgs", Path(custom_msgs_dir), ros_distro)],
+            )
+        )
+
+        assert inj._typestore is not None
+        assert "custom_msgs/msg/MyCustomMsg" in inj._typestore.types.keys()
+
+    finally:
+        shutil.rmtree(custom_msgs_dir, ignore_errors=True)
+
+
+def test_typestore_reaches_ros_loader():
+    # Sufficient just one distro to test forwarding
+    ros_distro = Stores.LATEST
+    inj = RosbagInjector(
+        config=ROSInjectionConfig(
+            file_path=Path("test.bag"),
+            sequence_name="test",
+            ros_distro=ros_distro,
+        )
+    )
+    loader = inj._open_or_get_loader()
+    assert inj._typestore.types == get_typestore(ros_distro).types
+    assert loader._typestore.types == inj._typestore.types
+
+
+@pytest.mark.parametrize(
+    "ros_distro",
+    [distro for distro in Stores],
+)
+def test_standard_typestore_registration_extractor(ros_distro: Stores):
+    """
+    Test that the standard ROS message types are registered in the typestore.
+    """
+    inj = ROSSequenceExtractor(
+        config=ROSExtractorConfig(
+            rosbag_path=Path("no-path"),
+            sequence_name="test",
+            ros_distro=ros_distro,
+        )
+    )
+
+    assert inj.typestore is not None
+    assert inj.typestore.types.keys() == get_typestore(ros_distro).types.keys()
+
+
+@pytest.mark.parametrize(
+    "ros_distro",
+    [distro for distro in Stores],
+)
+def test_custom_typestore_registration_extractor(ros_distro: Stores):
+    """
+    Test that custom ROS message types are registered in the typestore.
+    """
+    # Create a temporary directory for custom message definitions
+    custom_msgs_dir = Path("/tmp/custom_msgs")
+
+    try:
+        custom_msgs_dir.mkdir(parents=True, exist_ok=True)
+        # use directory here
+        custom_msg_file = custom_msgs_dir / "MyCustomMsg.msg"
+        custom_msg_file.write_text("int32 data\n")
+        print(f"Created custom message definition at: {custom_msg_file}")
+
+        inj = ROSSequenceExtractor(
+            config=ROSExtractorConfig(
+                rosbag_path=Path("no-path"),
+                sequence_name="test",
+                ros_distro=ros_distro,
+                custom_msgs=[("custom_msgs", Path(custom_msgs_dir), ros_distro)],
+            )
+        )
+
+        assert inj.typestore is not None
+        assert "custom_msgs/msg/MyCustomMsg" in inj.typestore.types.keys()
+
+    finally:
+        shutil.rmtree(custom_msgs_dir, ignore_errors=True)
+
+
+class _FakeClient:
+    pass
+
+
+def test_typestore_reaches_mosaico_loader():
+    # Sufficient just one distro to test forwarding
+    ros_distro = Stores.LATEST
+    extr = ROSSequenceExtractor(
+        config=ROSExtractorConfig(
+            rosbag_path=Path("no-path"),
+            sequence_name="test",
+            ros_distro=ros_distro,
+        )
+    )
+    loader = extr._open_or_get_mosaicoloader(_FakeClient())
+    assert extr.typestore.types == get_typestore(ros_distro).types
+    assert loader._typestore.types == extr.typestore.types


### PR DESCRIPTION
## Summary

**Breaking changes**
- `ROSAdapterBase.init_schema_metadata()` / `update_schema_metadata()` removed — replaced by the new `RosSchemaMetadata` helper.
- `ROSTypeRegistry` changed from a process-wide singleton (bare classmethods) to an instantiable class; existing `ROSTypeRegistry.register(...)`-style calls no longer work — construct an instance instead.
- `ROSLoader` / `MosaicoLoader` constructors now take an already-resolved `Typestore` (or a `Stores` distro) directly; they no longer touch `ROSTypeRegistry` themselves — that setup moved up into `RosbagInjector` / `ROSSequenceExtractor`.

**Improvements**
- Added `ROSInjectionConfig.update_if_exists`, for covering both multi-part bag ingestion and merging reprocessed results into an already-ingested sequence.
- Added `--dry-run` to both `RosbagInjector` and `ROSSequenceExtractor`: reports resolved topics/adapters/rejections without connecting to the server or writing/deleting anything.
- Added per-topic `topic_metadata` to `ROSInjectionConfig`.
- Added a `registry` field on both configs to explicitly share a pre-populated `ROSTypeRegistry` across runs, while each run defaults to its own isolated instance (no more cross-run state leakage in long-lived processes).
- New `RosSchemaMetadata` class centralizes the reserved `_ros_` topic-metadata namespace (now also carrying `source_file` provenance) instead of duplicating the key across adapters/loaders/injector.
- `MOSAICO_API_KEY` env var support for the CLI, avoiding leaking the key via shell history/process list.
- Extracted shared topic-classification/adapter-resolution logic from `ROSLoader`/`MosaicoLoader` into a common base class.
- `ProgressManager` moved into its own `ui` module.
- Injection summary now reports per-topic malformed-message counts.
- Substantially expanded unit test coverage (metadata handling, registry scoping, injector message processing, typestore registration, base loader resolver).

**Fixes**
- `RosbagInjector.run()` no longer silently swallows fatal errors — they're re-raised/logged and the CLI now exits non-zero.
- Fixed a mutable-default-argument bug on `ROSInjectionConfig.metadata`.
- Fixed reversed metadata-merge precedence and an undefined-method typo in per-topic metadata construction.
- Clearer error diagnostics when encoding an `Unmodeled` ontology back to a ROS message on schema mismatch/partial adaptation (`unmodeled.py`).