### PR TITLE
feat(mosaicod): implemented get_schema endpoint

### DIFF
--- a/mosaicod/crates/mosaicod-core/src/types/flight.rs
+++ b/mosaicod/crates/mosaicod-core/src/types/flight.rs
@@ -3,19 +3,19 @@ use crate::types::TimestampRange;
 
 /// Message used to initiate the flight communication to upload a new datastream
 pub struct DoPutCmd {
-    pub resource_locator: String, //(cabba) TODO: replace this with a resource locator
+    pub resource_locator: String,
     pub key: String,
 }
 
 /// Request info on a mosaico resource (topic or sequence)
 pub struct GetFlightInfoCmd {
-    pub resource_locator: String, //(cabba) TODO: replace this with a resource locator
+    pub resource_locator: String,
     pub timestamp_range: Option<TimestampRange>,
 }
 
 /// Request the schema of a mosaico topic
 pub struct GetSchemaCmd {
-    pub resource_locator: String, //(cabba) TODO: replace this with a resource locator
+    pub resource_locator: String,
 }
 
 pub struct TicketTopic {

--- a/mosaicod/crates/mosaicod-core/src/types/flight.rs
+++ b/mosaicod/crates/mosaicod-core/src/types/flight.rs
@@ -13,6 +13,11 @@ pub struct GetFlightInfoCmd {
     pub timestamp_range: Option<TimestampRange>,
 }
 
+/// Request the schema of a mosaico topic
+pub struct GetSchemaCmd {
+    pub resource_locator: String, //(cabba) TODO: replace this with a resource locator
+}
+
 pub struct TicketTopic {
     /// Locator for the topic
     pub locator: types::TopicLocator,

--- a/mosaicod/crates/mosaicod-facade/src/topic.rs
+++ b/mosaicod/crates/mosaicod-facade/src/topic.rs
@@ -300,6 +300,18 @@ pub async fn info(context: &Context, locator: &types::TopicLocator) -> Result<To
     internal::info(&mut cx, context.timeseries_querier.clone(), &topic_record).await
 }
 
+/// Returns the arrow schema of the topic identified by [`locator`].
+pub async fn schema(context: &Context, locator: &types::TopicLocator) -> Result<SchemaRef> {
+    let mut cx = context.db.connection();
+    let topic_record = db::topic_find_by_locator(&mut cx, locator)
+        .await
+        .map_err(|e| match e {
+            db::Error::NotFound => core::Error::not_found(locator.to_string()),
+            _ => e.error(),
+        })?;
+    internal::arrow_schema(context.timeseries_querier.clone(), &topic_record).await
+}
+
 /// Serializes and writes [`TopicMetadata`] to the object store.
 ///
 /// # Errors

--- a/mosaicod/crates/mosaicod-grpc-flight/src/endpoint.rs
+++ b/mosaicod/crates/mosaicod-grpc-flight/src/endpoint.rs
@@ -4,10 +4,12 @@ mod do_action;
 mod do_get;
 mod do_put;
 mod get_flight_info;
+mod get_schema;
 mod list_flights;
 
 pub use do_action::do_action;
 pub use do_get::do_get;
 pub use do_put::{DoPutContext, do_put};
 pub use get_flight_info::get_flight_info;
+pub use get_schema::get_schema;
 pub use list_flights::list_flights;

--- a/mosaicod/crates/mosaicod-grpc-flight/src/endpoint/get_schema.rs
+++ b/mosaicod/crates/mosaicod-grpc-flight/src/endpoint/get_schema.rs
@@ -1,0 +1,45 @@
+use arrow::ipc::writer::IpcWriteOptions;
+use arrow_flight::{
+    FlightDescriptor, SchemaAsIpc, SchemaResult, flight_descriptor::DescriptorType,
+};
+use mosaicod_core::{self as core, types};
+use mosaicod_facade as facade;
+use mosaicod_grpc_common as grpc_common;
+use mosaicod_marshal as marshal;
+use tracing::{info, trace};
+
+/// Message provided when an error occurs while encoding a schema result.
+const UNABLE_TO_BUILD_SCHEMA_RESULT: &str = "unable to build schema result";
+
+/// Returns the [`SchemaResult`] for the requested Topic.
+pub async fn get_schema(
+    ctx: &facade::Context,
+    desc: FlightDescriptor,
+) -> grpc_common::Result<SchemaResult> {
+    match desc.r#type() {
+        DescriptorType::Cmd => {
+            let cmd = marshal::flight::get_schema_cmd(&desc.cmd)?;
+            let resource_name = cmd.resource_locator;
+
+            info!("requesting schema for resource {}", resource_name);
+
+            let topic_locator = resource_name.parse::<types::TopicLocator>().map_err(|_| {
+                core::Error::locator_kind_mismatch(resource_name.clone(), "topic".to_owned())
+            })?;
+
+            let schema = facade::topic::schema(ctx, &topic_locator).await?;
+
+            trace!("{} done", topic_locator);
+
+            let options = IpcWriteOptions::default();
+            let schema_result: SchemaResult = SchemaAsIpc::new(schema.as_ref(), &options)
+                .try_into()
+                .map_err(|_| {
+                    core::Error::internal(Some(UNABLE_TO_BUILD_SCHEMA_RESULT.to_owned()))
+                })?;
+
+            Ok(schema_result)
+        }
+        _ => Err(core::Error::unsupported_descriptor())?,
+    }
+}

--- a/mosaicod/crates/mosaicod-grpc-flight/src/flight.rs
+++ b/mosaicod/crates/mosaicod-grpc-flight/src/flight.rs
@@ -99,6 +99,23 @@ impl Service {
         Ok(Response::new(info))
     }
 
+    async fn impl_get_schema(
+        &self,
+        request: Request<FlightDescriptor>,
+    ) -> grpc_common::Result<Response<SchemaResult>> {
+        let auth_ctx = middleware::auth_context(&request)?;
+
+        if !auth_ctx.permissions().can_read() {
+            Err(core::Error::unauthorized(
+                "provided API key does not have READ permissions.".to_string(),
+            ))?;
+        }
+
+        let desc = request.into_inner();
+        let schema_result = endpoint::get_schema(&self.context(), desc).await?;
+        Ok(Response::new(schema_result))
+    }
+
     async fn impl_list_flights(
         &self,
         request: Request<Criteria>,
@@ -228,11 +245,10 @@ impl FlightService for Service {
 
     async fn get_schema(
         &self,
-        _request: Request<FlightDescriptor>,
+        request: Request<FlightDescriptor>,
     ) -> std::result::Result<Response<SchemaResult>, Status> {
-        Err(core::Error::unimplemented()
-            .to_public_error()
-            .log_to_status())
+        let resp = self.impl_get_schema(request).await.log_to_status()?;
+        Ok(resp)
     }
 
     async fn do_get(

--- a/mosaicod/crates/mosaicod-marshal/src/flight.rs
+++ b/mosaicod/crates/mosaicod-marshal/src/flight.rs
@@ -45,6 +45,31 @@ pub fn get_flight_info_cmd(v: &[u8]) -> Result<types::flight::GetFlightInfoCmd, 
 }
 
 // ////////////////////////////////////////////////////////////////////////////
+// GET SCHEMA CMD
+// ////////////////////////////////////////////////////////////////////////////
+
+/// Non-exported type for deserialize [`GetSchemaCmd`]
+#[derive(Deserialize)]
+struct GetSchemaCmd {
+    resource_locator: String,
+}
+
+impl From<GetSchemaCmd> for types::flight::GetSchemaCmd {
+    fn from(value: GetSchemaCmd) -> Self {
+        types::flight::GetSchemaCmd {
+            resource_locator: value.resource_locator,
+        }
+    }
+}
+
+/// Convert a raw flight command into a [`GetSchemaCmd`]
+pub fn get_schema_cmd(v: &[u8]) -> Result<types::flight::GetSchemaCmd, super::Error> {
+    serde_json::from_slice::<GetSchemaCmd>(v)
+        .map_err(|e| super::Error::DeserializationError(e.to_string()))
+        .map(|v| v.into())
+}
+
+// ////////////////////////////////////////////////////////////////////////////
 // DO PUT
 // ////////////////////////////////////////////////////////////////////////////
 #[derive(Deserialize)]
@@ -475,5 +500,19 @@ mod tests {
 
         assert_eq!(dest.resource_locator, name);
         assert!(dest.timestamp_range.is_none());
+    }
+
+    /// Check that the conversion between [`super::GetSchemaCmd`] and
+    /// [`types::flight::GetSchemaCmd`] is correct.
+    #[test]
+    fn get_schema_cmd_to_types() {
+        let src = super::GetSchemaCmd {
+            resource_locator: "test_sequence/topic/a".to_owned(),
+        };
+
+        let name = src.resource_locator.clone();
+        let dest: types::flight::GetSchemaCmd = src.into();
+
+        assert_eq!(dest.resource_locator, name);
     }
 }

--- a/mosaicod/tests/src/actions.rs
+++ b/mosaicod/tests/src/actions.rs
@@ -415,6 +415,30 @@ pub async fn get_flight_info(
     Ok(info)
 }
 
+/// Returns the arrow schema for a topic.
+pub async fn get_schema(
+    client: &mut Client,
+    topic_name: &str,
+) -> Result<arrow::datatypes::Schema, tonic::Status> {
+    let cmd = format!(
+        r#"
+        {{
+            "resource_locator": "{}"
+        }}
+        "#,
+        topic_name,
+    );
+
+    dbg!(&cmd);
+
+    let descriptor = FlightDescriptor::new_cmd(cmd);
+
+    let schema_result = client.get_schema(descriptor).await?.into_inner();
+
+    arrow::datatypes::Schema::try_from(schema_result)
+        .map_err(|e| tonic::Status::internal(format!("failed to decode schema: {e}")))
+}
+
 pub async fn sequence_notification_create(
     client: &mut Client,
     locator: &str,

--- a/mosaicod/tests/tests/schema.rs
+++ b/mosaicod/tests/tests/schema.rs
@@ -5,8 +5,8 @@ use mosaicod_db as db;
 use mosaicod_ext as ext;
 use tests::{self, actions, common};
 
-/// This test will check that the schema provided by the get_flight_info and
-/// do_get is the same.
+/// This test will check that the schema returned by the standalone `get_schema` matches the
+/// one carried by `do_get` for the same topic.
 #[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
 async fn test_schema_coherence(pool: sqlx::Pool<db::DatabaseType>) {
     let server = common::ServerBuilder::new(common::HOST, pool).build().await;
@@ -40,7 +40,8 @@ async fn test_schema_coherence(pool: sqlx::Pool<db::DatabaseType>) {
         .await
         .unwrap();
     let ticket = info.endpoint[0].ticket.clone().unwrap();
-    let info_schema = info.try_decode_schema().unwrap();
+
+    let schema = actions::get_schema(&mut client, topic_name).await.unwrap();
 
     let (_, batches) = actions::do_get_with_ticket(&mut client, ticket)
         .await
@@ -52,8 +53,64 @@ async fn test_schema_coherence(pool: sqlx::Pool<db::DatabaseType>) {
     let do_get_schema = (*batches[0].schema()).clone();
 
     dbg!(&do_get_schema);
-    dbg!(&info_schema);
+    dbg!(&schema);
 
     // Check schema coherence
-    assert!(do_get_schema.fields() == info_schema.fields());
+    assert_eq!(do_get_schema.fields(), schema.fields());
+}
+
+/// `get_schema` only supports Topic locators; a Sequence locator must be rejected.
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_get_schema_wrong_locator_kind(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let sequence_name = "test_sequence";
+    actions::sequence_create(&mut client, sequence_name, None)
+        .await
+        .unwrap();
+
+    let res = actions::get_schema(&mut client, sequence_name).await;
+    assert_eq!(res.unwrap_err().code(), tonic::Code::InvalidArgument);
+}
+
+/// `get_schema` on a nonexistent topic must return NotFound.
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_get_schema_nonexistent_topic(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let res = actions::get_schema(&mut client, "ghost_sequence/ghost_topic").await;
+    assert_eq!(res.unwrap_err().code(), tonic::Code::NotFound);
+}
+
+/// `get_schema` on a topic which exists but has no data uploaded yet must succeed
+/// and return an empty schema, instead of failing.
+#[sqlx::test(migrator = "mosaicod_db::testing::MIGRATOR")]
+async fn test_get_schema_empty_topic(pool: sqlx::Pool<db::DatabaseType>) {
+    let server = common::ServerBuilder::new(common::HOST, pool).build().await;
+    let mut client = common::ClientBuilder::new(common::HOST, server.port())
+        .build()
+        .await;
+
+    let sequence_name = "test_sequence";
+    let topic_name = &format!("{}/my_topic", sequence_name);
+
+    actions::sequence_create(&mut client, sequence_name, None)
+        .await
+        .unwrap();
+    let (_, session_uuid) = actions::session_create(&mut client, sequence_name)
+        .await
+        .unwrap();
+    actions::topic_create(&mut client, &session_uuid, topic_name, None)
+        .await
+        .unwrap();
+
+    let schema = actions::get_schema(&mut client, topic_name).await.unwrap();
+
+    assert!(schema.fields().is_empty());
 }


### PR DESCRIPTION
Example of input JSON (request):

``` json
{
  "resource_locator": "test_sequence/my_topic"
}
```

Example of output JSON (response):

``` json
{
  schema: <bytes>
}
```


Closes #746 
