### PR TITLE
fix(mosaicod): typos in doc

### DIFF
--- a/mosaicod/crates/mosaicod-core/src/types/time.rs
+++ b/mosaicod/crates/mosaicod-core/src/types/time.rs
@@ -1,8 +1,8 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// SEntinel value to represent the positive unbounded timestamp
+/// Sentinel value to represent the positive unbounded timestamp
 const TIMESTAMP_UB_POS_SENTINEL: i64 = i64::MAX;
-/// SEntinel value to represent the negative unbounded timestamp
+/// Sentinel value to represent the negative unbounded timestamp
 const TIMESTAMP_UB_NEG_SENTINEL: i64 = i64::MIN;
 
 /// Timestamp format used by mosaico, currently this timestamp represent nanoseconds


### PR DESCRIPTION
Fixed typos in rust documentation