### PR TITLE
feat(mosaicod): SIGTERM added to handled signals

### DIFF
--- a/mosaicod/crates/mosaicod-commands/src/command/cleanup.rs
+++ b/mosaicod/crates/mosaicod-commands/src/command/cleanup.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use mosaicod_core::{self as core, error::PublicResult as Result, params, types};
 use mosaicod_db as db;
 use mosaicod_task as task;
-use signal_hook::{consts::SIGINT, iterator::Signals};
+use signal_hook::{consts::SIGINT, consts::SIGTERM, iterator::Signals};
 use std::thread;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
@@ -50,7 +50,7 @@ pub fn cleanup(args: Cleanup) -> Result<()> {
     let shutdown = CancellationToken::new();
 
     // Forward SIGINT to the cancellation token so a running loop can exit gracefully.
-    let mut signals = Signals::new([SIGINT]).map_err(|_| {
+    let mut signals = Signals::new([SIGINT, SIGTERM]).map_err(|_| {
         core::Error::internal(Some("unable to create termination signal".to_owned()))
     })?;
 

--- a/mosaicod/crates/mosaicod-commands/src/command/server.rs
+++ b/mosaicod/crates/mosaicod-commands/src/command/server.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use mosaicod_core::{self as core, error::PublicResult as Result, params};
 use mosaicod_db as db;
 use mosaicod_grpc as grpc;
-use signal_hook::{consts::SIGINT, iterator::Signals};
+use signal_hook::{consts::SIGINT, consts::SIGTERM, iterator::Signals};
 use std::net::IpAddr;
 use std::thread;
 use tracing::{debug, info};
@@ -84,7 +84,7 @@ pub fn server(args: Server, json_format: bool) -> Result<()> {
     }
 
     // (cabba) NOTE: maybe we need to return a more specific error ?
-    let mut signals = Signals::new([SIGINT]).map_err(|_| {
+    let mut signals = Signals::new([SIGINT, SIGTERM]).map_err(|_| {
         core::Error::internal(Some("unable to create termination signal".to_owned()))
     })?;
 

--- a/mosaicod/crates/mosaicod-commands/src/command/store_optimizer.rs
+++ b/mosaicod/crates/mosaicod-commands/src/command/store_optimizer.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use mosaicod_core::{self as core, error::PublicResult as Result, params, types};
 use mosaicod_db as db;
 use mosaicod_task as task;
-use signal_hook::{consts::SIGINT, iterator::Signals};
+use signal_hook::{consts::SIGINT, consts::SIGTERM, iterator::Signals};
 use std::thread;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
@@ -50,7 +50,7 @@ pub fn store_optimization(args: StoreOptimizer) -> Result<()> {
     let shutdown = CancellationToken::new();
 
     // Forward SIGINT to the cancellation token so a running loop can exit gracefully.
-    let mut signals = Signals::new([SIGINT]).map_err(|_| {
+    let mut signals = Signals::new([SIGINT, SIGTERM]).map_err(|_| {
         core::Error::internal(Some("unable to create termination signal".to_owned()))
     })?;
 

--- a/mosaicod/crates/mosaicod-task/src/cleanup.rs
+++ b/mosaicod/crates/mosaicod-task/src/cleanup.rs
@@ -109,7 +109,7 @@ impl Cleanup {
     ///
     /// Returns how many folders have been marked TO_DELETE and how many folder have actually been deleted.
     ///
-    /// If `shutdown_notifier` is cancelled while folders are being processed, the loop stops
+    /// If `shutdown_notifier` is canceled while folders are being processed, the loop stops
     /// early and the folders processed so far are logged as usual.
     pub async fn try_cleanup(
         &mut self,


### PR DESCRIPTION
SIGTERM is handled the same way as SIGINT per every process (server, store-optimizer and cleanup)

Closes #765 