### PR TITLE
fix(py): change warning type from DeprecationWarning to FutureWarning

### DIFF
--- a/mosaico-sdk-py/src/mosaicolabs/_deprecated.py
+++ b/mosaico-sdk-py/src/mosaicolabs/_deprecated.py
@@ -44,7 +44,7 @@ class _MovedPackageFinder(MetaPathFinder):
         warnings.warn(
             f"'{fullname}' is deprecated and will be removed in a future release; "
             f"import from '{new_name}' instead.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=3,
         )
 


### PR DESCRIPTION
Fixes #741 

> Note: this fix needs to be ported to the latest SDK release in PyPI 
